### PR TITLE
test private repo integration with dz-solana

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           ssh-private-key: |
             ${{ secrets.DOUBLEZERO_PRIV_KEY }}
+            ${{ secrets.DOUBLEZEROFOUNDATION_SSH_PRIVATE }}
 
       - name: Test | CI Pipeline
         run: just ci

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ chrono = { version = "0", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 config = "0"
 csv = "1"
+doublezero-revenue-distribution = { git = "ssh://git@github.com/doublezerofoundation/doublezero-solana", features = ["no-entrypoint"] }
 futures-util = "0"
 itertools = "0"
 network-shapley = { git = "https://github.com/doublezerofoundation/network-shapley-rs", features = ["serde", "borsh"] }


### PR DESCRIPTION
Test private repo integration (ssh access) to the dz-solana repo, same as already in place with the dz monorepo