### PR TITLE
sentinel: accept mainnet-beta env moniker

### DIFF
--- a/crates/sentinel/src/settings.rs
+++ b/crates/sentinel/src/settings.rs
@@ -126,6 +126,7 @@ impl Settings {
             "devnet" => Ok(devnet::program_id::id()),
             "testnet" => Ok(testnet::program_id::id()),
             "mainnet" => Ok(mainnet::program_id::id()),
+            "mainnet-beta" => Ok(mainnet::program_id::id()),
             other => Pubkey::from_str(other),
         }
     }


### PR DESCRIPTION
## Summary of Changes
- Update sentinel settings to accept `mainnet-beta` env moniker in addition to `mainnet` since it was changed upstream and now being passed down in ansible as `mainnet-beta`
- Resolves https://github.com/malbeclabs/doublezero/issues/1480