### PR TITLE
solana-cli: fix validator deposits not found

### DIFF
--- a/sh/test_doublezero_solana_clean.sh
+++ b/sh/test_doublezero_solana_clean.sh
@@ -133,10 +133,6 @@ echo "doublezero-solana revenue-distribution fetch config -u l"
 $CLI_BIN revenue-distribution fetch config -u l
 echo
 
-echo "doublezero-solana revenue-distribution fetch validator-deposits -u l --node-id $DUMMY_KEY"
-$CLI_BIN revenue-distribution fetch validator-deposits -u l --node-id $DUMMY_KEY
-echo
-
 echo "doublezero-solana revenue-distribution fetch validator-deposits -u l"
 $CLI_BIN revenue-distribution fetch validator-deposits -u l
 echo


### PR DESCRIPTION
## Summary of Changes
- Update doublezero-solana CLI revenue distribution validator deposits fetch sub-command to show not found when given a node ID that is not found