### PR TITLE
release: add rpm build

### DIFF
--- a/release/.goreleaser.doublezero-solana.yaml
+++ b/release/.goreleaser.doublezero-solana.yaml
@@ -50,6 +50,7 @@ nfpms:
     license: Apache 2.0
     formats:
       - deb
+      - rpm
     bindir: /usr/local/bin
     release: "1"
     section: default


### PR DESCRIPTION
We aren't building an rpm package for doublezero-solana. We need to.