### PR TITLE
remove sentinel setting new validator airdrop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,7 +1744,7 @@ dependencies = [
 [[package]]
 name = "doublezero-config"
 version = "0.5.3"
-source = "git+ssh://git@github.com/malbeclabs/doublezero#8497d92b4b6e5a7aa50286ff72e32ff097b942bd"
+source = "git+ssh://git@github.com/malbeclabs/doublezero#b9042933656dd431732177f15c327ed960905556"
 dependencies = [
  "eyre",
  "solana-sdk",
@@ -1804,7 +1804,7 @@ dependencies = [
 [[package]]
 name = "doublezero-program-common"
 version = "0.5.3"
-source = "git+ssh://git@github.com/malbeclabs/doublezero#8497d92b4b6e5a7aa50286ff72e32ff097b942bd"
+source = "git+ssh://git@github.com/malbeclabs/doublezero#b9042933656dd431732177f15c327ed960905556"
 dependencies = [
  "borsh 1.5.7",
  "byteorder",
@@ -1838,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "doublezero-record"
 version = "0.5.3"
-source = "git+ssh://git@github.com/malbeclabs/doublezero#8497d92b4b6e5a7aa50286ff72e32ff097b942bd"
+source = "git+ssh://git@github.com/malbeclabs/doublezero#b9042933656dd431732177f15c327ed960905556"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -1872,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "doublezero-serviceability"
 version = "0.5.3"
-source = "git+ssh://git@github.com/malbeclabs/doublezero#8497d92b4b6e5a7aa50286ff72e32ff097b942bd"
+source = "git+ssh://git@github.com/malbeclabs/doublezero#b9042933656dd431732177f15c327ed960905556"
 dependencies = [
  "borsh 1.5.7",
  "doublezero-program-common",
@@ -1907,7 +1907,7 @@ dependencies = [
 [[package]]
 name = "doublezero-telemetry"
 version = "0.5.3"
-source = "git+ssh://git@github.com/malbeclabs/doublezero#8497d92b4b6e5a7aa50286ff72e32ff097b942bd"
+source = "git+ssh://git@github.com/malbeclabs/doublezero#b9042933656dd431732177f15c327ed960905556"
 dependencies = [
  "borsh 1.5.7",
  "doublezero-program-common",
@@ -1920,7 +1920,7 @@ dependencies = [
 [[package]]
 name = "doublezero_sdk"
 version = "0.5.3"
-source = "git+ssh://git@github.com/malbeclabs/doublezero#8497d92b4b6e5a7aa50286ff72e32ff097b942bd"
+source = "git+ssh://git@github.com/malbeclabs/doublezero#b9042933656dd431732177f15c327ed960905556"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",

--- a/crates/sentinel/src/client/doublezero_ledger.rs
+++ b/crates/sentinel/src/client/doublezero_ledger.rs
@@ -40,7 +40,6 @@ impl DzRpcClient {
         &self,
         service_key: &Pubkey,
         client_ip: &Ipv4Addr,
-        airdrop_lamports: u64,
     ) -> Result<Signature> {
         let (globalstate_pk, _) = get_globalstate_pda(&self.serviceability_id);
         let (pass_pk, _) = get_accesspass_pda(&self.serviceability_id, client_ip, service_key);
@@ -48,7 +47,6 @@ impl DzRpcClient {
             accesspass_type: AccessPassType::SolanaValidator,
             client_ip: *client_ip,
             last_access_epoch: u64::MAX,
-            airdrop_lamports,
         };
         let accounts = vec![
             AccountMeta::new(pass_pk, false),

--- a/crates/sentinel/src/main.rs
+++ b/crates/sentinel/src/main.rs
@@ -46,7 +46,6 @@ async fn main() -> anyhow::Result<()> {
         keypair,
         settings.serviceability_program_id()?,
         rx,
-        settings.onboarding_lamports(),
         settings.previous_leader_epochs(),
     )
     .await?;

--- a/crates/sentinel/src/sentinel/handler.rs
+++ b/crates/sentinel/src/sentinel/handler.rs
@@ -20,7 +20,6 @@ pub struct Sentinel {
     dz_rpc_client: DzRpcClient,
     sol_rpc_client: SolRpcClient,
     rx: UnboundedReceiver<Signature>,
-    onboarding_lamports: u64,
     previous_leader_epochs: u8,
 }
 
@@ -31,14 +30,12 @@ impl Sentinel {
         keypair: Arc<Keypair>,
         serviceability_id: Pubkey,
         rx: UnboundedReceiver<Signature>,
-        onboarding_lamports: u64,
         previous_leader_epochs: u8,
     ) -> Result<Self> {
         Ok(Self {
             dz_rpc_client: DzRpcClient::new(dz_rpc, keypair.clone(), serviceability_id),
             sol_rpc_client: SolRpcClient::new(sol_rpc, keypair),
             rx,
-            onboarding_lamports,
             previous_leader_epochs,
         })
     }
@@ -80,7 +77,7 @@ impl Sentinel {
         let AccessMode::SolanaValidator { service_key, .. } = access_ids.mode;
         if let Some(validator_ip) = self.verify_qualifiers(&access_ids.mode).await? {
             self.dz_rpc_client
-                .issue_access_pass(&service_key, &validator_ip, self.onboarding_lamports)
+                .issue_access_pass(&service_key, &validator_ip)
                 .await?;
             let signature = self
                 .sol_rpc_client

--- a/crates/sentinel/src/settings.rs
+++ b/crates/sentinel/src/settings.rs
@@ -47,9 +47,6 @@ pub struct Settings {
     /// The number of previous epochs to search for appearance in the leader schedule
     previous_leader_epochs: u8,
 
-    /// The amount of lamports to fund a new account authorized on the DZ network
-    onboarding_lamports: u64,
-
     /// metrics listening endpoint
     #[serde(default = "default_metrics_addr")]
     metrics_addr: String,
@@ -109,10 +106,6 @@ impl Settings {
 
     pub fn dz_rpc(&self) -> Url {
         Url::parse(&self.dz_rpc).expect("invalid dz_rpc url")
-    }
-
-    pub fn onboarding_lamports(&self) -> u64 {
-        self.onboarding_lamports
     }
 
     pub fn previous_leader_epochs(&self) -> u8 {


### PR DESCRIPTION
Updates the sentinel to remove the SetAccessPass instruction argument to set the new validator user lamports, as this is determined by the serviceability program itself via a setting in the globalstate.