### PR TITLE
Jg/validator sig update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,7 +1786,7 @@ dependencies = [
 [[package]]
 name = "doublezero-passport"
 version = "0.1.0"
-source = "git+ssh://git@github.com/doublezerofoundation/doublezero-solana?branch=jg%2Fpassport-sig-message-string#971d9e85dff225a65b138ff3686d74529cc0bb57"
+source = "git+ssh://git@github.com/doublezerofoundation/doublezero-solana#e71c7101a98f71d94dc99831a069dabdee8ee144"
 dependencies = [
  "borsh 1.5.7",
  "bytemuck",
@@ -1816,7 +1816,7 @@ dependencies = [
 [[package]]
 name = "doublezero-program-tools"
 version = "0.1.0"
-source = "git+ssh://git@github.com/doublezerofoundation/doublezero-solana?branch=jg%2Fpassport-sig-message-string#971d9e85dff225a65b138ff3686d74529cc0bb57"
+source = "git+ssh://git@github.com/doublezerofoundation/doublezero-solana#e71c7101a98f71d94dc99831a069dabdee8ee144"
 dependencies = [
  "bincode 1.3.3",
  "borsh 1.5.7",
@@ -1848,7 +1848,7 @@ dependencies = [
 [[package]]
 name = "doublezero-revenue-distribution"
 version = "0.1.0"
-source = "git+ssh://git@github.com/doublezerofoundation/doublezero-solana?branch=jg%2Fpassport-sig-message-string#971d9e85dff225a65b138ff3686d74529cc0bb57"
+source = "git+ssh://git@github.com/doublezerofoundation/doublezero-solana#e71c7101a98f71d94dc99831a069dabdee8ee144"
 dependencies = [
  "borsh 1.5.7",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,11 @@ chrono = { version = "0", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 config = "0"
 csv = "1"
-doublezero-passport = { git = "ssh://git@github.com/doublezerofoundation/doublezero-solana", branch = "jg/passport-sig-message-string" }
+doublezero-passport = { git = "ssh://git@github.com/doublezerofoundation/doublezero-solana" }
 doublezero-program-common = { git = "ssh://git@github.com/malbeclabs/doublezero" }
-doublezero-program-tools = { git = "ssh://git@github.com/doublezerofoundation/doublezero-solana", branch = "jg/passport-sig-message-string" }
+doublezero-program-tools = { git = "ssh://git@github.com/doublezerofoundation/doublezero-solana" }
 doublezero-record = { git = "ssh://git@github.com/malbeclabs/doublezero", features = [ "no-entrypoint" ] }
-doublezero-revenue-distribution = { git = "ssh://git@github.com/doublezerofoundation/doublezero-solana", branch = "jg/passport-sig-message-string" }
+doublezero-revenue-distribution = { git = "ssh://git@github.com/doublezerofoundation/doublezero-solana" }
 doublezero_sdk = { git = "ssh://git@github.com/malbeclabs/doublezero" }
 doublezero-serviceability = { git = "ssh://git@github.com/malbeclabs/doublezero", features = [ "no-entrypoint", "serde"] }
 doublezero-telemetry = { git = "ssh://git@github.com/malbeclabs/doublezero", features = [ "no-entrypoint", "serde" ] }


### PR DESCRIPTION
Complementary to https://github.com/malbeclabs/doublezero/issues/1355

The solana cli requires messages to be signed to be input as strings. Changes the expected message structure to be a string of `service_key=<B58_ENCODED_PUBKEY>`

Blocked by: https://github.com/doublezerofoundation/doublezero-solana/pull/44