### PR TITLE
fix(goreleaser): Install binaries in /usr/bin/ instead of /usr/local/bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+
 /target
 
 # IDE
@@ -30,6 +31,7 @@ cache/
 *.bak
 *.txt
 *.log
+dist/
 
 # Local test data
 forked-accounts/

--- a/release/.goreleaser.contributor-rewards.yaml
+++ b/release/.goreleaser.contributor-rewards.yaml
@@ -50,7 +50,7 @@ nfpms:
     license: Apache 2.0
     formats:
       - deb
-    bindir: /usr/local/bin
+    bindir: /usr/bin
     release: 1
     section: default
     contents:

--- a/release/.goreleaser.doublezero-solana-cli.yaml
+++ b/release/.goreleaser.doublezero-solana-cli.yaml
@@ -51,7 +51,7 @@ nfpms:
     formats:
       - deb
       - rpm
-    bindir: /usr/local/bin
+    bindir: /usr/bin
     release: "1"
     section: default
     # NOTE: doublezero-solana-cli is not required to be a systemd service

--- a/release/.goreleaser.doublezero-solana-validator-debt.yaml
+++ b/release/.goreleaser.doublezero-solana-validator-debt.yaml
@@ -50,7 +50,7 @@ nfpms:
     license: Apache 2.0
     formats:
       - deb
-    bindir: /usr/local/bin
+    bindir: /usr/bin
     release: 1
     section: default
     contents:

--- a/release/.goreleaser.sentinel.yaml
+++ b/release/.goreleaser.sentinel.yaml
@@ -50,7 +50,7 @@ nfpms:
     license: Apache 2.0
     formats:
       - deb
-    bindir: /usr/local/bin
+    bindir: /usr/bin
     release: 1
     section: default
     contents:


### PR DESCRIPTION
## Summary of Changes
* Change installation directory for binaries from /usr/local/bin/ to /usr/bin/
* Linux distributions require that packages do not install files into /usr/local/:
  * https://www.debian.org/doc/debian-policy/ch-opersys.html#site-specific-programs
  * https://docs.fedoraproject.org/en-US/packaging-guidelines/

Closes https://github.com/malbeclabs/doublezero/issues/2083.

## Testing Verification
* Built packages locally with `goreleaser --snapshot --clean`
