### PR TITLE
sentinel: change error to reason for known sig verification failure

### DIFF
--- a/crates/sentinel/src/sentinel/verification.rs
+++ b/crates/sentinel/src/sentinel/verification.rs
@@ -30,7 +30,7 @@ impl<'a, SolRpcClient: SolRpcClientType> ValidatorVerifier<'a, SolRpcClient> {
             Ok(v) => v,
             Err(e @ Error::SignatureVerify) => {
                 return {
-                    info!(error = %e, "signature verification failed");
+                    info!(reason = %e, "signature verification failed");
                     Ok(vec![])
                 };
             }


### PR DESCRIPTION
# Summary

Small PR to change `error` to `reason` to not trigger alerts when errors like these occur:

```
Oct 22 12:39:48 aws-mn-sentinel1 doublezero-sentinel[298603]: 2025-10-22T12:39:48.114282Z  INFO doublezero_ledger_sentinel::sentinel::verification: signature verification failed error=access request signature did not verify
```