### PR TITLE
add verify_merkle_root function

### DIFF
--- a/crates/validator-revenue/src/transaction.rs
+++ b/crates/validator-revenue/src/transaction.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Result, anyhow};
 use doublezero_program_tools::{instruction::try_build_instruction, zero_copy};
 use doublezero_revenue_distribution::{
     ID,


### PR DESCRIPTION
This PR adds a verify_transaction function that accepts a merkle proof and a leaf so that anyone can verify the merkle root posted for a distribution. 

Closes https://github.com/malbeclabs/doublezero/issues/1407

Testing: 

```
running 1 test
Simulated program logs:
  Program dzrevZC94tBLwuHw1dyynZxaXTWyp7yocsinyEVPtt4 invoke [1]
  Program log: Verify distribution merkle root
  Program log: DZ epoch: 84
  Program log: Solana validator debt 0
  Program log:   node_id: va1i6T6vTcijrCz6G8r89H6igKjwkLfF6g5fnpvZu1b
  Program log:   amount: 543
  Program dzrevZC94tBLwuHw1dyynZxaXTWyp7yocsinyEVPtt4 consumed 4165 of 200000 compute units
  Program dzrevZC94tBLwuHw1dyynZxaXTWyp7yocsinyEVPtt4 success
test transaction::tests::test_verify_distribution ... ok
```