### PR TITLE
configure goreleaser devnet release and default unit file

### DIFF
--- a/release/.goreleaser.sentinel.yaml
+++ b/release/.goreleaser.sentinel.yaml
@@ -100,3 +100,8 @@ cloudsmiths:
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"
+  - organization: malbeclabs
+    repository: doublezero-devnet
+    distributions:
+      deb: "any-distro/any-version"
+      rpm: "any-distro/any-version"

--- a/release/packaging/systemd/doublezero-sentinel.service
+++ b/release/packaging/systemd/doublezero-sentinel.service
@@ -1,0 +1,18 @@
+# NOTE: This is a placeholder unit.
+# It will NOT start the monitor with correct runtime flags.
+# Expected: Ansible will manage an override file at:
+#   /etc/systemd/system/doublezero-sentinel.service.d/override.conf
+# which will set the real ExecStart and options.
+
+[Unit]
+Description=DoubleZero Sentinel
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/doublezero-sentinel
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
push releases to `doublezero-devnet` cloudsmith repository as well as the `doublezero` rpeository and ensure the default skeleton unit file is available to the package to enable systemd to pick up and then override