### PR TITLE
contributor-rewards: add quadratic penalty for uptime

### DIFF
--- a/crates/contributor-rewards/tests/test_pvt_links.rs
+++ b/crates/contributor-rewards/tests/test_pvt_links.rs
@@ -27,7 +27,7 @@ fn create_expected_results() -> HashMap<(String, String), ExpectedLink> {
         ExpectedLink {
             latency_ms: 154.520,
             bandwidth_gbps: 10.0,
-            uptime: 1.0,
+            uptime: 0.9265342099820373, // ~99.69% valid samples, penalty applied: 0.9265
         },
     );
 


### PR DESCRIPTION
Summary
----
Fix https://github.com/malbeclabs/doublezero/issues/1884

Implements quadratic penalty formula for private link uptime based on telemetry sample availability. Links with <98% valid samples are effectively dropped, while links with 98-100% samples receive graduated penalties proportional to data quality.

## Changes

Changes

- Core: Track total sample count (including zeros/failures) to calculate true uptime ratio
- Penalty Formula: Apply quadratic formula f(x) = -1578.9474x² + 3176.3158x - 1596.3684 clamped to [0, 1]
- Threshold Behavior: Links with <98% valid samples dropped (uptime ≈ 0), 99% uptime penalized to ~66%, 100% uptime unchanged
- Structured Logging: Added table-based output for penalized links showing sample quality, uptime values, and bandwidth reduction
- Testing: Added 11 tests covering edge cases, boundaries, and real-world scenarios
- Integration Test: Updated expected uptime value for link with 99.69% valid samples (0.9265 after penalty)

## Formula Behavior

| True Uptime | Penalized Uptime | Effect                          |
|-------------|------------------|---------------------------------|
| 100%        | 1.0              | No penalty                      |
| 99%         | 0.658            | ~34% bandwidth reduction        |
| 98%         | ~0               | Threshold - effectively dropped |
| <98%        | 0                | Link excluded from calculations |
