### PR TITLE
contributor-rewards: enhance metrics for shapley computations

### DIFF
--- a/crates/contributor-rewards/src/calculator/data_prep.rs
+++ b/crates/contributor-rewards/src/calculator/data_prep.rs
@@ -131,6 +131,36 @@ impl PreparedData {
             city_weights,
         };
 
+        // Record overall Shapley inputs
+        metrics::gauge!(
+            "doublezero_contributor_rewards_shapley_inputs_total",
+            "kind" => "devices"
+        )
+        .set(shapley_inputs.devices.len() as f64);
+        metrics::gauge!(
+            "doublezero_contributor_rewards_shapley_inputs_total",
+            "kind" => "private_links"
+        )
+        .set(shapley_inputs.private_links.len() as f64);
+        metrics::gauge!(
+            "doublezero_contributor_rewards_shapley_inputs_total",
+            "kind" => "public_links"
+        )
+        .set(shapley_inputs.public_links.len() as f64);
+        metrics::gauge!(
+            "doublezero_contributor_rewards_shapley_inputs_total",
+            "kind" => "demands"
+        )
+        .set(shapley_inputs.demands.len() as f64);
+
+        for (city, weight) in shapley_inputs.city_weights.iter() {
+            metrics::gauge!(
+                "doublezero_contributor_rewards_shapley_city_weight",
+                "city" => city.clone()
+            )
+            .set(*weight);
+        }
+
         Ok(Self {
             epoch: fetch_epoch,
             device_telemetry,


### PR DESCRIPTION
Summary
----
After deploying `contributor-rewards` to testnet and looking at the metrics, I noticed some missing areas, this PR tries to address those.

Changes:
- Added input volume metrics for devices, links, and demands
- Implemented failure counters per city with proper error context
- Added payload size metrics for all ledger write operations
- Optimized performance by pre-serializing data
- Track total Shapley value and operator count for validation
- Track city weights and processed city count