### PR TITLE
fix(workspace): bump stable rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup | Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.90.0
+          toolchain: 1.91.0
           components: clippy, rustfmt, llvm-tools-preview
 
       - name: Setup | Rust cache

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.90"
+channel = "1.91.0"
 components = ["clippy", "rust-analyzer", "rustfmt"]


### PR DESCRIPTION
# Summary

Simple PR to bump stable rust version to `1.91.0`