### PR TITLE
solana-cli: fetch solana validator deposit accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,6 +1924,7 @@ dependencies = [
  "doublezero-solana-validator-debt",
  "doublezero_sdk",
  "serde_json",
+ "solana-account-decoder-client-types",
  "solana-client",
  "solana-commitment-config",
  "solana-sdk",

--- a/crates/solana-cli/Cargo.toml
+++ b/crates/solana-cli/Cargo.toml
@@ -18,6 +18,7 @@ doublezero-solana-client-tools.workspace = true
 doublezero-solana-validator-debt.workspace = true
 doublezero_sdk.workspace = true
 serde_json.workspace = true
+solana-account-decoder-client-types.workspace = true
 solana-client.workspace = true
 solana-commitment-config.workspace = true
 solana-sdk.workspace = true

--- a/crates/solana-cli/src/command/revenue_distribution/fetch.rs
+++ b/crates/solana-cli/src/command/revenue_distribution/fetch.rs
@@ -1,255 +1,300 @@
 use anyhow::{Result, anyhow};
-use clap::Args;
+use clap::{Args, Subcommand};
+use doublezero_program_tools::PrecomputedDiscriminator;
 use doublezero_program_tools::zero_copy;
 use doublezero_revenue_distribution::state::{CommunityBurnRateMode, Journal};
 use doublezero_solana_client_tools::rpc::{SolanaConnection, SolanaConnectionOptions};
+use solana_account_decoder_client_types::UiAccountEncoding;
+use solana_client::rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig};
+use solana_client::rpc_filter::{Memcmp, RpcFilterType};
 use solana_sdk::pubkey::Pubkey;
+
+#[derive(Debug, Subcommand)]
+pub enum FetchSubcommand {
+    /// Show program config and parameters
+    Config(SolanaConnectionOptions),
+
+    /// Print the on-chain journal account (debug format for now)
+    Journal(SolanaConnectionOptions),
+
+    /// Show configured Solana validator fee parameters (if any)
+    ValidatorFees(SolanaConnectionOptions),
+
+    /// List Solana validator deposit accounts with their balances with optional node ID filter
+    ValidatorDeposits {
+        #[arg(long = "node-id", short = 'n', value_name = "PUBKEY")]
+        node_id: Option<Pubkey>,
+        #[command(flatten)]
+        connection_options: SolanaConnectionOptions,
+    },
+}
 
 #[derive(Debug, Args)]
 pub struct FetchCommand {
-    #[arg(long)]
-    config: bool,
-
-    #[arg(long)]
-    journal: bool,
-
-    #[arg(long)]
-    solana_validator_fees: bool,
-
-    #[arg(long, value_name = "PUBKEY")]
-    validator_deposit: Option<Pubkey>,
-
-    // TODO: --distribution with Option<u64>.
-    // TODO: --contributor-rewards with Option<Pubkey>.
-    //
-    #[command(flatten)]
-    solana_connection_options: SolanaConnectionOptions,
+    #[command(subcommand)]
+    cmd: FetchSubcommand,
 }
 
 impl FetchCommand {
     pub async fn try_into_execute(self) -> Result<()> {
-        let FetchCommand {
-            config,
-            journal,
-            solana_validator_fees,
-            validator_deposit,
-            solana_connection_options,
-        } = self;
+        match self.cmd {
+            FetchSubcommand::Config(connection_options) => {
+                let connection = SolanaConnection::try_from(connection_options)?;
+                let (program_config_key, program_config) =
+                    super::try_fetch_program_config(&connection).await?;
 
-        let connection = SolanaConnection::try_from(solana_connection_options)?;
-
-        if config {
-            let (program_config_key, program_config) =
-                super::try_fetch_program_config(&connection).await?;
-
-            println!("Program config: {program_config_key}");
-            println!();
-
-            println!("Parameter                                   | Value");
-            println!(
-                "--------------------------------------------+-------------------------------------------------"
-            );
-            println!(
-                "Is program paused?                          | {}",
-                program_config.is_paused()
-            );
-            println!(
-                "Admin key                                   | {}",
-                program_config.admin_key
-            );
-            println!(
-                "Debt accountant key                         | {}",
-                program_config.debt_accountant_key
-            );
-            println!(
-                "Rewards accountant key                      | {}",
-                program_config.rewards_accountant_key
-            );
-            println!(
-                "Contributor manager key                     | {}",
-                program_config.contributor_manager_key
-            );
-            println!(
-                "SOL/2Z swap program ID                      | {}",
-                program_config.sol_2z_swap_program_id
-            );
-
-            let distribution_parameters = &program_config.distribution_parameters;
-            println!(
-                "Calculation grace period                    | {:?}",
-                std::time::Duration::from_secs(
-                    distribution_parameters
-                        .calculation_grace_period_seconds
-                        .into()
-                ),
-            );
-            println!(
-                "Minimum duration to finalize rewards        | {} epoch{}",
-                distribution_parameters.minimum_epoch_duration_to_finalize_rewards,
-                if distribution_parameters.minimum_epoch_duration_to_finalize_rewards == 1 {
-                    ""
-                } else {
-                    "s"
-                }
-            );
-
-            let community_burn_rate_params =
-                &distribution_parameters.community_burn_rate_parameters;
-            let community_burn_rate_mode = community_burn_rate_params.mode();
-            println!(
-                "Next community burn rate                    | {:.7}% ({})",
-                u32::from(community_burn_rate_params.next_burn_rate().unwrap()) as f64
-                    / 10_000_000.0,
-                community_burn_rate_mode.to_string().to_lowercase()
-            );
-            if community_burn_rate_mode != CommunityBurnRateMode::Limit {
+                println!("Program config: {program_config_key}\n");
+                println!("Parameter                                   | Value");
                 println!(
-                    "Community burn rate limit                   | {:.7}%",
-                    u32::from(community_burn_rate_params.limit) as f64 / 10_000_000.0
+                    "--------------------------------------------+-------------------------------------------------"
                 );
-            }
-            match community_burn_rate_mode {
-                CommunityBurnRateMode::Static => {
+                println!(
+                    "Is program paused?                          | {}",
+                    program_config.is_paused()
+                );
+                println!(
+                    "Admin key                                   | {}",
+                    program_config.admin_key
+                );
+                println!(
+                    "Debt accountant key                         | {}",
+                    program_config.debt_accountant_key
+                );
+                println!(
+                    "Rewards accountant key                      | {}",
+                    program_config.rewards_accountant_key
+                );
+                println!(
+                    "Contributor manager key                     | {}",
+                    program_config.contributor_manager_key
+                );
+                println!(
+                    "SOL/2Z swap program ID                      | {}",
+                    program_config.sol_2z_swap_program_id
+                );
+
+                let distribution_parameters = &program_config.distribution_parameters;
+                println!(
+                    "Calculation grace period                    | {:?}",
+                    std::time::Duration::from_secs(
+                        distribution_parameters
+                            .calculation_grace_period_seconds
+                            .into()
+                    ),
+                );
+                println!(
+                    "Minimum duration to finalize rewards        | {} epoch{}",
+                    distribution_parameters.minimum_epoch_duration_to_finalize_rewards,
+                    if distribution_parameters.minimum_epoch_duration_to_finalize_rewards == 1 {
+                        ""
+                    } else {
+                        "s"
+                    }
+                );
+
+                let community_burn_rate_params =
+                    &distribution_parameters.community_burn_rate_parameters;
+                let community_burn_rate_mode = community_burn_rate_params.mode();
+                println!(
+                    "Next community burn rate                    | {:.7}% ({})",
+                    u32::from(community_burn_rate_params.next_burn_rate().unwrap()) as f64
+                        / 10_000_000.0,
+                    community_burn_rate_mode.to_string().to_lowercase()
+                );
+                if community_burn_rate_mode != CommunityBurnRateMode::Limit {
                     println!(
-                        "Community burn rate increases after         | {} epoch{}",
-                        community_burn_rate_params.dz_epochs_to_increasing,
-                        if community_burn_rate_params.dz_epochs_to_increasing == 1 {
-                            ""
-                        } else {
-                            "s"
-                        }
-                    );
-                    println!(
-                        "Community burn rate limit reached after     | {} epoch{}",
-                        community_burn_rate_params.dz_epochs_to_limit,
-                        if community_burn_rate_params.dz_epochs_to_limit == 1 {
-                            ""
-                        } else {
-                            "s"
-                        }
+                        "Community burn rate limit                   | {:.7}%",
+                        u32::from(community_burn_rate_params.limit) as f64 / 10_000_000.0
                     );
                 }
-                CommunityBurnRateMode::Increasing => {
-                    println!(
-                        "Community burn rate limit reached after     | {} epoch{}",
-                        community_burn_rate_params.dz_epochs_to_limit,
-                        if community_burn_rate_params.dz_epochs_to_limit == 1 {
-                            ""
-                        } else {
-                            "s"
+                match community_burn_rate_mode {
+                    CommunityBurnRateMode::Static => {
+                        println!(
+                            "Community burn rate increases after         | {} epoch{}",
+                            community_burn_rate_params.dz_epochs_to_increasing,
+                            if community_burn_rate_params.dz_epochs_to_increasing == 1 {
+                                ""
+                            } else {
+                                "s"
+                            }
+                        );
+                        println!(
+                            "Community burn rate limit reached after     | {} epoch{}",
+                            community_burn_rate_params.dz_epochs_to_limit,
+                            if community_burn_rate_params.dz_epochs_to_limit == 1 {
+                                ""
+                            } else {
+                                "s"
+                            }
+                        );
+                    }
+                    CommunityBurnRateMode::Increasing => {
+                        println!(
+                            "Community burn rate limit reached after     | {} epoch{}",
+                            community_burn_rate_params.dz_epochs_to_limit,
+                            if community_burn_rate_params.dz_epochs_to_limit == 1 {
+                                ""
+                            } else {
+                                "s"
+                            }
+                        );
+                    }
+                    CommunityBurnRateMode::Limit => {}
+                }
+
+                let solana_validator_fee_params =
+                    &distribution_parameters.solana_validator_fee_parameters;
+                println!(
+                    "Solana validator base block rewards fee     | {:.2}%",
+                    u16::from(solana_validator_fee_params.base_block_rewards_pct) as f64 / 100.0
+                );
+                println!(
+                    "Solana validator priority block rewards fee | {:.2}%",
+                    u16::from(solana_validator_fee_params.priority_block_rewards_pct) as f64
+                        / 100.0
+                );
+                println!(
+                    "Solana validator inflation rewards fee      | {:.2}%",
+                    u16::from(solana_validator_fee_params.inflation_rewards_pct) as f64 / 100.0
+                );
+                println!(
+                    "Solana validator Jito tips fee              | {:.2}%",
+                    u16::from(solana_validator_fee_params.jito_tips_pct) as f64 / 100.0
+                );
+                println!(
+                    "Solana validator fixed SOL fee              | {:.9} SOL",
+                    solana_validator_fee_params.fixed_sol_amount as f64 * 1e-9
+                );
+
+                let relay_parameters = &program_config.relay_parameters;
+                println!(
+                    "Distribute rewards relay amount             | {:.9} SOL",
+                    relay_parameters.distribute_rewards_lamports as f64 * 1e-9
+                );
+                println!();
+            }
+
+            FetchSubcommand::ValidatorFees(connection_options) => {
+                let connection = SolanaConnection::try_from(connection_options)?;
+                let (program_config_key, program_config) =
+                    super::try_fetch_program_config(&connection).await?;
+
+                println!("Program config: {program_config_key}\n");
+
+                match program_config.checked_solana_validator_fee_parameters() {
+                    Some(fee_params) => {
+                        println!("Solana validator fee   | Value");
+                        println!("-----------------------+--------------------");
+                        if fee_params.base_block_rewards_pct != Default::default() {
+                            println!(
+                                "Base block rewards     | {:.2}%",
+                                u16::from(fee_params.base_block_rewards_pct) as f64 / 100.0
+                            );
                         }
-                    );
+                        if fee_params.priority_block_rewards_pct != Default::default() {
+                            println!(
+                                "Priority block rewards | {:.2}%",
+                                u16::from(fee_params.priority_block_rewards_pct) as f64 / 100.0
+                            );
+                        }
+                        if fee_params.inflation_rewards_pct != Default::default() {
+                            println!(
+                                "Inflation rewards      | {:.2}%",
+                                u16::from(fee_params.inflation_rewards_pct) as f64 / 100.0
+                            );
+                        }
+                        if fee_params.jito_tips_pct != Default::default() {
+                            println!(
+                                "Jito tips              | {:.2}%",
+                                u16::from(fee_params.jito_tips_pct) as f64 / 100.0
+                            );
+                        }
+                        if fee_params.fixed_sol_amount != 0 {
+                            println!(
+                                "Fixed                  | {:.9} SOL",
+                                fee_params.fixed_sol_amount as f64 * 1e-9
+                            );
+                        }
+                    }
+                    None => println!("... Solana validator fee parameters not configured yet"),
                 }
-                CommunityBurnRateMode::Limit => {}
+                println!();
             }
 
-            let solana_validator_fee_params =
-                &distribution_parameters.solana_validator_fee_parameters;
-            println!(
-                "Solana validator base block rewards fee     | {:.2}%",
-                u16::from(solana_validator_fee_params.base_block_rewards_pct) as f64 / 100.0
-            );
-            println!(
-                "Solana validator priority block rewards fee | {:.2}%",
-                u16::from(solana_validator_fee_params.priority_block_rewards_pct) as f64 / 100.0
-            );
-            println!(
-                "Solana validator inflation rewards fee      | {:.2}%",
-                u16::from(solana_validator_fee_params.inflation_rewards_pct) as f64 / 100.0
-            );
-            println!(
-                "Solana validator Jito tips fee              | {:.2}%",
-                u16::from(solana_validator_fee_params.jito_tips_pct) as f64 / 100.0
-            );
-            println!(
-                "Solana validator fixed SOL fee              | {:.9} SOL",
-                solana_validator_fee_params.fixed_sol_amount as f64 * 1e-9
-            );
-
-            let relay_parameters = &program_config.relay_parameters;
-            println!(
-                "Distribute rewards relay amount             | {:.9} SOL",
-                relay_parameters.distribute_rewards_lamports as f64 * 1e-9
-            );
-            println!();
-        } else if solana_validator_fees {
-            let (program_config_key, program_config) =
-                super::try_fetch_program_config(&connection).await?;
-
-            println!("Program config: {program_config_key}");
-            println!();
-
-            match program_config.checked_solana_validator_fee_parameters() {
-                Some(fee_params) => {
-                    println!("Solana validator fee   | Value");
-                    println!("-----------------------+--------------------");
-                    if fee_params.base_block_rewards_pct != Default::default() {
-                        println!(
-                            "Base block rewards     | {:.2}%",
-                            u16::from(fee_params.base_block_rewards_pct) as f64 / 100.0
-                        );
-                    }
-                    if fee_params.priority_block_rewards_pct != Default::default() {
-                        println!(
-                            "Priority block rewards | {:.2}%",
-                            u16::from(fee_params.priority_block_rewards_pct) as f64 / 100.0
-                        );
-                    }
-                    if fee_params.inflation_rewards_pct != Default::default() {
-                        println!(
-                            "Inflation rewards      | {:.2}%",
-                            u16::from(fee_params.inflation_rewards_pct) as f64 / 100.0
-                        );
-                    }
-                    if fee_params.jito_tips_pct != Default::default() {
-                        println!(
-                            "Jito tips              | {:.2}%",
-                            u16::from(fee_params.jito_tips_pct) as f64 / 100.0
-                        );
-                    }
-                    if fee_params.fixed_sol_amount != 0 {
-                        println!(
-                            "Fixed                  | {:.9} SOL",
-                            fee_params.fixed_sol_amount as f64 * 1e-9
-                        );
-                    }
-                }
-                None => {
-                    println!("... Solana validator fee parameters not configured yet");
-                }
+            FetchSubcommand::Journal(connection_options) => {
+                let connection = SolanaConnection::try_from(connection_options)?;
+                let journal_key = Journal::find_address().0;
+                let journal_info = connection.get_account(&journal_key).await?;
+                let (journal, _) =
+                    zero_copy::checked_from_bytes_with_discriminator::<Journal>(&journal_info.data)
+                        .ok_or(anyhow!("Failed to deserialize journal"))?;
+                println!("Journal: {journal:?}");
             }
-            println!();
-        }
 
-        if journal {
-            let journal_key = Journal::find_address().0;
-            let journal_info = connection.get_account(&journal_key).await?;
+            FetchSubcommand::ValidatorDeposits {
+                node_id,
+                connection_options,
+            } => {
+                let connection = SolanaConnection::try_from(connection_options)?;
+                let config = RpcProgramAccountsConfig {
+                    filters: Some(vec![RpcFilterType::Memcmp(Memcmp::new_raw_bytes(
+                        0,
+                        doublezero_revenue_distribution::state::SolanaValidatorDeposit::discriminator_slice().to_vec(),
+                    ))]),
+                    account_config: RpcAccountInfoConfig {
+                        encoding: Some(UiAccountEncoding::Base64),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                };
 
-            let (journal, _) =
-                zero_copy::checked_from_bytes_with_discriminator::<Journal>(&journal_info.data)
-                    .ok_or(anyhow!("Failed to deserialize journal"))?;
+                let outputs = if let Some(node_id) = node_id {
+                    let (deposit_key, _deposit, deposit_balance) =
+                        super::fetch_solana_validator_deposit(&connection, &node_id).await;
+                    vec![(deposit_key, node_id, deposit_balance)]
+                } else {
+                    let accounts = connection
+                        .get_program_accounts_with_config(
+                            &doublezero_revenue_distribution::ID,
+                            config,
+                        )
+                        .await?;
 
-            // TODO: Pretty print.
-            println!("Journal: {journal:?}");
-        }
+                    let rent_exemption = connection
+                        .rpc_client
+                        .get_minimum_balance_for_rent_exemption(zero_copy::data_end::<
+                            doublezero_revenue_distribution::state::SolanaValidatorDeposit,
+                        >())
+                        .await?;
 
-        if let Some(node_id) = validator_deposit {
-            let (deposit_key, deposit, deposit_balance) =
-                super::fetch_solana_validator_deposit(&connection, &node_id).await;
+                    let mut outputs = Vec::new();
+                    for (pubkey, account) in accounts {
+                        let balance = account.lamports.saturating_sub(rent_exemption);
+                        let (account, _) = zero_copy::checked_from_bytes_with_discriminator::<
+                            doublezero_revenue_distribution::state::SolanaValidatorDeposit,
+                        >(&account.data)
+                        .ok_or(anyhow!("Failed to deserialize solana validator deposit"))?;
+                        outputs.push((pubkey, account.node_id, balance));
+                    }
 
-            println!("Solana validator deposit: {deposit_key}");
-            println!();
+                    outputs
+                };
 
-            match deposit {
-                Some(deposit) => {
-                    println!("Node ID: {}", deposit.node_id);
-                    println!("Balance: {:.9} SOL", deposit_balance as f64 * 1e-9);
+                let mut outputs = outputs.into_iter().collect::<Vec<_>>();
+                outputs.sort_by_key(|(pubkey, node_id, _)| (*node_id, *pubkey));
+
+                println!(
+                    "Solana validator deposit accounts            | Node ID                                     | Balance (SOL)"
+                );
+                println!(
+                    "---------------------------------------------+---------------------------------------------+--------------"
+                );
+
+                for (pubkey, node_id, balance) in outputs {
+                    println!("{} | {} | {:.9}", pubkey, node_id, balance as f64 * 1e-9);
                 }
-                None => {
-                    println!("... not found");
-                }
+                println!();
             }
-            println!();
         }
 
         Ok(())

--- a/sh/test_doublezero_solana_clean.sh
+++ b/sh/test_doublezero_solana_clean.sh
@@ -131,8 +131,16 @@ echo "doublezero-solana revenue-distribution fetch -h"
 $CLI_BIN revenue-distribution fetch -h
 echo
 
-echo "doublezero-solana revenue-distribution fetch -u l --config --validator-deposit $DUMMY_KEY"
-$CLI_BIN revenue-distribution fetch -u l --config --validator-deposit $DUMMY_KEY
+echo "doublezero-solana revenue-distribution fetch config -u l"
+$CLI_BIN revenue-distribution fetch config -u l
+echo
+
+echo "doublezero-solana revenue-distribution fetch validator-deposits -u l --node-id $DUMMY_KEY"
+$CLI_BIN revenue-distribution fetch validator-deposits -u l --node-id $DUMMY_KEY
+echo
+
+echo "doublezero-solana revenue-distribution fetch validator-deposits -u l"
+$CLI_BIN revenue-distribution fetch validator-deposits -u l
 echo
 
 echo "doublezero-solana revenue-distribution contributor-rewards -h"
@@ -173,8 +181,12 @@ $CLI_BIN revenue-distribution validator-deposit \
     $DUMMY_KEY
 echo
 
-echo "doublezero-solana revenue-distribution fetch -u l --validator-deposit $DUMMY_KEY"
-$CLI_BIN revenue-distribution fetch -u l --validator-deposit $DUMMY_KEY
+echo "doublezero-solana revenue-distribution fetch validator-deposits -u l --node-id $DUMMY_KEY"
+$CLI_BIN revenue-distribution fetch validator-deposits -u l --node-id $DUMMY_KEY
+echo
+
+echo "doublezero-solana revenue-distribution fetch validator-deposits -u l"
+$CLI_BIN revenue-distribution fetch validator-deposits -u l
 echo
 
 ### ATA commands.


### PR DESCRIPTION
## Summary of Changes
- Add ability to fetch solana validator deposit accounts with node ID and balance to the CLI
- Move fetch flags to sub-commands
- Remove solana prefix on sub-commands
- Resolves https://github.com/malbeclabs/doublezero/issues/1804

## Testing Verification
```console
$ doublezero-solana revenue-distribution fetch validator-deposits -u t

Solana validator deposit accounts            | Node ID                                     | Balance (SOL)
---------------------------------------------+---------------------------------------------+--------------
79jStiBvoxujPWfmGfRahfFJd5SU2XruSwfDmysXt3xA | Node111111111111111111111111111111111111111 | 0.000000001
EdmeAaCNiKkkNX73vch6kibJCeLnzcSPFpNzKeoRPYxP | Node111111111111111111111111111111111111112 | 0.000000069
AReLULgb4P7ipxQJy9cheGUsGRqQCbJNTFZXmjdkGMdE | Node111111111111111111111111111111111111113 | 0.000000420


$ doublezero-solana revenue-distribution fetch validator-deposits -u t --node-id Node111111111111111111111111111111111111111

Solana validator deposit accounts            | Node ID                                     | Balance (SOL)
---------------------------------------------+---------------------------------------------+--------------
79jStiBvoxujPWfmGfRahfFJd5SU2XruSwfDmysXt3xA | Node111111111111111111111111111111111111111 | 0.000000001
```