### PR TITLE
add env vars for mint_key, ledger and solana rpcs (#1408)

### DIFF
--- a/crates/validator-revenue/src/fee_payment_calculator.rs
+++ b/crates/validator-revenue/src/fee_payment_calculator.rs
@@ -13,17 +13,18 @@ use solana_sdk::{epoch_info::EpochInfo, pubkey::Pubkey};
 use solana_transaction_status_client_types::UiConfirmedBlock;
 use std::env;
 
+const DEFAULT_LEDGER_URL: &str = "http://localhost:8899";
 pub fn ledger_rpc() -> String {
     match env::var("LEDGER_RPC") {
         Ok(rpc) => rpc,
-        Err(_) => "http://localhost:8899".to_string(),
+        Err(_) => DEFAULT_LEDGER_URL.to_string(),
     }
 }
 
 pub fn solana_rpc() -> String {
     match env::var("SOLANA_RPC") {
         Ok(rpc) => rpc,
-        Err(_) => "http://localhost:8899".to_string(),
+        Err(_) => DEFAULT_LEDGER_URL.to_string(),
     }
 }
 

--- a/crates/validator-revenue/src/ledger.rs
+++ b/crates/validator-revenue/src/ledger.rs
@@ -69,7 +69,7 @@ pub async fn read_from_ledger(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fee_payment_calculator::FeePaymentCalculator;
+    use crate::fee_payment_calculator::{FeePaymentCalculator, ledger_rpc, solana_rpc};
     use crate::rewards::{EpochRewards, Reward};
 
     use solana_client::{
@@ -86,10 +86,8 @@ mod tests {
     async fn test_write_to_read_from_ledger() -> anyhow::Result<()> {
         let validator_id = "devgM7SXHvoHH6jPXRsjn97gygPUo58XEnc9bqY1jpj";
         let commitment_config = CommitmentConfig::processed();
-        let solana_rpc_client =
-            RpcClient::new_with_commitment("http://localhost:8899".to_string(), commitment_config);
-        let ledger_rpc_client =
-            RpcClient::new_with_commitment("http://localhost:8899".to_string(), commitment_config);
+        let solana_rpc_client = RpcClient::new_with_commitment(solana_rpc(), commitment_config);
+        let ledger_rpc_client = RpcClient::new_with_commitment(ledger_rpc(), commitment_config);
         let vote_account_config = RpcGetVoteAccountsConfig {
             vote_pubkey: Some(validator_id.to_string()),
             commitment: CommitmentConfig::finalized().into(),

--- a/crates/validator-revenue/src/transaction.rs
+++ b/crates/validator-revenue/src/transaction.rs
@@ -30,7 +30,13 @@ pub struct Transaction {
 
 fn mint_key() -> Pubkey {
     match env::var("MINT_KEY_ENVIRONMENT") {
-        Ok(_) => doublezero_revenue_distribution::env::mainnet::DOUBLEZERO_MINT_KEY,
+        Ok(val) => {
+            if val == "mainnet-beta" {
+                doublezero_revenue_distribution::env::mainnet::DOUBLEZERO_MINT_KEY
+            } else {
+                doublezero_revenue_distribution::env::development::DOUBLEZERO_MINT_KEY
+            }
+        }
         Err(_) => doublezero_revenue_distribution::env::development::DOUBLEZERO_MINT_KEY,
     }
 }

--- a/crates/validator-revenue/src/worker.rs
+++ b/crates/validator-revenue/src/worker.rs
@@ -144,7 +144,7 @@ pub async fn write_payments<T: ValidatorRewards>(
 mod tests {
     use super::*;
     use crate::block;
-    use crate::fee_payment_calculator::MockValidatorRewards;
+    use crate::fee_payment_calculator::{MockValidatorRewards, ledger_rpc, solana_rpc};
     use crate::jito::{JitoReward, JitoRewards};
     use solana_client::nonblocking::rpc_client::RpcClient;
     use solana_client::rpc_response::{
@@ -205,14 +205,14 @@ mod tests {
         mock_fee_payment_calculator
             .expect_solana_rpc_client()
             .return_const(RpcClient::new_with_commitment(
-                "http://localhost:8899".to_string(),
+                solana_rpc(),
                 commitment_config,
             ));
 
         mock_fee_payment_calculator
             .expect_ledger_rpc_client()
             .return_const(RpcClient::new_with_commitment(
-                "http://localhost:8899".to_string(),
+                ledger_rpc(),
                 commitment_config,
             ));
 


### PR DESCRIPTION
This PR adds in env vars to set ledger, solana, and the mint key. 

Closes https://github.com/malbeclabs/doublezero/issues/1408