### PR TITLE
match releaser package to crate name

### DIFF
--- a/release/.goreleaser.sentinel.yaml
+++ b/release/.goreleaser.sentinel.yaml
@@ -15,7 +15,7 @@ builds:
     tool: cargo
     command: build
     flags:
-      - --package=doublezero-sentinel
+      - --package=doublezero-ledger-sentinel
       - --release
     targets:
        - x86_64-unknown-linux-gnu


### PR DESCRIPTION
Go releaser's rust builder seems to want the name of the cargo.toml crate, not the name of the output binary when that cargo.toml specifies a binary name different from the crate name