### PR TITLE
cargo config for pulling private crates

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[net]
+git-fetch-with-cli = true


### PR DESCRIPTION
This change allows using the local ssh agent to access private crates dependencies when they're defined within the Cargo.toml file. This allows for a uniform experience between local development and CI so long as the necessary CI (github actions) secrets are set with the ssh keys loaded into secrets and a setup action such as webfactory/ssh-agent is loaded prior to the cargo build stage