### PR TITLE
contributor-rewards: add release support

### DIFF
--- a/.github/workflows/release.contributor-rewards.yml
+++ b/.github/workflows/release.contributor-rewards.yml
@@ -1,0 +1,42 @@
+name: releaser.contributor-rewards
+
+on:
+  push:
+    tags:
+      - "contributor-rewards/v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: |
+            ${{ secrets.MALBECLABS_DOUBLEZERO_SSH }}
+            ${{ secrets.DOUBLEZERO_SOLANA_PRIVATE }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: |
+            target
+            target/x86_64-unknown-linux-gnu/release
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install dependencies for rpm packaging
+        run: |
+          sudo apt update
+          sudo apt install squashfs-tools rpm -y
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser-pro
+          args: release -f release/.goreleaser.contributor-rewards.yaml --clean
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_BOTS_WEBHOOK }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          CLOUDSMITH_TOKEN: ${{ secrets.CLOUDSMITH_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,12 +137,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "alloy-rlp"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,45 +1223,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
-name = "contributor-rewards"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "backon",
- "bitvec",
- "borsh 1.5.7",
- "chrono",
- "clap",
- "config",
- "csv",
- "dotenvy",
- "doublezero-program-common",
- "doublezero-program-tools",
- "doublezero-record",
- "doublezero-revenue-distribution",
- "doublezero-serviceability",
- "doublezero-telemetry",
- "governor 0.10.1",
- "itertools 0.14.0",
- "network-shapley",
- "rayon",
- "rust_decimal",
- "serde",
- "serde_json",
- "solana-account-decoder",
- "solana-client",
- "solana-sdk",
- "solana-system-interface",
- "svm-hash",
- "tabled",
- "tempfile",
- "thiserror 2.0.16",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,20 +1514,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1780,6 +1721,45 @@ source = "git+ssh://git@github.com/malbeclabs/doublezero#387e64ba548048b96c998a8
 dependencies = [
  "eyre",
  "solana-sdk",
+]
+
+[[package]]
+name = "doublezero-contributor-rewards"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "backon",
+ "bitvec",
+ "borsh 1.5.7",
+ "chrono",
+ "clap",
+ "config",
+ "csv",
+ "dotenvy",
+ "doublezero-program-common",
+ "doublezero-program-tools",
+ "doublezero-record",
+ "doublezero-revenue-distribution",
+ "doublezero-serviceability",
+ "doublezero-telemetry",
+ "governor",
+ "itertools 0.10.5",
+ "network-shapley",
+ "rayon",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "solana-account-decoder",
+ "solana-client",
+ "solana-sdk",
+ "solana-system-interface",
+ "svm-hash",
+ "tabled",
+ "tempfile",
+ "thiserror 2.0.16",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2737,7 +2717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
 dependencies = [
  "cfg-if",
- "dashmap 5.5.3",
+ "dashmap",
  "futures",
  "futures-timer",
  "no-std-compat",
@@ -2748,29 +2728,6 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "spinning_top",
-]
-
-[[package]]
-name = "governor"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444405bbb1a762387aa22dd569429533b54a1d8759d35d3b64cb39b0293eaa19"
-dependencies = [
- "cfg-if",
- "dashmap 6.1.0",
- "futures-sink",
- "futures-timer",
- "futures-util",
- "getrandom 0.3.3",
- "hashbrown 0.15.5",
- "nonzero_ext",
- "parking_lot",
- "portable-atomic",
- "quanta",
- "rand 0.9.2",
- "smallvec",
- "spinning_top",
- "web-time 1.1.0",
 ]
 
 [[package]]
@@ -2834,8 +2791,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash",
 ]
 
@@ -3334,15 +3289,6 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -5515,7 +5461,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c789ec87f4687d022a2405cf46e0cd6284889f1839de292cadeb6c6019506f2"
 dependencies = [
- "dashmap 5.5.3",
+ "dashmap",
  "futures",
  "lazy_static",
  "log",
@@ -5864,7 +5810,7 @@ checksum = "2c4a1e134e7f683fca78ff3912f1590858b51f6a64aad417d30baca8926ed2fd"
 dependencies = [
  "async-trait",
  "bincode 1.3.3",
- "dashmap 5.5.3",
+ "dashmap",
  "futures",
  "futures-util",
  "indexmap",
@@ -7343,10 +7289,10 @@ dependencies = [
  "async-channel",
  "bytes",
  "crossbeam-channel",
- "dashmap 5.5.3",
+ "dashmap",
  "futures",
  "futures-util",
- "governor 0.6.3",
+ "governor",
  "histogram",
  "indexmap",
  "itertools 0.12.1",

--- a/crates/contributor-rewards/Cargo.toml
+++ b/crates/contributor-rewards/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "contributor-rewards"
+name = "doublezero-contributor-rewards"
 readme = "README.md"
 
 # Workspace inherited keys

--- a/release/.goreleaser.contributor-rewards.yaml
+++ b/release/.goreleaser.contributor-rewards.yaml
@@ -1,0 +1,107 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+project_name: doublezero-contributor-rewards
+
+monorepo:
+  tag_prefix: contributor-rewards/
+
+builds:
+  - id: doublezero-contributor-rewards
+    binary: doublezero-contributor-rewards
+    builder: rust
+    tool: cargo
+    command: build
+    flags:
+      - --package=doublezero-contributor-rewards
+      - --release
+    targets:
+      - x86_64-unknown-linux-gnu
+    env:
+      - RUSTFLAGS=-C linker=x86_64-linux-gnu-gcc
+      - BUILD_VERSION={{ .Version }}
+      - BUILD_COMMIT={{ .ShortCommit }}
+      - DATE={{ .Date }}
+
+archives:
+  - id: contributor_rewards_archive
+    formats: ["tar.gz"]
+    ids: [doublezero-contributor-rewards]
+    # this name template makes the OS and Arch compatible with the results of `uname`
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+
+nfpms:
+  - id: doublezero-contributor-rewards
+    package_name: doublezero-contributor-rewards
+    ids: [doublezero-contributor-rewards]
+    vendor: doublezero
+    homepage: doublezero.xyz
+    maintainer: tech <tech@malbeclabs.com>
+    description: |-
+      DoubleZero Contributor Rewards
+    license: Apache 2.0
+    formats:
+      - deb
+    bindir: /usr/local/bin
+    release: 1
+    section: default
+    contents:
+      - src: release/packaging/systemd/doublezero-contributor-rewards.service
+        dst: /lib/systemd/system/doublezero-contributor-rewards.service
+        type: config
+    overrides:
+      rpm:
+        contents:
+          - src: release/packaging/systemd/doublezero-contributor-rewards.service
+            dst: /usr/lib/systemd/system/doublezero-contributor-rewards.service
+            type: config
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  github:
+    owner: doublezerofoundation
+    name: doublezero-offchain
+  draft: false
+  replace_existing_artifacts: true
+
+announce:
+  slack:
+    enabled: true
+    message_template: "DoubleZero Contributor Rewards {{ .Tag }} has been released! Check it out at {{ .ReleaseURL }}"
+    channel: "#bots"
+
+git:
+  ignore_tags:
+    - contributor-rewards/daily
+
+nightly:
+  publish_release: true
+  keep_single_release: true
+  version_template: "{{ incpatch .Version }}~git{{ .Env.BUILD_DATE }}.{{ .ShortCommit }}"
+  tag_name: "contributor-rewards/daily"
+
+cloudsmiths:
+  - organization: malbeclabs
+    repository: doublezero
+    distributions:
+      deb: "any-distro/any-version"
+      rpm: "any-distro/any-version"
+  - organization: malbeclabs
+    repository: doublezero-devnet
+    distributions:
+      deb: "any-distro/any-version"
+      rpm: "any-distro/any-version"

--- a/release/packaging/systemd/doublezero-contributor-rewards.service
+++ b/release/packaging/systemd/doublezero-contributor-rewards.service
@@ -1,0 +1,18 @@
+# NOTE: This is a placeholder unit.
+# It will NOT start the monitor with correct runtime flags.
+# Expected: Ansible will manage an override file at:
+#   /etc/systemd/system/doublezero-contributor-rewards.service.d/override.conf
+# which will set the real ExecStart and options.
+
+[Unit]
+Description=DoubleZero Contributor Rewards
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/doublezero-contributor-rewards
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Summary
----
This adds preliminary support to build release via goreleaser for contributor-rewards. Pretty much a copy pasta of sentinel. We can try it but should be safe to merge.