### PR TITLE
solana-cli: version 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-solana-cli"
-version = "0.1.10"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "borsh 1.5.7",

--- a/crates/solana-cli/Cargo.toml
+++ b/crates/solana-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "doublezero-solana-cli"
 description = "Command line to interact with DoubleZero Solana programs"
-version = "0.1.10"
+version = "0.1.1"
 
 edition.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
Inadvertently added a nonsensical version for doublezero-solana-cli. This PR fixes this