### PR TITLE
sentinel: simplify leader schedule check

### DIFF
--- a/crates/sentinel/src/sentinel/handler.rs
+++ b/crates/sentinel/src/sentinel/handler.rs
@@ -608,7 +608,7 @@ mod tests {
             .times(n)
             .returning(|_| Ok(Signature::new_unique()));
         sol.expect_grant_access().times(0);
-        sol.expect_check_leader_schedule().times(0);
+        sol.expect_is_scheduled_leader().times(0);
         sol.expect_get_validator_ip().times(0);
 
         let mut dz = MockDzRpcClientType::new();
@@ -650,7 +650,7 @@ mod tests {
         }
 
         // Verifier deps per ID
-        sol.expect_check_leader_schedule()
+        sol.expect_is_scheduled_leader()
             .times(n)
             .withf(|_pk, prev_epochs| *prev_epochs == 0)
             .returning(|_, _| Ok(true));

--- a/crates/sentinel/src/sentinel/verification.rs
+++ b/crates/sentinel/src/sentinel/verification.rs
@@ -107,10 +107,10 @@ impl<'a, SolRpcClient: SolRpcClientType> ValidatorVerifier<'a, SolRpcClient> {
         rpc_with_retry(
             || async {
                 self.sol_rpc_client
-                    .check_leader_schedule(validator_id, self.previous_leader_epochs)
+                    .is_scheduled_leader(validator_id, self.previous_leader_epochs)
                     .await
             },
-            "check_leader_schedule",
+            "is_scheduled_leader",
         )
         .await
     }

--- a/crates/solana-cli/src/command/passport/find_validator.rs
+++ b/crates/solana-cli/src/command/passport/find_validator.rs
@@ -120,7 +120,7 @@ async fn print_node_info(node: &RpcContactInfo, sol_client: &SolRpcClient) {
     let pubkey = node.pubkey.parse::<Pubkey>().expect("Invalid pubkey");
 
     if sol_client
-        .check_leader_schedule(&pubkey, ENV_PREVIOUS_LEADER_EPOCHS)
+        .is_scheduled_leader(&pubkey, ENV_PREVIOUS_LEADER_EPOCHS)
         .await
         .is_ok()
     {

--- a/crates/solana-cli/src/command/passport/prepare_access.rs
+++ b/crates/solana-cli/src/command/passport/prepare_access.rs
@@ -79,7 +79,7 @@ impl PrepareValidatorAccessCommand {
             print!("  Leader scheduler: ");
 
             if sol_client
-                .check_leader_schedule(&primary_validator_id, 5)
+                .is_scheduled_leader(&primary_validator_id, 5)
                 .await
                 .is_ok()
             {
@@ -111,7 +111,7 @@ impl PrepareValidatorAccessCommand {
                     print!("  Leader scheduler: ");
 
                     if sol_client
-                        .check_leader_schedule(backup_id, ENV_PREVIOUS_LEADER_EPOCHS)
+                        .is_scheduled_leader(backup_id, ENV_PREVIOUS_LEADER_EPOCHS)
                         .await?
                     {
                         println!(" ❌ Fail (on leader scheduler)");


### PR DESCRIPTION
Summary
----
Fix https://github.com/malbeclabs/doublezero/issues/1646

Simplifies and makes the intent of leader schedule check logic clearer in the sentinel client.

## Changes

- Renamed `check_leader_schedule` to `is_scheduled_leader` for better clarity
- Refactored logic to use two-step pattern matching instead of confusing double negation
- Updated tests
