### PR TITLE
feat(scheduler): Automatically finalize distribution

### DIFF
--- a/crates/validator-debt/src/worker.rs
+++ b/crates/validator-debt/src/worker.rs
@@ -142,6 +142,10 @@ pub async fn calculate_distribution(
         .read_distribution(dz_epoch, solana_debt_calculator.solana_rpc_client())
         .await?;
 
+    if distribution.is_debt_calculation_finalized() {
+        bail!("distribution has already been finalized for dz epoch {dz_epoch}");
+    }
+
     // get solana current timestamp
     let clock_account = solana_debt_calculator
         .solana_rpc_client()

--- a/scheduler/CHANGELOG.md
+++ b/scheduler/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
-- feat(automate_calculate_distribution): Add GenServer and Rust NIF to automatically calculuae a distribution on a configurable interval ([#197]https://github.com/doublezerofoundation/doublezero-offchain/pull/197)
+- feat(automate_finalize_distribution):
+- feat(automate_calculate_distribution): Add GenServer and Rust NIF to automatically calculate a distribution on a configurable interval ([#197]https://github.com/doublezerofoundation/doublezero-offchain/pull/197)
 - feat(automate_initialize_distribution): Add GenServer and Rust NIF to automatically initialize a distribution on a configurable interval ([#197]https://github.com/doublezerofoundation/doublezero-offchain/pull/197)
 - feat(automate_debt_payment): Add GenServer and Rust NIF to automatically collect debt on a configurable interval ([#183]https://github.com/doublezerofoundation/doublezero-offchain/pull/183)
 - feat(scheduler): add Elixir app that manages scheduling and executing Rust processes for debt collection and payment  ([#183]https://github.com/doublezerofoundation/doublezero-offchain/pull/183)

--- a/scheduler/lib/scheduler/scheduler_doublezero.ex
+++ b/scheduler/lib/scheduler/scheduler_doublezero.ex
@@ -3,5 +3,12 @@ defmodule Scheduler.DoubleZero do
 
   def pay_debt(_dz_epoch, _ledger_rpc, _solana_rpc), do: :erlang.nif_error(:nif_not_loaded)
   def initialize_distribution(_ledger_rpc, _solana_rpc), do: :erlang.nif_error(:nif_not_loaded)
-  def calculate_distribution(_ledger_rpc, _solana_rpc), do: :erlang.nif_error(:nif_not_loaded)
+
+  def calculate_distribution(_dz_epoch, _ledger_rpc, _solana_rpc, _post_to_slack),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def finalize_distribution(_dz_epoch, _ledger_rpc, _solana_rpc),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def current_dz_epoch(_ledger_rpc), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/scheduler/lib/scheduler/worker/calculate_distribution.ex
+++ b/scheduler/lib/scheduler/worker/calculate_distribution.ex
@@ -1,23 +1,83 @@
 defmodule Scheduler.Worker.CalculateDistribution do
+  @moduledoc """
+    Calculates distribution for the current dz epoch - 1 (most recently closed epoch) and runs three times to ensure that the outcome is the same (this is done in worker.rs calculate_distribution) for calculated debt. If it's equal for three runs, the debt is finalized.
+  """
   use GenServer
 
   require Logger
 
   def start_link(_var \\ []) do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+    state = %{count: 0, dz_epoch: nil}
+    GenServer.start_link(__MODULE__, state, name: __MODULE__)
   end
 
-  def init([] = state) do
-    {:ok, state, {:continue, :calculate_distribution}}
+  def init(state) do
+    {:ok, state, {:continue, :get_current_dz_epoch}}
+  end
+
+  def handle_continue(:get_current_dz_epoch, state) do
+    case Scheduler.DoubleZero.current_dz_epoch(ledger_rpc()) do
+      dz_epoch when is_integer(dz_epoch) ->
+        # dz_epoch - 1 gets the most recently closed dz_epoch
+        epoch_to_calculate = dz_epoch - 1
+
+        Logger.info("Calculating debt for dz epoch #{epoch_to_calculate}")
+
+        state = %{state | dz_epoch: epoch_to_calculate}
+        {:noreply, state, {:continue, :calculate_distribution}}
+
+      error ->
+        Logger.error("calculate_distribution: failed to get dz_epoch: #{inspect(error)}")
+        {:stop, "calculate_distribution failed to get dz_epoch", state}
+    end
+  end
+
+  def handle_continue(:calculate_distribution, %{count: 2} = state) do
+    case Scheduler.DoubleZero.calculate_distribution(
+           state.dz_epoch,
+           ledger_rpc(),
+           solana_rpc(),
+           true
+         ) do
+      {:error, error} ->
+        Logger.error("calculate_distribution: received error: #{inspect(error)}")
+        {:stop, "calculate_distribution shutting down", state}
+
+      _ ->
+        Logger.info("Proceeding to finalize debt")
+        {:noreply, state, {:continue, :finalize_distribution}}
+    end
   end
 
   def handle_continue(:calculate_distribution, state) do
-    case Scheduler.DoubleZero.calculate_distribution(ledger_rpc(), solana_rpc()) do
+    case Scheduler.DoubleZero.calculate_distribution(
+           state.dz_epoch,
+           ledger_rpc(),
+           solana_rpc(),
+           false
+         ) do
+      {:error, error} ->
+        Logger.error("calculate_distribution: received error: #{inspect(error)}")
+        {:stop, "calculate_distribution shutting down", state}
+
+      _ ->
+        state = %{state | count: state.count + 1}
+        Logger.info("Completed calculation for debt ##{state.count}")
+        {:noreply, state, {:continue, :calculate_distribution}}
+    end
+  end
+
+  def handle_continue(:finalize_distribution, state) do
+    Logger.info("Finalizing debt for dz epoch #{state.dz_epoch}")
+
+    case Scheduler.DoubleZero.finalize_distribution(state.dz_epoch, ledger_rpc(), solana_rpc()) do
       {:error, error} ->
         Logger.error("calculate_distribution: received error: #{inspect(error)}")
 
       _ ->
-        :ok
+        Logger.info(
+          "calculate_distribution: finalized distribution for dz epoch #{state.dz_epoch}"
+        )
     end
 
     {:stop, "calculate_distribution shutting down", state}


### PR DESCRIPTION
## Summary of Changes

This PR updates the calculate_distribution worker to add in a counter that increments each time the calculate_distribution function successfully completes. When the counter reaches three, it moves to the finalize_distribution callback where the finalize_distribution NIF is called. If any of the calls fail or the computed_debt differs from the ledger debt record, the process is stopped and the counter is reset to zero.    

Note that only the third successful run is posted to slack.

Closes https://github.com/malbeclabs/doublezero/issues/2028

## Testing Verification

* This was run and posted to slack as evidenced [here](https://malbeclabs.slack.com/archives/C09LES1Q127/p1763585298695259)
