### PR TITLE
contributor-rewards: add scheduler support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ test-ledger/
 *.sql
 *.gz
 .DS_Store
+*.state

--- a/crates/contributor-rewards/src/calculator/orchestrator.rs
+++ b/crates/contributor-rewards/src/calculator/orchestrator.rs
@@ -20,9 +20,9 @@ use std::{collections::BTreeMap, path::PathBuf, time::Instant};
 use tabled::{builder::Builder as TableBuilder, settings::Style};
 use tracing::{info, warn};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Orchestrator {
-    settings: Settings,
+    pub settings: Settings,
 }
 
 impl Orchestrator {

--- a/crates/contributor-rewards/src/cli/mod.rs
+++ b/crates/contributor-rewards/src/cli/mod.rs
@@ -2,6 +2,7 @@ pub mod common;
 pub mod impls;
 pub mod inspect;
 pub mod rewards;
+pub mod scheduler;
 pub mod snapshot;
 pub mod telemetry;
 pub mod traits;

--- a/crates/contributor-rewards/src/cli/scheduler.rs
+++ b/crates/contributor-rewards/src/cli/scheduler.rs
@@ -1,0 +1,99 @@
+use anyhow::{Result, bail};
+use clap::Subcommand;
+use contributor_rewards::{calculator::orchestrator::Orchestrator, worker::RewardsWorker};
+use std::{path::PathBuf, time::Duration};
+use tracing::info;
+
+#[derive(Subcommand, Debug)]
+pub enum SchedulerCommands {
+    /// Start the automated rewards scheduler
+    #[command(about = "Start automated rewards calculation scheduler")]
+    Start {
+        /// Path to keypair file for signing transactions
+        #[clap(
+            short = 'k',
+            long,
+            value_name = "FILE",
+            help = "Path to keypair file (required unless --dry-run)"
+        )]
+        keypair: Option<PathBuf>,
+
+        /// Skip writing to ledger (useful for testing)
+        #[clap(long, help = "Run in dry-run mode without chain writes")]
+        dry_run: bool,
+
+        /// Check interval in seconds (overrides config file)
+        #[clap(
+            short = 'i',
+            long,
+            value_name = "SECONDS",
+            help = "Interval between checks in seconds"
+        )]
+        interval: Option<u64>,
+
+        /// Path to scheduler state file (overrides config file)
+        #[clap(
+            short = 's',
+            long,
+            value_name = "FILE",
+            help = "Path to state file for tracking progress"
+        )]
+        state_file: Option<PathBuf>,
+    },
+}
+
+pub async fn handle(orchestrator: &Orchestrator, cmd: SchedulerCommands) -> Result<()> {
+    match cmd {
+        SchedulerCommands::Start {
+            keypair,
+            dry_run,
+            interval,
+            state_file,
+        } => start_scheduler(orchestrator, keypair, dry_run, interval, state_file).await,
+    }
+}
+
+async fn start_scheduler(
+    orchestrator: &Orchestrator,
+    keypair_path: Option<PathBuf>,
+    dry_run_override: bool,
+    interval_override: Option<u64>,
+    state_file_override: Option<PathBuf>,
+) -> Result<()> {
+    let settings = orchestrator.settings();
+
+    // Use CLI args if provided, otherwise fall back to config settings
+    let interval = interval_override.unwrap_or(settings.worker.interval_seconds);
+    let state_file =
+        state_file_override.unwrap_or_else(|| PathBuf::from(&settings.worker.state_file));
+    let dry_run = dry_run_override || settings.worker.enable_dry_run;
+
+    // Validate keypair if not in dry-run mode
+    if !dry_run {
+        if let Some(ref kp_path) = keypair_path {
+            if !kp_path.exists() {
+                bail!("Keypair file not found: {kp_path:?}");
+            }
+            if !kp_path.is_file() {
+                bail!("Keypair path is not a file: {kp_path:?}");
+            }
+        } else {
+            bail!(
+                "Keypair is required when not in dry-run mode. Use --keypair to specify a keypair file or --dry-run to skip"
+            );
+        }
+    }
+
+    info!("Starting rewards scheduler");
+
+    // Create and run worker
+    let worker = RewardsWorker::new(
+        orchestrator,
+        state_file,
+        keypair_path,
+        dry_run,
+        Duration::from_secs(interval),
+    );
+
+    worker.run().await
+}

--- a/crates/contributor-rewards/src/lib.rs
+++ b/crates/contributor-rewards/src/lib.rs
@@ -2,3 +2,4 @@ pub mod calculator;
 pub mod ingestor;
 pub mod processor;
 pub mod settings;
+pub mod worker;

--- a/crates/contributor-rewards/src/main.rs
+++ b/crates/contributor-rewards/src/main.rs
@@ -28,6 +28,9 @@ Examples:
     # Calculate rewards for the previous epoch
     contributor-rewards calculate-rewards -k keypair.json
 
+    # Start automated scheduler
+    contributor-rewards scheduler start --dry-run
+
     # Read telemetry aggregates
     contributor-rewards read-telem-agg --epoch 123
 
@@ -64,6 +67,11 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: cli::telemetry::TelemetryCommands,
     },
+    /// Run automated rewards scheduler
+    Scheduler {
+        #[command(subcommand)]
+        cmd: cli::scheduler::SchedulerCommands,
+    },
 }
 
 impl Cli {
@@ -83,6 +91,7 @@ impl Cli {
             Commands::Inspect { cmd } => cli::inspect::handle(&orchestrator, cmd).await,
             Commands::Snapshot { cmd } => cli::snapshot::handle(&orchestrator, cmd).await,
             Commands::Telemetry { cmd } => cli::telemetry::handle(&orchestrator, cmd).await,
+            Commands::Scheduler { cmd } => cli::scheduler::handle(&orchestrator, cmd).await,
         }
     }
 }

--- a/crates/contributor-rewards/src/settings/mod.rs
+++ b/crates/contributor-rewards/src/settings/mod.rs
@@ -28,6 +28,9 @@ pub struct Settings {
     pub inet_lookback: InetLookbackSettings,
     /// Telemetry default handling configuration
     pub telemetry_defaults: TelemetryDefaultSettings,
+    /// Worker configuration (optional)
+    #[serde(default)]
+    pub worker: WorkerSettings,
 }
 
 /// Shapley value calculation parameters for reward distribution
@@ -116,6 +119,30 @@ pub struct TelemetryDefaultSettings {
     /// Enable previous epoch lookup for public links
     /// If true, fetches previous epoch's average when current has insufficient data
     pub enable_previous_epoch_lookup: bool,
+}
+
+/// Worker configuration for automated rewards calculation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkerSettings {
+    /// Check interval in seconds (default: 300 = 5 minutes)
+    pub interval_seconds: u64,
+    /// Path to worker state file (default: /var/lib/doublezero/contributor-rewards.state)
+    pub state_file: String,
+    /// Maximum consecutive failures before halting (default: 10)
+    pub max_consecutive_failures: u32,
+    /// Enable dry run mode for worker (default: false)
+    pub enable_dry_run: bool,
+}
+
+impl Default for WorkerSettings {
+    fn default() -> Self {
+        Self {
+            interval_seconds: 300,
+            state_file: "/var/lib/doublezero/contributor-rewards.state".to_string(),
+            max_consecutive_failures: 10,
+            enable_dry_run: false,
+        }
+    }
 }
 
 impl Settings {

--- a/crates/contributor-rewards/src/settings/validation.rs
+++ b/crates/contributor-rewards/src/settings/validation.rs
@@ -143,7 +143,7 @@ mod tests {
     use super::*;
     use crate::settings::{
         InetLookbackSettings, PrefixSettings, ProgramSettings, RpcSettings, ShapleySettings,
-        TelemetryDefaultSettings, network::Network,
+        TelemetryDefaultSettings, WorkerSettings, network::Network,
     };
 
     fn create_valid_config() -> Settings {
@@ -184,6 +184,7 @@ mod tests {
                 private_default_latency_ms: 1000.0,
                 enable_previous_epoch_lookup: true,
             },
+            worker: WorkerSettings::default(),
         }
     }
 

--- a/crates/contributor-rewards/src/worker/mod.rs
+++ b/crates/contributor-rewards/src/worker/mod.rs
@@ -1,0 +1,5 @@
+pub mod runner;
+pub mod state;
+
+pub use runner::RewardsWorker;
+pub use state::WorkerState;

--- a/crates/contributor-rewards/src/worker/runner.rs
+++ b/crates/contributor-rewards/src/worker/runner.rs
@@ -1,0 +1,344 @@
+use crate::{
+    calculator::{orchestrator::Orchestrator, recorder::compute_record_address},
+    ingestor::fetcher::Fetcher,
+    worker::state::WorkerState,
+};
+use anyhow::{Result, anyhow, bail};
+use backon::{ExponentialBuilder, Retryable};
+use doublezero_program_tools::zero_copy;
+use doublezero_revenue_distribution::state::ProgramConfig;
+use solana_client::client_error::ClientError as SolanaClientError;
+use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey};
+use std::{
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+use tokio::{
+    signal,
+    time::{MissedTickBehavior, interval},
+};
+use tracing::{debug, error, info, warn};
+
+/// Main rewards worker that runs periodically to calculate rewards
+pub struct RewardsWorker {
+    orchestrator: Orchestrator,
+    state_file: PathBuf,
+    keypair_path: Option<PathBuf>,
+    dry_run: bool,
+    interval: Duration,
+    max_consecutive_failures: u32,
+}
+
+impl RewardsWorker {
+    /// Create a new rewards worker
+    pub fn new(
+        orchestrator: &Orchestrator,
+        state_file: PathBuf,
+        keypair_path: Option<PathBuf>,
+        dry_run: bool,
+        interval: Duration,
+    ) -> Self {
+        let max_consecutive_failures = orchestrator.settings.worker.max_consecutive_failures;
+        Self {
+            orchestrator: orchestrator.clone(),
+            state_file,
+            keypair_path,
+            dry_run,
+            interval,
+            max_consecutive_failures,
+        }
+    }
+
+    /// Run the worker loop
+    pub async fn run(self) -> Result<()> {
+        info!("Starting rewards worker");
+        info!("Configuration:");
+        info!("  Interval: {:?}", self.interval);
+        info!("  Dry run: {}", self.dry_run);
+        info!("  State file: {:?}", self.state_file);
+        info!(
+            "  Max consecutive failures: {}",
+            self.max_consecutive_failures
+        );
+
+        if self.dry_run {
+            info!("  Running in DRY RUN mode - no chain writes will occur");
+        } else {
+            info!(
+                "  Keypair: {:?}",
+                self.keypair_path.as_ref().map(|p| p.display())
+            );
+        }
+
+        // Load or create worker state
+        let mut state = WorkerState::load_or_default(&self.state_file)?;
+
+        // Set up shutdown signal
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_clone = shutdown.clone();
+
+        // Spawn signal handler
+        tokio::spawn(async move {
+            let _ = signal::ctrl_c().await;
+            info!("Received shutdown signal");
+            shutdown_clone.store(true, Ordering::Relaxed);
+        });
+
+        // Create interval timer
+        let mut ticker = interval(self.interval);
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        info!("Worker started, entering main loop");
+
+        // Main worker loop
+        loop {
+            // Check for shutdown
+            if shutdown.load(Ordering::Relaxed) {
+                info!("Shutting down worker");
+                state.save(&self.state_file)?;
+                break;
+            }
+
+            // Wait for next tick
+            ticker.tick().await;
+
+            // Mark that we're checking
+            state.mark_check();
+
+            // Check if we're in failure state
+            if state.is_in_failure_state(self.max_consecutive_failures) {
+                error!(
+                    "Worker is in failure state ({} consecutive failures), halting",
+                    state.consecutive_failures
+                );
+                state.save(&self.state_file)?;
+                bail!("Too many consecutive failures");
+            }
+
+            // Process rewards
+            match self.process_rewards(&mut state).await {
+                Ok(processed) => {
+                    if processed {
+                        info!("Successfully processed rewards");
+                    } else {
+                        debug!("No new rewards to process");
+                    }
+                    // Save state after successful check
+                    state.save(&self.state_file)?;
+                }
+                Err(e) => {
+                    error!("Failed to process rewards: {}", e);
+                    state.mark_failure();
+                    state.save(&self.state_file)?;
+
+                    // Continue running unless we hit max failures
+                    if !state.is_in_failure_state(self.max_consecutive_failures) {
+                        warn!("Will retry on next interval");
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Process rewards for the current epoch if needed
+    async fn process_rewards(&self, state: &mut WorkerState) -> Result<bool> {
+        // Get current epoch
+        let fetcher = Fetcher::from_settings(&self.orchestrator.settings)?;
+        let epoch_info = fetcher.dz_rpc_client.get_epoch_info().await?;
+        let current_epoch = epoch_info.epoch;
+
+        // Target epoch is current - 1 (we process the previous completed epoch)
+        if current_epoch == 0 {
+            debug!("Current epoch is 0, nothing to process yet");
+            return Ok(false);
+        }
+
+        let target_epoch = current_epoch - 1;
+
+        info!(
+            "Current epoch: {}, target epoch for processing: {}",
+            current_epoch, target_epoch
+        );
+
+        // Check if we should process this epoch
+        if !state.should_process_epoch(target_epoch) {
+            info!(
+                "Epoch {} already processed (last processed: {:?}), waiting for new epoch",
+                target_epoch, state.last_processed_epoch
+            );
+            return Ok(false);
+        }
+
+        // Check if rewards already exist for this epoch (idempotency check)
+        if self.rewards_exist_for_epoch(&fetcher, target_epoch).await? {
+            info!(
+                "Rewards already exist for epoch {}, marking as processed",
+                target_epoch
+            );
+            state.mark_success(target_epoch);
+            return Ok(false);
+        }
+
+        info!("Processing rewards for epoch {}", target_epoch);
+
+        if self.dry_run {
+            info!(
+                "DRY RUN: Would calculate and write rewards for epoch {}",
+                target_epoch
+            );
+            info!("DRY RUN: Skipping actual ledger writes");
+
+            // Still fetch and compute to verify everything works
+            // but don't write to chain
+            let _fetcher = Fetcher::from_settings(&self.orchestrator.settings)?;
+            info!("DRY RUN: Fetched data successfully");
+            info!(
+                "DRY RUN: Would write device telemetry, internet telemetry, reward input, and shapley outputs"
+            );
+
+            // Mark success even in dry run so we track what we've processed
+            state.mark_success(target_epoch);
+            info!(
+                "DRY RUN: Marked epoch {} as processed (no chain writes)",
+                target_epoch
+            );
+        } else {
+            // Calculate and write rewards for real
+            self.orchestrator
+                .calculate_rewards(Some(target_epoch), self.keypair_path.clone(), false)
+                .await?;
+
+            // Mark success
+            state.mark_success(target_epoch);
+            info!(
+                "Successfully calculated and wrote rewards for epoch {}",
+                target_epoch
+            );
+        }
+
+        Ok(true)
+    }
+
+    /// Check if rewards already exist for a given epoch
+    async fn rewards_exist_for_epoch(&self, fetcher: &Fetcher, epoch: u64) -> Result<bool> {
+        // Check for contributor rewards record
+        if self
+            .check_contributor_rewards_record(fetcher, epoch)
+            .await?
+        {
+            debug!("Contributor rewards record exists for epoch {}", epoch);
+            return Ok(true);
+        }
+
+        // Check for reward input record
+        if self.check_reward_input_record(fetcher, epoch).await? {
+            debug!("Reward input record exists for epoch {}", epoch);
+            return Ok(true);
+        }
+
+        debug!("No existing rewards found for epoch {}", epoch);
+        Ok(false)
+    }
+
+    /// Check if contributor rewards record exists
+    async fn check_contributor_rewards_record(
+        &self,
+        fetcher: &Fetcher,
+        epoch: u64,
+    ) -> Result<bool> {
+        // Get rewards accountant
+        let rewards_accountant = self.get_rewards_accountant(fetcher).await?;
+
+        // Compute record address
+        let prefix = self
+            .orchestrator
+            .settings
+            .prefixes
+            .contributor_rewards
+            .as_bytes();
+        let epoch_bytes = epoch.to_le_bytes();
+        let seeds: &[&[u8]] = &[prefix, &epoch_bytes, b"shapley_output"];
+        let record_key = compute_record_address(&rewards_accountant, seeds)?;
+
+        debug!("Checking for contributor rewards at: {}", record_key);
+
+        // Check if account exists
+        let exists = self.account_exists(fetcher, &record_key).await?;
+        Ok(exists)
+    }
+
+    /// Check if reward input record exists
+    async fn check_reward_input_record(&self, fetcher: &Fetcher, epoch: u64) -> Result<bool> {
+        // Get rewards accountant
+        let rewards_accountant = self.get_rewards_accountant(fetcher).await?;
+
+        // Compute record address
+        let prefix = self.orchestrator.settings.prefixes.reward_input.as_bytes();
+        let epoch_bytes = epoch.to_le_bytes();
+        let seeds: &[&[u8]] = &[prefix, &epoch_bytes];
+        let record_key = compute_record_address(&rewards_accountant, seeds)?;
+
+        debug!("Checking for reward input at: {}", record_key);
+
+        // Check if account exists
+        let exists = self.account_exists(fetcher, &record_key).await?;
+        Ok(exists)
+    }
+
+    /// Get rewards accountant from program config
+    async fn get_rewards_accountant(&self, fetcher: &Fetcher) -> Result<Pubkey> {
+        let (program_config_address, _) = ProgramConfig::find_address();
+        debug!(
+            "Fetching rewards_accountant from ProgramConfig PDA: {}",
+            program_config_address
+        );
+
+        let account = (|| async {
+            fetcher
+                .solana_write_client
+                .get_account(&program_config_address)
+                .await
+        })
+        .retry(&ExponentialBuilder::default().with_jitter())
+        .notify(|err: &SolanaClientError, dur: Duration| {
+            info!(
+                "retrying get_account error: {:?} with sleeping {:?}",
+                err, dur
+            )
+        })
+        .await?;
+
+        let program_config =
+            zero_copy::checked_from_bytes_with_discriminator::<ProgramConfig>(&account.data)
+                .ok_or_else(|| anyhow!("Failed to deserialize ProgramConfig"))?
+                .0;
+
+        Ok(program_config.rewards_accountant_key)
+    }
+
+    /// Check if an account exists on chain
+    async fn account_exists(&self, fetcher: &Fetcher, pubkey: &Pubkey) -> Result<bool> {
+        let maybe_account = (|| async {
+            fetcher
+                .dz_rpc_client
+                .get_account_with_commitment(pubkey, CommitmentConfig::confirmed())
+                .await
+        })
+        .retry(&ExponentialBuilder::default().with_jitter())
+        .notify(|err: &SolanaClientError, dur: Duration| {
+            debug!(
+                "retrying get_account error: {:?} with sleeping {:?}",
+                err, dur
+            )
+        })
+        .await?;
+
+        Ok(maybe_account.value.is_some())
+    }
+}

--- a/crates/contributor-rewards/src/worker/state.rs
+++ b/crates/contributor-rewards/src/worker/state.rs
@@ -1,0 +1,146 @@
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::{fs, io::Write, path::Path};
+use tracing::{debug, error, info, warn};
+
+/// Worker state persisted to disk
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkerState {
+    /// Last epoch that was successfully processed
+    pub last_processed_epoch: Option<u64>,
+    /// Last time the worker checked for new epochs
+    pub last_check_time: DateTime<Utc>,
+    /// Last time rewards were successfully calculated
+    pub last_success_time: Option<DateTime<Utc>>,
+    /// Number of consecutive failures
+    pub consecutive_failures: u32,
+}
+
+impl Default for WorkerState {
+    fn default() -> Self {
+        Self {
+            last_processed_epoch: None,
+            last_check_time: Utc::now(),
+            last_success_time: None,
+            consecutive_failures: 0,
+        }
+    }
+}
+
+impl WorkerState {
+    /// Load state from file, or create new if doesn't exist
+    pub fn load_or_default(path: &Path) -> Result<Self> {
+        if path.exists() {
+            debug!("Loading worker state from {:?}", path);
+            let contents = fs::read_to_string(path)
+                .with_context(|| format!("Failed to read state file: {path:?}"))?;
+
+            // Try to parse the state file
+            match serde_json::from_str::<WorkerState>(&contents) {
+                Ok(state) => {
+                    info!(
+                        "Loaded worker state: last_processed_epoch={:?}, last_check={:?}",
+                        state.last_processed_epoch, state.last_check_time
+                    );
+                    Ok(state)
+                }
+                Err(e) => {
+                    // State file is corrupted, create backup and start fresh
+                    let backup_path = path.with_extension("state.backup");
+                    warn!(
+                        "State file corrupted: {}. Creating backup at {:?} and starting fresh",
+                        e, backup_path
+                    );
+
+                    // Try to backup the corrupted file
+                    if let Err(backup_err) = fs::copy(path, &backup_path) {
+                        warn!("Failed to backup corrupted state file: {}", backup_err);
+                    }
+
+                    // Return default state
+                    Ok(Self::default())
+                }
+            }
+        } else {
+            debug!("No existing worker state found at {:?}, creating new", path);
+            Ok(Self::default())
+        }
+    }
+
+    /// Save state to file atomically
+    pub fn save(&self, path: &Path) -> Result<()> {
+        // Create parent directory if it doesn't exist
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create directory: {parent:?}"))?;
+        }
+
+        // Serialize state
+        let contents =
+            serde_json::to_string_pretty(self).context("Failed to serialize worker state")?;
+
+        // Write to temporary file first (atomic write pattern)
+        let temp_path = path.with_extension("state.tmp");
+
+        // Write to temp file
+        {
+            let mut temp_file = fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&temp_path)
+                .with_context(|| format!("Failed to create temp file: {temp_path:?}"))?;
+
+            temp_file
+                .write_all(contents.as_bytes())
+                .with_context(|| format!("Failed to write to temp file: {temp_path:?}"))?;
+
+            temp_file
+                .sync_all()
+                .with_context(|| format!("Failed to sync temp file: {temp_path:?}"))?;
+        }
+
+        // Atomically rename temp file to final location
+        fs::rename(&temp_path, path)
+            .with_context(|| format!("Failed to rename {temp_path:?} to {path:?}"))?;
+
+        debug!("Saved worker state atomically to {:?}", path);
+        Ok(())
+    }
+
+    /// Update state after successful processing
+    pub fn mark_success(&mut self, epoch: u64) {
+        self.last_processed_epoch = Some(epoch);
+        self.last_success_time = Some(Utc::now());
+        self.consecutive_failures = 0;
+        info!("Marked epoch {} as successfully processed", epoch);
+    }
+
+    /// Update state after check (regardless of outcome)
+    pub fn mark_check(&mut self) {
+        self.last_check_time = Utc::now();
+    }
+
+    /// Update state after failure
+    pub fn mark_failure(&mut self) {
+        self.consecutive_failures += 1;
+        error!(
+            "Marked failure, consecutive failures: {}",
+            self.consecutive_failures
+        );
+    }
+
+    /// Check if we should process a given epoch
+    pub fn should_process_epoch(&self, epoch: u64) -> bool {
+        match self.last_processed_epoch {
+            None => true, // Never processed anything
+            Some(last) => epoch > last,
+        }
+    }
+
+    /// Check if we're in a failure state that should halt processing
+    pub fn is_in_failure_state(&self, max_failures: u32) -> bool {
+        self.consecutive_failures >= max_failures
+    }
+}

--- a/crates/contributor-rewards/tests/test_pub_links.rs
+++ b/crates/contributor-rewards/tests/test_pub_links.rs
@@ -57,6 +57,7 @@ fn test_settings() -> settings::Settings {
             private_default_latency_ms: 1000.0,
             enable_previous_epoch_lookup: true,
         },
+        worker: settings::WorkerSettings::default(),
     }
 }
 

--- a/crates/contributor-rewards/tests/test_pvt_links.rs
+++ b/crates/contributor-rewards/tests/test_pvt_links.rs
@@ -145,6 +145,7 @@ fn test_settings() -> settings::Settings {
             private_default_latency_ms: 1000.0,
             enable_previous_epoch_lookup: true,
         },
+        worker: settings::WorkerSettings::default(),
     }
 }
 

--- a/crates/contributor-rewards/tests/test_telemetry_defaults.rs
+++ b/crates/contributor-rewards/tests/test_telemetry_defaults.rs
@@ -51,6 +51,7 @@ fn create_test_settings(
             private_default_latency_ms: private_default_ms,
             enable_previous_epoch_lookup: enable_previous,
         },
+        worker: settings::WorkerSettings::default(),
     }
 }
 

--- a/crates/contributor-rewards/tests/worker_test.rs
+++ b/crates/contributor-rewards/tests/worker_test.rs
@@ -1,0 +1,81 @@
+#[cfg(test)]
+mod tests {
+    use contributor_rewards::worker::WorkerState;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_worker_state_persistence() {
+        let temp_dir = TempDir::new().unwrap();
+        let state_file = temp_dir.path().join("test.state");
+
+        // Create and save state
+        let mut state = WorkerState::default();
+        state.mark_success(100);
+        state.save(&state_file).unwrap();
+
+        // Load state and verify
+        let loaded_state = WorkerState::load_or_default(&state_file).unwrap();
+        assert_eq!(loaded_state.last_processed_epoch, Some(100));
+        assert_eq!(loaded_state.consecutive_failures, 0);
+    }
+
+    #[test]
+    fn test_should_process_epoch() {
+        let mut state = WorkerState::default();
+
+        // Should process when no epoch has been processed
+        assert!(state.should_process_epoch(1));
+
+        // Mark epoch 5 as processed
+        state.mark_success(5);
+
+        // Should not process epochs <= 5
+        assert!(!state.should_process_epoch(5));
+        assert!(!state.should_process_epoch(4));
+
+        // Should process epochs > 5
+        assert!(state.should_process_epoch(6));
+        assert!(state.should_process_epoch(10));
+    }
+
+    #[test]
+    fn test_failure_tracking() {
+        let mut state = WorkerState::default();
+
+        // Initially no failures
+        assert_eq!(state.consecutive_failures, 0);
+        assert!(!state.is_in_failure_state(5));
+
+        // Track failures
+        state.mark_failure();
+        assert_eq!(state.consecutive_failures, 1);
+
+        state.mark_failure();
+        assert_eq!(state.consecutive_failures, 2);
+
+        // Check failure state
+        assert!(!state.is_in_failure_state(3));
+        assert!(state.is_in_failure_state(2)); // Exactly at threshold
+
+        // Success resets failures
+        state.mark_success(10);
+        assert_eq!(state.consecutive_failures, 0);
+        assert!(!state.is_in_failure_state(1));
+    }
+
+    #[test]
+    fn test_state_file_creation() {
+        let temp_dir = TempDir::new().unwrap();
+        let non_existent_path = temp_dir.path().join("subdir").join("state.json");
+
+        // Should create parent directories
+        let mut state = WorkerState::default();
+        state.mark_success(42);
+        state.save(&non_existent_path).unwrap();
+
+        // Verify file was created and can be loaded
+        assert!(non_existent_path.exists());
+        let loaded = WorkerState::load_or_default(&non_existent_path).unwrap();
+        assert_eq!(loaded.last_processed_epoch, Some(42));
+    }
+}


### PR DESCRIPTION
## Summary

Fix https://github.com/malbeclabs/doublezero/issues/1615

This PR adds scheduler to the contributor-rewards CLI with the following CLI:

```bash
$ ./target/release/doublezero-contributor-rewards -c testnet.toml scheduler -h
Run automated rewards scheduler

Usage: doublezero-contributor-rewards scheduler <COMMAND>

Commands:
  start  Start automated rewards calculation scheduler
  help   Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help

$ ./target/release/doublezero-contributor-rewards -c testnet.toml scheduler start -h
Start automated rewards calculation scheduler

Usage: doublezero-contributor-rewards scheduler start [OPTIONS]

Options:
  -k, --keypair <FILE>      Path to keypair file (required unless --dry-run)
      --dry-run             Run in dry-run mode without chain writes
  -i, --interval <SECONDS>  Interval between checks in seconds
  -s, --state-file <FILE>   Path to state file for tracking progress
  -h, --help                Print help
```

## Changes

- Added `scheduler start` subcommand
- Periodic checking (default 5 min) for new completed epochs
- Tracks last processed epoch, check times, and failure counts
- Persistent state tracking in JSON format with atomic file writes
- Dry-run mode
- Maximum consecutive failure limit (default: 10) before halting (could lower this and/or remove defaults)
- `WorkerSettings` section with some defaults (thinking of removing)
