### PR TITLE
solana-cli: fix backup validator leader schedule check output

### DIFF
--- a/crates/solana-cli/src/command/passport/prepare_access.rs
+++ b/crates/solana-cli/src/command/passport/prepare_access.rs
@@ -112,16 +112,15 @@ impl PrepareValidatorAccessCommand {
 
                     if sol_client
                         .check_leader_schedule(backup_id, ENV_PREVIOUS_LEADER_EPOCHS)
-                        .await
-                        .is_err()
+                        .await?
                     {
-                        println!(" ✅ OK (not a leader scheduled validator)");
-                    } else {
                         println!(" ❌ Fail (on leader scheduler)");
                         errors.push(format!(
                             "Backup validator ID ({}) should not be on leader scheduler. It must be a non-leader scheduled validator.",
                             backup_id
                         ));
+                    } else {
+                        println!(" ✅ OK (not a leader scheduled validator)");
                     }
                 } else {
                     println!("❌ Gossip Fail",);


### PR DESCRIPTION
This PR fixes a bug in the execution of the condition used to validate the identity of backup nodes.

The previous implementation incorrectly evaluated the condition, which could result in validation failures or unexpected behavior. With this fix, the condition is now executed as intended, ensuring that backup identities are validated correctly and consistently.

**Validator leader schedule check improvements:**

* Changed the `.check_leader_schedule` call to propagate errors using the `?` operator, ensuring that only a successful check with a `false` result prints the "OK" message, while errors are handled by the caller. The success and failure messages have been swapped to match the new logic. (`crates/solana-cli/src/command/passport/prepare_access.rs`)