### PR TITLE
fix(contributor-rewards): make scheduler retry infinitely

### DIFF
--- a/crates/contributor-rewards/example.config.toml
+++ b/crates/contributor-rewards/example.config.toml
@@ -110,9 +110,6 @@ state_file = "/var/lib/doublezero-contributor-rewards/scheduler.state"
 # Directory to store epoch snapshots (only used if storage_backend = "local-file")
 snapshot_dir = "/var/lib/doublezero-contributor-rewards/snapshots"
 
-# Maximum consecutive failures before halting
-max_consecutive_failures = 10
-
 # Enable dry run mode (no on-chain writes, but snapshots still upload to S3)
 enable_dry_run = false
 

--- a/crates/contributor-rewards/src/settings/mod.rs
+++ b/crates/contributor-rewards/src/settings/mod.rs
@@ -136,8 +136,6 @@ pub struct SchedulerSettings {
     pub state_file: String,
     /// Directory to store epoch snapshots
     pub snapshot_dir: String,
-    /// Maximum consecutive failures before halting
-    pub max_consecutive_failures: u32,
     /// Enable dry run mode for worker
     pub enable_dry_run: bool,
     /// Storage backend for snapshots

--- a/crates/contributor-rewards/src/settings/validation.rs
+++ b/crates/contributor-rewards/src/settings/validation.rs
@@ -208,7 +208,6 @@ mod tests {
                 interval_seconds: 300,
                 state_file: "/var/lib/doublezero-contributor-rewards/scheduler.state".to_string(),
                 snapshot_dir: "/var/lib/doublezero-contributor-rewards/snapshots".to_string(),
-                max_consecutive_failures: 10,
                 enable_dry_run: false,
                 storage_backend: StorageBackend::LocalFile,
                 grace_period_max_wait_seconds: 21600,

--- a/crates/contributor-rewards/test.config.toml
+++ b/crates/contributor-rewards/test.config.toml
@@ -54,7 +54,6 @@ enable_previous_epoch_lookup = true
 interval_seconds = 300
 state_file = "/tmp/doublezero-contributor-rewards-test.state"
 snapshot_dir = "/tmp/doublezero-contributor-rewards-snapshots"
-max_consecutive_failures = 10
 enable_dry_run = false
 storage_backend = "s3"
 

--- a/crates/contributor-rewards/tests/common/mod.rs
+++ b/crates/contributor-rewards/tests/common/mod.rs
@@ -47,7 +47,6 @@ pub fn create_test_settings(
             interval_seconds: 300,
             state_file: "/var/lib/doublezero-contributor-rewards/scheduler.state".to_string(),
             snapshot_dir: "/tmp/snapshots".to_string(),
-            max_consecutive_failures: 10,
             enable_dry_run: false,
             storage_backend: settings::aws::StorageBackend::LocalFile,
             grace_period_max_wait_seconds: 21600,

--- a/crates/contributor-rewards/tests/test_pub_links.rs
+++ b/crates/contributor-rewards/tests/test_pub_links.rs
@@ -62,7 +62,6 @@ fn test_settings() -> settings::Settings {
             interval_seconds: 300,
             state_file: "/var/lib/doublezero-contributor-rewards/scheduler.state".to_string(),
             snapshot_dir: "/tmp/snapshots".to_string(),
-            max_consecutive_failures: 10,
             enable_dry_run: false,
             storage_backend: settings::aws::StorageBackend::LocalFile,
             grace_period_max_wait_seconds: 21600,

--- a/crates/contributor-rewards/tests/test_pvt_links.rs
+++ b/crates/contributor-rewards/tests/test_pvt_links.rs
@@ -136,7 +136,6 @@ fn test_settings() -> settings::Settings {
             interval_seconds: 300,
             state_file: "/var/lib/doublezero-contributor-rewards/scheduler.state".to_string(),
             snapshot_dir: "/tmp/snapshots".to_string(),
-            max_consecutive_failures: 10,
             enable_dry_run: false,
             storage_backend: settings::aws::StorageBackend::LocalFile,
             grace_period_max_wait_seconds: 21600,

--- a/crates/contributor-rewards/tests/test_s3_storage.rs
+++ b/crates/contributor-rewards/tests/test_s3_storage.rs
@@ -36,7 +36,6 @@ fn create_test_settings(
             interval_seconds: 300,
             state_file: "/tmp/test.state".to_string(),
             snapshot_dir,
-            max_consecutive_failures: 10,
             enable_dry_run: false,
             storage_backend,
             grace_period_max_wait_seconds: 21600,


### PR DESCRIPTION
# Summary

contributor-rewards scheduler was entering a permanent failure state after 10 consecutive RPC failures, requiring manual intervention to recover. This PR
removes the hard halt and implements self-healing retry logic with monitoring alerts.

Fixes https://github.com/malbeclabs/infra/issues/368

## Changes

- Remove hard halt: Scheduler now retries indefinitely instead of halting after max failures
- Add RPC retry with backoff: Wrap get_epoch_info() with backoff
- Add periodic alerting: Emit ERROR log every 10 consecutive failures for monitoring
- Remove max_consecutive_failures config: No longer needed since hard halt is removed
