### PR TITLE
update access pass creation to delegate funding to serviceability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,7 +1726,7 @@ dependencies = [
 [[package]]
 name = "doublezero-config"
 version = "0.5.3"
-source = "git+ssh://git@github.com/malbeclabs/doublezero#7b6ce4a35e60c7cfc3d2013e11dfb0d6dd001c08"
+source = "git+ssh://git@github.com/malbeclabs/doublezero#1e7f111f96bee6b7a3551c7d02b468595ad3d6e0"
 dependencies = [
  "eyre",
  "solana-sdk",
@@ -1786,7 +1786,7 @@ dependencies = [
 [[package]]
 name = "doublezero-program-common"
 version = "0.5.3"
-source = "git+ssh://git@github.com/malbeclabs/doublezero#7b6ce4a35e60c7cfc3d2013e11dfb0d6dd001c08"
+source = "git+ssh://git@github.com/malbeclabs/doublezero#1e7f111f96bee6b7a3551c7d02b468595ad3d6e0"
 dependencies = [
  "borsh 1.5.7",
  "byteorder",
@@ -1820,7 +1820,7 @@ dependencies = [
 [[package]]
 name = "doublezero-record"
 version = "0.5.3"
-source = "git+ssh://git@github.com/malbeclabs/doublezero#7b6ce4a35e60c7cfc3d2013e11dfb0d6dd001c08"
+source = "git+ssh://git@github.com/malbeclabs/doublezero#1e7f111f96bee6b7a3551c7d02b468595ad3d6e0"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -1830,7 +1830,7 @@ dependencies = [
 [[package]]
 name = "doublezero-serviceability"
 version = "0.5.3"
-source = "git+ssh://git@github.com/malbeclabs/doublezero#7b6ce4a35e60c7cfc3d2013e11dfb0d6dd001c08"
+source = "git+ssh://git@github.com/malbeclabs/doublezero#1e7f111f96bee6b7a3551c7d02b468595ad3d6e0"
 dependencies = [
  "borsh 1.5.7",
  "doublezero-program-common",
@@ -1865,7 +1865,7 @@ dependencies = [
 [[package]]
 name = "doublezero-telemetry"
 version = "0.5.3"
-source = "git+ssh://git@github.com/malbeclabs/doublezero#7b6ce4a35e60c7cfc3d2013e11dfb0d6dd001c08"
+source = "git+ssh://git@github.com/malbeclabs/doublezero#1e7f111f96bee6b7a3551c7d02b468595ad3d6e0"
 dependencies = [
  "borsh 1.5.7",
  "doublezero-program-common",
@@ -1878,7 +1878,7 @@ dependencies = [
 [[package]]
 name = "doublezero_sdk"
 version = "0.5.3"
-source = "git+ssh://git@github.com/malbeclabs/doublezero#7b6ce4a35e60c7cfc3d2013e11dfb0d6dd001c08"
+source = "git+ssh://git@github.com/malbeclabs/doublezero#1e7f111f96bee6b7a3551c7d02b468595ad3d6e0"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",

--- a/crates/sentinel/src/sentinel/handler.rs
+++ b/crates/sentinel/src/sentinel/handler.rs
@@ -80,10 +80,7 @@ impl Sentinel {
         let AccessMode::SolanaValidator { service_key, .. } = access_ids.mode;
         if let Some(validator_ip) = self.verify_qualifiers(&access_ids.mode).await? {
             self.dz_rpc_client
-                .fund_authorized_user(&service_key, self.onboarding_lamports)
-                .await?;
-            self.dz_rpc_client
-                .issue_access_pass(&service_key, &validator_ip)
+                .issue_access_pass(&service_key, &validator_ip, self.onboarding_lamports)
                 .await?;
             let signature = self
                 .sol_rpc_client


### PR DESCRIPTION
With this change in serviceability https://github.com/malbeclabs/doublezero/pull/1335 we have moved the funding of a new user account with rent and txn lamports to be an instruction within the accesspass set transaction. This consolidates and simplifies the logic performed by the sentinel to only require validating the eligibility of the validator requesting access and generating an access pass for their service key/client IP pair.