### PR TITLE
validator-debt: add CI workflow for release

### DIFF
--- a/.github/workflows/release.solana-validator-debt.yml
+++ b/.github/workflows/release.solana-validator-debt.yml
@@ -1,0 +1,42 @@
+name: releaser.solana-validator-debt
+
+on:
+  push:
+    tags:
+      - "solana-validator-debt/v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: |
+            ${{ secrets.MALBECLABS_DOUBLEZERO_SSH }}
+            ${{ secrets.DOUBLEZERO_SOLANA_PRIVATE }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: |
+            target
+            target/x86_64-unknown-linux-gnu/release
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install dependencies for rpm packaging
+        run: |
+          sudo apt update
+          sudo apt install squashfs-tools rpm -y
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser-pro
+          args: release -f release/.goreleaser.doublezero-solana-validator-debt.yaml --clean
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_BOTS_WEBHOOK }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          CLOUDSMITH_TOKEN: ${{ secrets.CLOUDSMITH_TOKEN }}


### PR DESCRIPTION
Summary
----
Follow up on https://github.com/doublezerofoundation/doublezero-offchain/pull/110 to add the CI workflow for releasing validator-debt