### PR TITLE
fix versioned transaction handling; more logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-ledger-sentinel"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/crates/sentinel/Cargo.toml
+++ b/crates/sentinel/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
-version.workspace = true
+version = "0.1.1"
 
 [dependencies]
 anyhow.workspace = true


### PR DESCRIPTION
Adds better logging to the validator qualifications checks to debug log the reasons access is denied and convert to fetching and decoding versioned transactions and messages instead of the equivalent legacy types