### PR TITLE
validator-debt: separate `initialize_distribution` into its own process 

### DIFF
--- a/crates/validator-debt/src/worker.rs
+++ b/crates/validator-debt/src/worker.rs
@@ -66,12 +66,13 @@ pub async fn initialize_distribution<T: ValidatorRewards>(
         )
         .await?;
 
-    println!(
-        "initialized distribution tx: {:?}",
-        tx_initialized_sig.unwrap()
-    );
+    if let Some(tx) = tx_initialized_sig {
+        println!("initialized distribution tx: {tx:?}");
+    }
+
     Ok(())
 }
+
 pub async fn write_debts<T: ValidatorRewards>(
     solana_debt_calculator: &T,
     signer: Keypair,


### PR DESCRIPTION
This PR separates the initialize distribution step into its own function so that it can be called independently.

Closes https://github.com/malbeclabs/doublezero/issues/1606.