### PR TITLE
feat(scheduler): add action to deploy scheduler (#2193)

### DIFF
--- a/.github/workflows/release.scheduler.yml
+++ b/.github/workflows/release.scheduler.yml
@@ -57,20 +57,16 @@ jobs:
         run: mix deps.get
         working-directory: ./scheduler
 
-      - name: Compiles without warnings
-        run: mix compile --warnings-as-errors
-        working-directory: ./scheduler
-
       - name: Build release
         run: MIX_ENV=prod mix release
         working-directory: ./scheduler
 
-      - name: Deploy to server
-        uses: appleboy/scp-action@master
+      - name: Publish package to Cloudsmith
+        uses: cloudsmith-io/cloudsmith-cli-action@v1
         with:
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USERNAME }}
-          key: ${{ secrets.SSH_KEY }}
-          port: ${{ secrets.SSH_PORT }}
-          source: "scheduler/_build/prod/rel/scheduler/releases/*/*.tar.gz"
-          target: "/opt/scheduler"
+          api_key: ${{ secrets.CLOUDSMITH_API_KEY }}
+          command: push
+          format: raw
+          owner: malbeclabs
+          repo: doublezero
+          filename: scheduler/_build/prod/scheduler-0.1.0.tar.gz # need to derive the tag

--- a/scheduler/mix.exs
+++ b/scheduler/mix.exs
@@ -7,7 +7,12 @@ defmodule Scheduler.MixProject do
       version: "0.1.0",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      releases: [
+        scheduler: [
+          steps: [:assemble, :tar]
+        ]
+      ]
     ]
   end
 


### PR DESCRIPTION
## Summary of Changes

This adds a github workflow to package and deploy the scheduler app as a tarball to cloudsmith, but a second PR was needed

Should have closed https://github.com/malbeclabs/doublezero/issues/2193

## Testing Verification
* Ran it locally with [act](https://github.com/nektos/act)
* Doing it live

