### PR TITLE
solana-cli: add token balances and more info in stdout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1997,6 +1997,7 @@ dependencies = [
  "solana-system-interface",
  "solana-transaction-status-client-types",
  "spl-associated-token-account-interface",
+ "spl-token",
  "tabled",
  "tokio",
  "tracing-subscriber",

--- a/crates/solana-cli/Cargo.toml
+++ b/crates/solana-cli/Cargo.toml
@@ -34,6 +34,7 @@ solana-sdk.workspace = true
 solana-system-interface.workspace = true
 solana-transaction-status-client-types.workspace = true
 spl-associated-token-account-interface.workspace = true
+spl-token.workspace = true
 tabled.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/solana-cli/src/command/revenue_distribution/fetch/validator_deposits.rs
+++ b/crates/solana-cli/src/command/revenue_distribution/fetch/validator_deposits.rs
@@ -63,13 +63,13 @@ impl ValidatorDepositsCommand {
                 )
             } else if deposit_balance != 0 {
                 let warning_message = format!(
-                    "⚠️  Warning: Please use \"doublezero-solana revenue-distribution validator-deposit {node_id} -i\" to create"
+                    "⚠️  Warning: Please use \"doublezero-solana revenue-distribution validator-deposit --node-id {node_id} -i\" to create {deposit_key}"
                 );
 
                 if balance_only {
                     println!("{:.9}", deposit_balance as f64 * 1e-9);
-                    println!();
-                    println!("{warning_message}");
+                    eprintln!();
+                    eprintln!("{warning_message}");
 
                     return Ok(());
                 }
@@ -80,13 +80,11 @@ impl ValidatorDepositsCommand {
                         node_id,
                         amount: format!("{:.9}", deposit_balance as f64 * 1e-9),
                     }],
-                    Some(format!(
-                        "⚠️  Warning: Please use \"doublezero-solana revenue-distribution validator-deposit {node_id} -i\" to create"
-                    )),
+                    Some(warning_message),
                 )
             } else {
                 bail!(
-                    "No deposit account found. Please use \"doublezero-solana revenue-distribution validator-deposit {node_id} --fund <AMOUNT>\" to deposit SOL"
+                    "No deposit account found at {deposit_key}. Please use \"doublezero-solana revenue-distribution validator-deposit --node-id {node_id} --fund <AMOUNT>\" to deposit SOL"
                 );
             }
         } else {


### PR DESCRIPTION
Modified the output when calling `convert-2z`:
```sh
2Z token balance: 987241.76579348
Converted 2Z to SOL: 2iaBzd4vgEeDnpfSCD9aYFMWZ3UoVzrJfUjSMhsDhfSQ6isPZKkKe3ZWQ6b5aWvV3h8Vsk8Mmde6wmCiidD4Qc6s
Converted 802.80836326 2Z tokens to 1.000000000 SOL
```

Modified the output when funding a validator deposit account with 2Z:
```sh
2Z token balance: 985635.11947485
Solana validator deposit: 79jStiBvoxujPWfmGfRahfFJd5SU2XruSwfDmysXt3xA
Funded: 4X2KAHzsAiZSngG7ETxPzmprSm4qWo1jcvfLeCwaBXsPgeJk5aEoqxsBmMo8pUdhxTBfeMGTLc6TLZu3j2Uqn9N4
Node ID: Node111111111111111111111111111111111111111
Balance: 3.440000004 SOL
Converted 803.40753980 2Z tokens to fund deposit with 1.000000000 SOL
```

Also fixed the warning messages about creating deposit accounts
```sh
⚠️  Warning: Please use "doublezero-solana revenue-distribution validator-deposit --node-id siyjLRBfc88Hc11sFvQTeoUaaVaWHD5vbVS344QtTL9 -i" to create deposit account B6ZVuraH8JkSCZW27zq5ZWpaSSSBkyT4UBajAoaykDPq
```

Also reorganized the `convert_2z` module a bit.