### PR TITLE
Fix deps, fix clippy warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 [[package]]
 name = "doublezero-config"
 version = "0.6.4"
-source = "git+ssh://git@github.com/malbeclabs/doublezero?rev=89a675d#89a675daff59fd2f4bb30f130b7859d201c35151"
+source = "git+https://github.com/malbeclabs/doublezero?rev=89a675d#89a675daff59fd2f4bb30f130b7859d201c35151"
 dependencies = [
  "eyre",
  "solana-sdk",
@@ -1819,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "doublezero-passport"
 version = "0.1.0"
-source = "git+ssh://git@github.com/doublezerofoundation/doublezero-solana?rev=464823a#464823ad6d68973fee3058c676af6efa58804a45"
+source = "git+https://github.com/doublezerofoundation/doublezero-solana?rev=a3cd70b#a3cd70bb207043d871e8fb99041c773145d28e01"
 dependencies = [
  "borsh 1.5.7",
  "bytemuck",
@@ -1838,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "doublezero-program-common"
 version = "0.6.4"
-source = "git+ssh://git@github.com/malbeclabs/doublezero?rev=89a675d#89a675daff59fd2f4bb30f130b7859d201c35151"
+source = "git+https://github.com/malbeclabs/doublezero?rev=89a675d#89a675daff59fd2f4bb30f130b7859d201c35151"
 dependencies = [
  "borsh 1.5.7",
  "byteorder",
@@ -1850,7 +1850,7 @@ dependencies = [
 [[package]]
 name = "doublezero-program-tools"
 version = "0.1.0"
-source = "git+ssh://git@github.com/doublezerofoundation/doublezero-solana?rev=464823a#464823ad6d68973fee3058c676af6efa58804a45"
+source = "git+https://github.com/doublezerofoundation/doublezero-solana?rev=a3cd70b#a3cd70bb207043d871e8fb99041c773145d28e01"
 dependencies = [
  "bincode 1.3.3",
  "borsh 1.5.7",
@@ -1872,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "doublezero-record"
 version = "0.6.4"
-source = "git+ssh://git@github.com/malbeclabs/doublezero?rev=89a675d#89a675daff59fd2f4bb30f130b7859d201c35151"
+source = "git+https://github.com/malbeclabs/doublezero?rev=89a675d#89a675daff59fd2f4bb30f130b7859d201c35151"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -1882,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "doublezero-revenue-distribution"
 version = "0.1.0"
-source = "git+ssh://git@github.com/doublezerofoundation/doublezero-solana?rev=464823a#464823ad6d68973fee3058c676af6efa58804a45"
+source = "git+https://github.com/doublezerofoundation/doublezero-solana?rev=a3cd70b#a3cd70bb207043d871e8fb99041c773145d28e01"
 dependencies = [
  "borsh 1.5.7",
  "bytemuck",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "doublezero-serviceability"
 version = "0.6.4"
-source = "git+ssh://git@github.com/malbeclabs/doublezero?rev=89a675d#89a675daff59fd2f4bb30f130b7859d201c35151"
+source = "git+https://github.com/malbeclabs/doublezero?rev=89a675d#89a675daff59fd2f4bb30f130b7859d201c35151"
 dependencies = [
  "borsh 1.5.7",
  "doublezero-program-common",
@@ -1957,7 +1957,7 @@ dependencies = [
 [[package]]
 name = "doublezero-solana-client-tools"
 version = "0.1.0"
-source = "git+ssh://git@github.com/doublezerofoundation/doublezero-solana?rev=464823a#464823ad6d68973fee3058c676af6efa58804a45"
+source = "git+https://github.com/doublezerofoundation/doublezero-solana?rev=a3cd70b#a3cd70bb207043d871e8fb99041c773145d28e01"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2011,7 +2011,7 @@ dependencies = [
 [[package]]
 name = "doublezero-telemetry"
 version = "0.6.4"
-source = "git+ssh://git@github.com/malbeclabs/doublezero?rev=89a675d#89a675daff59fd2f4bb30f130b7859d201c35151"
+source = "git+https://github.com/malbeclabs/doublezero?rev=89a675d#89a675daff59fd2f4bb30f130b7859d201c35151"
 dependencies = [
  "borsh 1.5.7",
  "doublezero-config",
@@ -2025,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "doublezero_sdk"
 version = "0.6.4"
-source = "git+ssh://git@github.com/malbeclabs/doublezero?rev=89a675d#89a675daff59fd2f4bb30f130b7859d201c35151"
+source = "git+https://github.com/malbeclabs/doublezero?rev=89a675d#89a675daff59fd2f4bb30f130b7859d201c35151"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,44 +72,44 @@ url = "2"
 
 [workspace.dependencies.doublezero-passport]
 features = ["offchain"]
-git = "ssh://git@github.com/doublezerofoundation/doublezero-solana"
-rev = "464823a"
+git = "https://github.com/doublezerofoundation/doublezero-solana"
+rev = "a3cd70b"
 
 [workspace.dependencies.doublezero-program-tools]
-git = "ssh://git@github.com/doublezerofoundation/doublezero-solana"
-rev = "464823a"
+git = "https://github.com/doublezerofoundation/doublezero-solana"
+rev = "a3cd70b"
 
 [workspace.dependencies.doublezero-revenue-distribution]
-git = "ssh://git@github.com/doublezerofoundation/doublezero-solana"
-rev = "464823a"
+git = "https://github.com/doublezerofoundation/doublezero-solana"
+rev = "a3cd70b"
 
 [workspace.dependencies.doublezero-solana-client-tools]
-git = "ssh://git@github.com/doublezerofoundation/doublezero-solana"
-rev = "464823a"
+git = "https://github.com/doublezerofoundation/doublezero-solana"
+rev = "a3cd70b"
 
 ### Dependencies found in github.com/malbeclabs/doublezero
 
 [workspace.dependencies.doublezero-program-common]
-git = "ssh://git@github.com/malbeclabs/doublezero"
+git = "https://github.com/malbeclabs/doublezero"
 rev="89a675d"
 
 [workspace.dependencies.doublezero-record]
 features = ["no-entrypoint"]
-git = "ssh://git@github.com/malbeclabs/doublezero"
+git = "https://github.com/malbeclabs/doublezero"
 rev="89a675d"
 
 [workspace.dependencies.doublezero_sdk]
-git = "ssh://git@github.com/malbeclabs/doublezero"
+git = "https://github.com/malbeclabs/doublezero"
 rev="89a675d"
 
 [workspace.dependencies.doublezero-serviceability]
 features = ["no-entrypoint", "serde"]
-git = "ssh://git@github.com/malbeclabs/doublezero"
+git = "https://github.com/malbeclabs/doublezero"
 rev="89a675d"
 
 [workspace.dependencies.doublezero-telemetry]
 features = ["no-entrypoint", "serde"]
-git = "ssh://git@github.com/malbeclabs/doublezero"
+git = "https://github.com/malbeclabs/doublezero"
 rev="89a675d"
 
 ### Other git dependencies

--- a/crates/contributor-rewards/tests/test_pvt_links.rs
+++ b/crates/contributor-rewards/tests/test_pvt_links.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use doublezero_contributor_rewards::{
-    calculator::shapley_handler::{PreviousEpochCache, build_devices, build_private_links},
+    calculator::shapley_handler::{build_devices, build_private_links},
     ingestor::types::FetchData,
     processor::telemetry::DZDTelemetryProcessor,
     settings,


### PR DESCRIPTION
Summary
----
Now that the repos are public, we don't need to use `ssh://...` for deps, this fixes that along with a clippy warning.