### PR TITLE
passport: Add 'Find' subcommand to locate nodes by ID or IP address

### DIFF
--- a/crates/doublezero-solana/src/command/helpers.rs
+++ b/crates/doublezero-solana/src/command/helpers.rs
@@ -1,0 +1,39 @@
+use std::{
+    io::{Read, Write},
+    net::{TcpStream, ToSocketAddrs},
+};
+
+pub fn get_public_ipv4() -> Result<String, Box<dyn std::error::Error>> {
+    // Resolve the host `ifconfig.me` to IPv4 addresses
+    let addrs = "ifconfig.me:80"
+        .to_socket_addrs()?
+        .filter_map(|addr| match addr {
+            std::net::SocketAddr::V4(ipv4) => Some(ipv4),
+            _ => None,
+        })
+        .next()
+        .ok_or("Failed to resolve an IPv4 address")?;
+
+    // Establish a connection to the IPv4 address
+    let mut stream = TcpStream::connect(addrs)?;
+
+    // Send an HTTP GET request to retrieve only IPv4
+    let request = "GET /ip HTTP/1.1\r\nHost: ifconfig.me\r\nConnection: close\r\n\r\n";
+    stream.write_all(request.as_bytes())?;
+
+    // Read the response from the server
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response)?;
+
+    // Convert the response to text and find the body of the response
+    let response_text = str::from_utf8(&response)?;
+
+    // The IP will be in the body after the HTTP headers
+    if let Some(body_start) = response_text.find("\r\n\r\n") {
+        let ip = &response_text[body_start + 4..].trim();
+
+        return Ok(ip.to_string());
+    }
+
+    Err("Failed to extract the IP from the response".into())
+}

--- a/crates/doublezero-solana/src/command/mod.rs
+++ b/crates/doublezero-solana/src/command/mod.rs
@@ -1,6 +1,7 @@
 mod admin;
 mod ata;
 mod contributor;
+mod helpers;
 mod passport;
 mod prepaid;
 mod revenue_distribution;

--- a/crates/doublezero-solana/src/command/passport/fetch.rs
+++ b/crates/doublezero-solana/src/command/passport/fetch.rs
@@ -1,0 +1,28 @@
+use anyhow::{Result, anyhow};
+use doublezero_passport::state::ProgramConfig;
+use doublezero_program_tools::zero_copy;
+
+use crate::rpc::{Connection, SolanaConnectionOptions};
+
+pub async fn execute_fetch(
+    program_config: bool,
+    solana_connection_options: SolanaConnectionOptions,
+) -> Result<()> {
+    let connection = Connection::try_from(solana_connection_options)?;
+
+    if program_config {
+        let program_config_key = ProgramConfig::find_address().0;
+        let program_config_info = connection.get_account(&program_config_key).await?;
+
+        let (program_config, _) =
+            zero_copy::checked_from_bytes_with_discriminator::<ProgramConfig>(
+                &program_config_info.data,
+            )
+            .ok_or(anyhow!("Failed to deserialize program config"))?;
+
+        // TODO: Pretty print.
+        println!("Program config: {program_config:?}");
+    }
+
+    Ok(())
+}

--- a/crates/doublezero-solana/src/command/passport/find.rs
+++ b/crates/doublezero-solana/src/command/passport/find.rs
@@ -31,7 +31,7 @@ pub async fn execute_find(
             ),
         }
     } else if server_ip.is_some() {
-        let server_ip: Ipv4Addr = server_ip.unwrap().parse().unwrap();
+        let server_ip: Ipv4Addr = server_ip.as_ref().unwrap().parse()?;
         let node = nodes
             .iter()
             .find(|n| n.gossip.is_some() && n.gossip.unwrap().ip() == server_ip);

--- a/crates/doublezero-solana/src/command/passport/find.rs
+++ b/crates/doublezero-solana/src/command/passport/find.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
 use solana_sdk::pubkey::Pubkey;
-use std::{
-    io::{Read, Write},
-    net::{Ipv4Addr, TcpStream, ToSocketAddrs},
-};
+use std::net::Ipv4Addr;
 
-use crate::rpc::{Connection, SolanaConnectionOptions};
+use crate::{
+    command::helpers::get_public_ipv4,
+    rpc::{Connection, SolanaConnectionOptions},
+};
 
 pub async fn execute_find(
     node_id: Option<Pubkey>,
@@ -82,39 +82,4 @@ pub async fn execute_find(
     }
 
     Ok(())
-}
-
-pub fn get_public_ipv4() -> Result<String, Box<dyn std::error::Error>> {
-    // Resolve the host `ifconfig.me` to IPv4 addresses
-    let addrs = "ifconfig.me:80"
-        .to_socket_addrs()?
-        .filter_map(|addr| match addr {
-            std::net::SocketAddr::V4(ipv4) => Some(ipv4),
-            _ => None,
-        })
-        .next()
-        .ok_or("Failed to resolve an IPv4 address")?;
-
-    // Establish a connection to the IPv4 address
-    let mut stream = TcpStream::connect(addrs)?;
-
-    // Send an HTTP GET request to retrieve only IPv4
-    let request = "GET /ip HTTP/1.1\r\nHost: ifconfig.me\r\nConnection: close\r\n\r\n";
-    stream.write_all(request.as_bytes())?;
-
-    // Read the response from the server
-    let mut response = Vec::new();
-    stream.read_to_end(&mut response)?;
-
-    // Convert the response to text and find the body of the response
-    let response_text = str::from_utf8(&response)?;
-
-    // The IP will be in the body after the HTTP headers
-    if let Some(body_start) = response_text.find("\r\n\r\n") {
-        let ip = &response_text[body_start + 4..].trim();
-
-        return Ok(ip.to_string());
-    }
-
-    Err("Failed to extract the IP from the response".into())
 }

--- a/crates/doublezero-solana/src/command/passport/find.rs
+++ b/crates/doublezero-solana/src/command/passport/find.rs
@@ -14,23 +14,31 @@ pub async fn execute_find(
 ) -> Result<()> {
     println!("DoubleZero Passport - Find");
 
+    // Establish a connection to the Solana cluster
     let connection = Connection::try_from(solana_connection_options)?;
 
+    // Fetch the cluster nodes
     let nodes = connection.get_cluster_nodes().await?;
 
+    // Check if either node_id or server_ip is provided
     if let Some(node_id) = node_id {
+        // Search by node_id
         let node_id = node_id.to_string();
         let node = nodes.iter().find(|n| n.pubkey == node_id);
         match node {
             Some(node) => {
                 println!("Node-Id: {}", node.pubkey);
-                println!("Server IP: {}", node.gossip.unwrap().ip());
+                match &node.gossip {
+                    Some(gossip) => println!("Server IP: {}", gossip.ip()),
+                    None => println!("Server IP: <unknown>"),
+                }
             }
             None => println!(
                 "⚠️  Warning: Your node ID is not appearing in gossip. Your validator must be visible in gossip in order to connect to DoubleZero."
             ),
         }
     } else if server_ip.is_some() {
+        // Search by server_ip
         let server_ip: Ipv4Addr = server_ip.as_ref().unwrap().parse()?;
         let node = nodes
             .iter()
@@ -45,6 +53,7 @@ pub async fn execute_find(
             ),
         }
     } else {
+        // Neither node_id nor server_ip provided, attempt to detect public IP
         match get_public_ipv4() {
             Ok(ip) => {
                 println!("Detected public IP: {ip}");

--- a/crates/doublezero-solana/src/command/passport/find.rs
+++ b/crates/doublezero-solana/src/command/passport/find.rs
@@ -18,8 +18,8 @@ pub async fn execute_find(
 
     let nodes = connection.get_cluster_nodes().await?;
 
-    if node_id.is_some() {
-        let node_id = node_id.unwrap().to_string();
+    if let Some(node_id) = node_id {
+        let node_id = node_id.to_string();
         let node = nodes.iter().find(|n| n.pubkey == node_id);
         match node {
             Some(node) => {

--- a/crates/doublezero-solana/src/command/passport/find.rs
+++ b/crates/doublezero-solana/src/command/passport/find.rs
@@ -1,0 +1,105 @@
+use anyhow::Result;
+use solana_sdk::pubkey::Pubkey;
+use std::{
+    io::{Read, Write},
+    net::{Ipv4Addr, TcpStream, ToSocketAddrs},
+};
+
+use crate::rpc::{Connection, SolanaConnectionOptions};
+
+pub async fn execute_find(
+    node_id: Option<Pubkey>,
+    server_ip: Option<String>,
+    solana_connection_options: SolanaConnectionOptions,
+) -> Result<()> {
+    println!("DoubleZero Passport - Find");
+
+    let connection = Connection::try_from(solana_connection_options)?;
+
+    let nodes = connection.get_cluster_nodes().await?;
+
+    if node_id.is_some() {
+        let node_id = node_id.unwrap().to_string();
+        let node = nodes.iter().find(|n| n.pubkey == node_id);
+        match node {
+            Some(node) => {
+                println!("Node-Id: {}", node.pubkey);
+                println!("Server IP: {}", node.gossip.unwrap().ip());
+            }
+            None => println!(
+                "⚠️  Warning: Your node ID is not appearing in gossip. Your validator must be visible in gossip in order to connect to DoubleZero."
+            ),
+        }
+    } else if server_ip.is_some() {
+        let server_ip: Ipv4Addr = server_ip.unwrap().parse().unwrap();
+        let node = nodes
+            .iter()
+            .find(|n| n.gossip.is_some() && n.gossip.unwrap().ip() == server_ip);
+        match node {
+            Some(node) => {
+                println!("Node-Id: {}", node.pubkey);
+                println!("Server IP: {}", node.gossip.unwrap().ip());
+            }
+            None => println!(
+                "⚠️  Warning: Your IP is not appearing in gossip. Your validator must be visible in gossip in order to connect to DoubleZero."
+            ),
+        }
+    } else {
+        match get_public_ipv4() {
+            Ok(ip) => {
+                println!("Detected public IP: {}", ip);
+                let server_ip: Ipv4Addr = ip.parse().unwrap();
+                let node = nodes
+                    .iter()
+                    .find(|n| n.gossip.is_some() && n.gossip.unwrap().ip() == server_ip);
+                match node {
+                    Some(node) => {
+                        println!("Node-Id: {}", node.pubkey);
+                        println!("Server IP: {}", node.gossip.unwrap().ip());
+                    }
+                    None => println!(
+                        "⚠️  Warning: Your IP is not appearing in gossip. Your validator must be visible in gossip in order to connect to DoubleZero."
+                    ),
+                }
+            }
+            Err(e) => println!("Failed to get public IP: {}", e),
+        }
+    }
+
+    Ok(())
+}
+
+pub fn get_public_ipv4() -> Result<String, Box<dyn std::error::Error>> {
+    // Resolve the host `ifconfig.me` to IPv4 addresses
+    let addrs = "ifconfig.me:80"
+        .to_socket_addrs()?
+        .filter_map(|addr| match addr {
+            std::net::SocketAddr::V4(ipv4) => Some(ipv4),
+            _ => None,
+        })
+        .next()
+        .ok_or("Failed to resolve an IPv4 address")?;
+
+    // Establish a connection to the IPv4 address
+    let mut stream = TcpStream::connect(addrs)?;
+
+    // Send an HTTP GET request to retrieve only IPv4
+    let request = "GET /ip HTTP/1.1\r\nHost: ifconfig.me\r\nConnection: close\r\n\r\n";
+    stream.write_all(request.as_bytes())?;
+
+    // Read the response from the server
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response)?;
+
+    // Convert the response to text and find the body of the response
+    let response_text = str::from_utf8(&response)?;
+
+    // The IP will be in the body after the HTTP headers
+    if let Some(body_start) = response_text.find("\r\n\r\n") {
+        let ip = &response_text[body_start + 4..].trim();
+
+        return Ok(ip.to_string());
+    }
+
+    Err("Failed to extract the IP from the response".into())
+}

--- a/crates/doublezero-solana/src/command/passport/find.rs
+++ b/crates/doublezero-solana/src/command/passport/find.rs
@@ -48,7 +48,13 @@ pub async fn execute_find(
         match get_public_ipv4() {
             Ok(ip) => {
                 println!("Detected public IP: {ip}");
-                let server_ip: Ipv4Addr = ip.parse().unwrap();
+                let server_ip: Ipv4Addr = match ip.parse() {
+                    Ok(addr) => addr,
+                    Err(e) => {
+                        println!("Failed to parse detected public IP: {e}");
+                        return Ok(());
+                    }
+                };
                 let node = nodes
                     .iter()
                     .find(|n| n.gossip.is_some() && n.gossip.unwrap().ip() == server_ip);

--- a/crates/doublezero-solana/src/command/passport/find.rs
+++ b/crates/doublezero-solana/src/command/passport/find.rs
@@ -47,7 +47,7 @@ pub async fn execute_find(
     } else {
         match get_public_ipv4() {
             Ok(ip) => {
-                println!("Detected public IP: {}", ip);
+                println!("Detected public IP: {ip}");
                 let server_ip: Ipv4Addr = ip.parse().unwrap();
                 let node = nodes
                     .iter()
@@ -62,7 +62,7 @@ pub async fn execute_find(
                     ),
                 }
             }
-            Err(e) => println!("Failed to get public IP: {}", e),
+            Err(e) => println!("Failed to get public IP: {e}"),
         }
     }
 

--- a/crates/doublezero-solana/src/command/passport/mod.rs
+++ b/crates/doublezero-solana/src/command/passport/mod.rs
@@ -14,9 +14,12 @@ use solana_sdk::{
 };
 
 use crate::{
+    command::passport::find::execute_find,
     payer::{SolanaPayerOptions, Wallet},
     rpc::{Connection, SolanaConnectionOptions},
 };
+
+mod find;
 
 #[derive(Debug, Args)]
 pub struct PassportCliCommand {
@@ -26,6 +29,17 @@ pub struct PassportCliCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum PassportSubCommand {
+    Find {
+        #[arg(long, value_name = "PUBKEY")]
+        node_id: Option<Pubkey>,
+
+        #[arg(long, value_name = "IP_ADDRESS")]
+        server_ip: Option<String>,
+
+        #[command(flatten)]
+        solana_connection_options: SolanaConnectionOptions,
+    },
+
     Fetch {
         #[arg(long)]
         program_config: bool,
@@ -55,6 +69,11 @@ pub enum PassportSubCommand {
 impl PassportSubCommand {
     pub async fn try_into_execute(self) -> Result<()> {
         match self {
+            PassportSubCommand::Find {
+                node_id,
+                server_ip,
+                solana_connection_options,
+            } => execute_find(node_id, server_ip, solana_connection_options).await,
             PassportSubCommand::Fetch {
                 program_config,
                 solana_connection_options,

--- a/crates/doublezero-solana/src/command/passport/mod.rs
+++ b/crates/doublezero-solana/src/command/passport/mod.rs
@@ -1,25 +1,14 @@
-use std::str::FromStr;
-
-use anyhow::{Result, anyhow, bail};
+use anyhow::Result;
 use clap::{Args, Subcommand};
-use doublezero_passport::{
-    ID,
-    instruction::{AccessMode, PassportInstructionData, account::RequestAccessAccounts},
-    state::{AccessRequest, ProgramConfig},
-};
-use doublezero_program_tools::{instruction::try_build_instruction, zero_copy};
-use solana_sdk::{
-    compute_budget::ComputeBudgetInstruction, offchain_message::OffchainMessage, pubkey::Pubkey,
-    signature::Signature,
-};
+use solana_sdk::pubkey::Pubkey;
 
 use crate::{
-    command::passport::find::execute_find,
-    payer::{SolanaPayerOptions, Wallet},
-    rpc::{Connection, SolanaConnectionOptions},
+    command::passport::find::execute_find, payer::SolanaPayerOptions, rpc::SolanaConnectionOptions,
 };
 
+mod fetch;
 mod find;
+mod request_access;
 
 #[derive(Debug, Args)]
 pub struct PassportCliCommand {
@@ -77,7 +66,7 @@ impl PassportSubCommand {
             PassportSubCommand::Fetch {
                 program_config,
                 solana_connection_options,
-            } => execute_fetch(program_config, solana_connection_options).await,
+            } => fetch::execute_fetch(program_config, solana_connection_options).await,
             PassportSubCommand::RequestSolanaValidatorAccess {
                 service_key,
                 node_id,
@@ -85,7 +74,7 @@ impl PassportSubCommand {
                 message_version,
                 solana_payer_options,
             } => {
-                execute_request_solana_validator_access(
+                request_access::execute_request_solana_validator_access(
                     service_key,
                     node_id,
                     signature,
@@ -96,101 +85,4 @@ impl PassportSubCommand {
             }
         }
     }
-}
-
-//
-// PassportSubCommand::Fetch.
-//
-
-async fn execute_fetch(
-    program_config: bool,
-    solana_connection_options: SolanaConnectionOptions,
-) -> Result<()> {
-    let connection = Connection::try_from(solana_connection_options)?;
-
-    if program_config {
-        let program_config_key = ProgramConfig::find_address().0;
-        let program_config_info = connection.get_account(&program_config_key).await?;
-
-        let (program_config, _) =
-            zero_copy::checked_from_bytes_with_discriminator::<ProgramConfig>(
-                &program_config_info.data,
-            )
-            .ok_or(anyhow!("Failed to deserialize program config"))?;
-
-        // TODO: Pretty print.
-        println!("Program config: {program_config:?}");
-    }
-
-    Ok(())
-}
-
-//
-// PassportSubCommand::RequestSolanaValidatorAccess.
-//
-
-async fn execute_request_solana_validator_access(
-    service_key: Pubkey,
-    node_id: Pubkey,
-    signature: String,
-    message_version: u8,
-    solana_payer_options: SolanaPayerOptions,
-) -> Result<()> {
-    let verbose = solana_payer_options.signer_options.verbose;
-
-    let wallet = Wallet::try_from(solana_payer_options)?;
-    let wallet_key = wallet.pubkey();
-
-    let ed25519_signature = Signature::from_str(&signature)?;
-
-    // Verify the signature.
-    let raw_message = AccessRequest::access_request_message(&service_key);
-
-    if verbose {
-        println!("Raw message: {raw_message}");
-    }
-
-    let message = OffchainMessage::new(message_version, raw_message.as_bytes())?;
-    let serialized_message = message.serialize()?;
-
-    if !ed25519_signature.verify(node_id.as_array(), &serialized_message) {
-        bail!("Signature verification failed");
-    } else if verbose {
-        println!("Signature recovers node ID: {node_id}");
-    }
-
-    let request_access_ix = try_build_instruction(
-        &ID,
-        RequestAccessAccounts::new(&wallet_key, &service_key),
-        &PassportInstructionData::RequestAccess(AccessMode::SolanaValidator {
-            validator_id: node_id,
-            service_key,
-            ed25519_signature: ed25519_signature.into(),
-        }),
-    )?;
-
-    let mut compute_unit_limit = 10_000;
-
-    let (_, bump) = AccessRequest::find_address(&service_key);
-    compute_unit_limit += Wallet::compute_units_for_bump_seed(bump);
-
-    let mut instructions = vec![
-        request_access_ix,
-        ComputeBudgetInstruction::set_compute_unit_limit(compute_unit_limit),
-    ];
-
-    if let Some(ref compute_unit_price_ix) = wallet.compute_unit_price_ix {
-        instructions.push(compute_unit_price_ix.clone());
-    }
-
-    let transaction = wallet.new_transaction(&instructions).await?;
-    let tx_sig = wallet.send_or_simulate_transaction(&transaction).await?;
-
-    if let Some(tx_sig) = tx_sig {
-        println!("Request Solana validator access: {tx_sig}");
-
-        wallet.print_verbose_output(&[tx_sig]).await?;
-    }
-
-    Ok(())
 }

--- a/crates/doublezero-solana/src/command/passport/request_access.rs
+++ b/crates/doublezero-solana/src/command/passport/request_access.rs
@@ -1,0 +1,80 @@
+use anyhow::{Result, bail};
+use doublezero_passport::{
+    ID,
+    instruction::{AccessMode, PassportInstructionData, account::RequestAccessAccounts},
+    state::AccessRequest,
+};
+use doublezero_program_tools::instruction::try_build_instruction;
+use solana_sdk::{
+    compute_budget::ComputeBudgetInstruction, offchain_message::OffchainMessage, pubkey::Pubkey,
+    signature::Signature,
+};
+use std::str::FromStr;
+
+use crate::payer::{SolanaPayerOptions, Wallet};
+
+pub async fn execute_request_solana_validator_access(
+    service_key: Pubkey,
+    node_id: Pubkey,
+    signature: String,
+    message_version: u8,
+    solana_payer_options: SolanaPayerOptions,
+) -> Result<()> {
+    let verbose = solana_payer_options.signer_options.verbose;
+
+    let wallet = Wallet::try_from(solana_payer_options)?;
+    let wallet_key = wallet.pubkey();
+
+    let ed25519_signature = Signature::from_str(&signature)?;
+
+    // Verify the signature.
+    let raw_message = AccessRequest::access_request_message(&service_key);
+
+    if verbose {
+        println!("Raw message: {raw_message}");
+    }
+
+    let message = OffchainMessage::new(message_version, raw_message.as_bytes())?;
+    let serialized_message = message.serialize()?;
+
+    if !ed25519_signature.verify(node_id.as_array(), &serialized_message) {
+        bail!("Signature verification failed");
+    } else if verbose {
+        println!("Signature recovers node ID: {node_id}");
+    }
+
+    let request_access_ix = try_build_instruction(
+        &ID,
+        RequestAccessAccounts::new(&wallet_key, &service_key),
+        &PassportInstructionData::RequestAccess(AccessMode::SolanaValidator {
+            validator_id: node_id,
+            service_key,
+            ed25519_signature: ed25519_signature.into(),
+        }),
+    )?;
+
+    let mut compute_unit_limit = 10_000;
+
+    let (_, bump) = AccessRequest::find_address(&service_key);
+    compute_unit_limit += Wallet::compute_units_for_bump_seed(bump);
+
+    let mut instructions = vec![
+        request_access_ix,
+        ComputeBudgetInstruction::set_compute_unit_limit(compute_unit_limit),
+    ];
+
+    if let Some(ref compute_unit_price_ix) = wallet.compute_unit_price_ix {
+        instructions.push(compute_unit_price_ix.clone());
+    }
+
+    let transaction = wallet.new_transaction(&instructions).await?;
+    let tx_sig = wallet.send_or_simulate_transaction(&transaction).await?;
+
+    if let Some(tx_sig) = tx_sig {
+        println!("Request Solana validator access: {tx_sig}");
+
+        wallet.print_verbose_output(&[tx_sig]).await?;
+    }
+
+    Ok(())
+}

--- a/crates/doublezero-solana/src/command/passport/request_access.rs
+++ b/crates/doublezero-solana/src/command/passport/request_access.rs
@@ -33,9 +33,7 @@ pub async fn execute_request_solana_validator_access(
     // Check balance
     let balance = wallet.connection.get_balance(&wallet_key).await?;
     if balance <= MIN_BALANCE_LAMPORTS {
-        bail!(
-            "Your wallet balance is below 0.2 SOL. Please fund your wallet to proceed."
-        );
+        bail!("Your wallet balance is below 0.2 SOL. Please fund your wallet to proceed.");
     } else if verbose {
         println!("Wallet balance: {} lamports", balance);
     }


### PR DESCRIPTION
This pull request adds a new "Find" command to the DoubleZero Passport CLI, allowing users to search for a Solana node by its public key or server IP, or automatically detect the public IP to locate the node in the cluster gossip. The implementation includes network logic to resolve the public IP and integrates the new command into the CLI's command structure.

**New Find command and integration:**

* Added a new `find` module with the `execute_find` function, which searches for a node in the Solana cluster by node ID, server IP, or detected public IP, and reports if the node is visible in gossip. (`crates/doublezero-solana/src/command/passport/find.rs`)
* Imported and integrated the `execute_find` function into the passport command module to support the new Find subcommand. (`crates/doublezero-solana/src/command/passport/mod.rs`)
* Added the `Find` variant to the `PassportSubCommand` enum, with arguments for node ID, server IP, and Solana connection options. (`crates/doublezero-solana/src/command/passport/mod.rs`)
* Updated the command execution logic to handle the new Find subcommand and invoke the `execute_find` function asynchronously. (`crates/doublezero-solana/src/command/passport/mod.rs`)