### PR TITLE
fix(contributor-rewards): track shapley output record address for slack notifications

### DIFF
--- a/crates/contributor-rewards/src/calculator/orchestrator.rs
+++ b/crates/contributor-rewards/src/calculator/orchestrator.rs
@@ -310,17 +310,17 @@ impl Orchestrator {
 
                 // Write shapley output storage instead of individual proofs
                 if !write_config.should_skip_shapley_output() {
-                    ledger_operations::write_shapley_output(
+                    let prefix = &self.settings.get_contributor_rewards_prefix();
+                    ledger_operations::write_serialized_and_track(
                         &fetcher.dz_rpc_client,
                         &payer_signer,
-                        fetch_epoch,
-                        &shapley_storage,
+                        &[prefix, &fetch_epoch_bytes, b"shapley_output"],
                         &shapley_storage_bytes,
-                        &self.settings,
+                        "shapley output storage",
+                        &mut summary,
+                        self.settings.rpc.rps_limit,
                     )
-                    .await?;
-
-                    summary.add_success("shapley output storage".to_string());
+                    .await;
                 } else {
                     info!("[SKIP] Shapley output storage write (--skip-shapley-output)");
                 }

--- a/crates/contributor-rewards/src/settings/mod.rs
+++ b/crates/contributor-rewards/src/settings/mod.rs
@@ -217,6 +217,22 @@ impl Settings {
 
         Ok(settings)
     }
+
+    pub fn get_device_telemetry_prefix(&self) -> Vec<u8> {
+        self.prefixes.device_telemetry.as_bytes().to_vec()
+    }
+
+    pub fn get_internet_telemetry_prefix(&self) -> Vec<u8> {
+        self.prefixes.internet_telemetry.as_bytes().to_vec()
+    }
+
+    pub fn get_contributor_rewards_prefix(&self) -> Vec<u8> {
+        self.prefixes.contributor_rewards.as_bytes().to_vec()
+    }
+
+    pub fn get_reward_input_prefix(&self) -> Vec<u8> {
+        self.prefixes.reward_input.as_bytes().to_vec()
+    }
 }
 
 impl fmt::Display for Settings {


### PR DESCRIPTION
# Summary

Fixes a bug where Slack notifications displayed "N/A" for the shapley output record address instead of the actual on-chain address.

Fixes: https://github.com/malbeclabs/doublezero/issues/2272

## Changes

- Fix shapley output write to use write_serialized_and_track directly, ensuring record address is captured in WriteSummary
- Remove unused write_shapley_output function from ledger_operations.rs
- Move prefix helper functions from free functions to methods on Settings struct
