### PR TITLE
Derive rewards accountant key from ProgramConfig

### DIFF
--- a/crates/contributor-rewards/src/calculator/data_prep.rs
+++ b/crates/contributor-rewards/src/calculator/data_prep.rs
@@ -37,7 +37,7 @@ impl PreparedData {
             // Calculate expected internet telemetry links
             let expected_inet_samples = expected_inet_links(&fetch_data);
             let (inet_epoch, internet_data) = internet::fetch_with_accumulator(
-                &fetcher.rpc_client,
+                &fetcher.dz_rpc_client,
                 &fetcher.settings,
                 fetch_epoch,
                 expected_inet_samples,

--- a/crates/contributor-rewards/src/ingestor/telemetry.rs
+++ b/crates/contributor-rewards/src/ingestor/telemetry.rs
@@ -27,7 +27,7 @@ const ACCOUNT_TYPE_DISCRIMINATOR: u8 = AccountType::DeviceLatencySamples as u8;
 
 /// Fetch telemetry data for a specific epoch using RPC filtering
 pub async fn fetch(
-    rpc_client: &RpcClient,
+    dz_rpc_client: &RpcClient,
     settings: &Settings,
     epoch: u64,
 ) -> Result<DZDTelemetryData> {
@@ -57,7 +57,7 @@ pub async fn fetch(
 
     let start = Instant::now();
     let accounts = (|| async {
-        rpc_client
+        dz_rpc_client
             .get_program_accounts_with_config(&program_pubkey, config.clone())
             .await
     })


### PR DESCRIPTION
Summary
----
Fix https://github.com/malbeclabs/doublezero/issues/1467

This PR eliminates confusion around the dual purpose of the payer keypair, adds automatic fetching from on-chain ProgramConfig, and enforces proper validation for all write operations.

## Changes

- Renamed `payer_pubkey` to `rewards_accountant` throughout
- Changed CLI flag from `-p` to `-r` to reflect the new naming
- Added keypair validation against `ProgramConfig` for all write operations
- Ensures record addresses are always derived using the correct rewards accountant
- Made rewards_accountant optional for read commands (auto-fetched from `ProgramConfig`)
- Added `required_unless_present = "dry_run"` validation for keypair parameters
- Renamed `rpc_client` to `dz_rpc_client` for clarity
- Added helper functions `get_rewards_accountant` and `validate_rewards_accountant_keypair`