### PR TITLE
Handle paginated Jito rewards and missing entries

### DIFF
--- a/crates/validator-debt/src/jito.rs
+++ b/crates/validator-debt/src/jito.rs
@@ -1,21 +1,21 @@
 use std::{collections::HashMap, time::Duration};
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use backon::{ExponentialBuilder, Retryable};
 use serde::Deserialize;
-use tracing::info;
+use tracing::{debug, info};
 
 use crate::solana_debt_calculator::ValidatorRewards;
 
 const JITO_BASE_URL: &str = "https://kobe.mainnet.jito.network/api/v1/";
 
+// Safety cap to avoid runaway pagination if the API misbehaves.
+const MAX_JITO_PAGES: u16 = 25;
 pub const JITO_REWARDS_LIMIT: u16 = 1_500;
 
 #[derive(Deserialize, Debug)]
 pub struct JitoRewards {
-    // TODO: check total_count to see if it exceeds entries in a single response
-    // limit - default: 100, max: 10000
-    pub total_count: u16,
+    pub total_count: usize,
     pub rewards: Vec<JitoReward>,
 }
 
@@ -31,45 +31,82 @@ pub async fn get_jito_rewards<'a>(
     validator_ids: &'a [String],
     epoch: u64,
 ) -> Result<HashMap<&'a str, u64>> {
-    let url = format!(
-        // TODO: make limit an env var
-        // based on very unscientific checking of a number of epochs, 1200 is the highest count
-        "{JITO_BASE_URL}validator_rewards?epoch={epoch}&limit={JITO_REWARDS_LIMIT}"
-    );
+    let mut page: u16 = 1;
+    let mut total_count: Option<usize> = None;
+    let mut collected: usize = 0;
+    let mut all_rewards: HashMap<String, u64> = HashMap::new();
+    let mut pagination_notice_logged = false;
 
-    println!("Fetching Jito rewards for epoch {epoch}");
-    let rewards = (|| async { solana_debt_calculator.get::<JitoRewards>(&url).await })
-        .retry(
-            &ExponentialBuilder::default()
-                .with_max_times(5)
-                .with_min_delay(Duration::from_millis(100))
-                .with_max_delay(Duration::from_secs(10))
-                .with_jitter(),
-        )
-        .notify(|err, dur: Duration| {
-            info!("Jito API call failed, retrying in {:?}: {}", dur, err);
-        })
-        .await
-        .map_err(|e| {
-            anyhow!("Failed to fetch Jito rewards for epoch {epoch} after retries: {e:#?}")
-        })?;
+    let retry_strategy = ExponentialBuilder::default()
+        .with_max_times(5)
+        .with_min_delay(Duration::from_millis(100))
+        .with_max_delay(Duration::from_secs(10))
+        .with_jitter();
 
-    if rewards.total_count > JITO_REWARDS_LIMIT {
-        println!(
-            "Unexpectedly received total count higher than 1500; actual count is {}",
-            rewards.total_count
+    loop {
+        if page > MAX_JITO_PAGES {
+            info!(
+                "Stopping Jito rewards pagination for epoch {epoch}: reached MAX_JITO_PAGES={MAX_JITO_PAGES} after collecting {collected} entries; returning partial results"
+            );
+            break;
+        }
+
+        let url = format!(
+            "{JITO_BASE_URL}validator_rewards?epoch={epoch}&page={page}&limit={JITO_REWARDS_LIMIT}"
         );
+        debug!("Fetching Jito rewards for epoch {epoch}, page {page}");
+        let page_rewards = (|| async { solana_debt_calculator.get::<JitoRewards>(&url).await })
+            .retry(&retry_strategy)
+            .notify(|err, dur: Duration| {
+                info!("Jito API call failed, retrying in {:?}: {}", dur, err);
+            })
+            .await
+            .map_err(|e| anyhow!(e))
+            .with_context(|| {
+                format!("Failed to fetch Jito rewards page {page} for epoch {epoch} after retries")
+            })?;
+
+        if total_count.is_none() {
+            total_count = Some(page_rewards.total_count);
+            let page_size = usize::from(JITO_REWARDS_LIMIT);
+            if page_rewards.total_count > page_size && !pagination_notice_logged {
+                info!(
+                    "Detected paginated Jito rewards for epoch {epoch}: total_count={} exceeds page size {JITO_REWARDS_LIMIT}",
+                    page_rewards.total_count,
+                );
+                pagination_notice_logged = true;
+            }
+        }
+
+        if page_rewards.rewards.is_empty() {
+            info!(
+                "Stopping Jito rewards pagination for epoch {epoch}: empty page returned at page {page}"
+            );
+            break;
+        }
+
+        let page_len = page_rewards.rewards.len();
+        for reward in page_rewards.rewards {
+            *all_rewards.entry(reward.vote_account).or_insert(0) += reward.mev_revenue;
+        }
+        collected += page_len;
+
+        if let Some(total) = total_count {
+            if collected >= total {
+                info!(
+                    "Collected all Jito rewards for epoch {epoch}: collected {collected} of {total} after page {page}"
+                );
+                break;
+            }
+        }
+
+        page += 1;
     }
+
     let jito_rewards = validator_ids
         .iter()
         .map(|validator_id| {
-            println!("Fetching Jito rewards for validator_id {validator_id}");
-            let mev_revenue = rewards
-                .rewards
-                .iter()
-                .find(|reward| validator_id == &reward.vote_account)
-                .map(|reward| reward.mev_revenue)
-                .unwrap_or_default();
+            let mev_revenue = all_rewards.get(validator_id).copied().unwrap_or_default();
             (validator_id.as_str(), mev_revenue)
         })
         .collect::<HashMap<_, _>>();
@@ -79,34 +116,165 @@ pub async fn get_jito_rewards<'a>(
 
 #[cfg(test)]
 mod tests {
+    use mockall::Sequence;
+
     use super::*;
     use crate::solana_debt_calculator::MockValidatorRewards;
 
     #[tokio::test]
-    async fn test_get_jito_rewards() {
+    async fn get_jito_rewards_handles_single_page_when_total_under_limit() {
         let mut jito_mock_fetcher = MockValidatorRewards::new();
-        let pubkey = "CvSb7wdQAFpHuSpTYTJnX5SYH4hCfQ9VuGnqrKaKwycB";
-        let validator_ids: &[String] = &[String::from(pubkey)];
+        let validator_a = "ValidatorA";
+        let validator_b = "ValidatorB";
+        let validator_ids = vec![validator_a.to_string(), validator_b.to_string()];
         let epoch = 812;
-        let expected_mev_revenue = 503423196855;
+        let validator_a_revenue = 42;
+        let validator_b_revenue = 84;
+
         jito_mock_fetcher
             .expect_get::<JitoRewards>()
-            .withf(move |url| url.contains(&format!("epoch={epoch}")))
+            .withf(move |url| {
+                url.contains(&format!("epoch={epoch}"))
+                    && url.contains("page=1")
+                    && url.contains(&format!("limit={JITO_REWARDS_LIMIT}"))
+            })
             .times(1)
-            .returning(move |_| {
+            .return_once(move |_| {
                 Ok(JitoRewards {
-                    total_count: 1000,
+                    total_count: 2,
+                    rewards: vec![
+                        JitoReward {
+                            vote_account: validator_a.to_string(),
+                            mev_revenue: validator_a_revenue,
+                        },
+                        JitoReward {
+                            vote_account: validator_b.to_string(),
+                            mev_revenue: validator_b_revenue,
+                        },
+                    ],
+                })
+            });
+
+        let mock_response = get_jito_rewards(&jito_mock_fetcher, validator_ids.as_slice(), epoch)
+            .await
+            .unwrap();
+
+        assert_eq!(mock_response.get(validator_a), Some(&validator_a_revenue));
+        assert_eq!(mock_response.get(validator_b), Some(&validator_b_revenue));
+    }
+
+    #[tokio::test]
+    async fn get_jito_rewards_fetches_all_pages_when_total_exceeds_page_size() {
+        let mut jito_mock_fetcher = MockValidatorRewards::new();
+        let validator_a = "ValidatorA";
+        let validator_b = "ValidatorB";
+        let validator_c = "ValidatorC";
+        let validator_ids = vec![
+            validator_a.to_string(),
+            validator_b.to_string(),
+            validator_c.to_string(),
+        ];
+        let epoch = 900;
+
+        let mut seq = Sequence::new();
+        jito_mock_fetcher
+            .expect_get::<JitoRewards>()
+            .withf(move |url| url.contains(&format!("epoch={epoch}")) && url.contains("page=1"))
+            .times(1)
+            .in_sequence(&mut seq)
+            .return_once(move |_| {
+                Ok(JitoRewards {
+                    total_count: 3,
+                    rewards: vec![
+                        JitoReward {
+                            vote_account: validator_a.to_string(),
+                            mev_revenue: 10,
+                        },
+                        JitoReward {
+                            vote_account: validator_b.to_string(),
+                            mev_revenue: 20,
+                        },
+                    ],
+                })
+            });
+
+        jito_mock_fetcher
+            .expect_get::<JitoRewards>()
+            .withf(move |url| url.contains(&format!("epoch={epoch}")) && url.contains("page=2"))
+            .times(1)
+            .in_sequence(&mut seq)
+            .return_once(move |_| {
+                Ok(JitoRewards {
+                    total_count: 3,
                     rewards: vec![JitoReward {
-                        vote_account: pubkey.to_string(),
-                        mev_revenue: expected_mev_revenue,
+                        vote_account: validator_c.to_string(),
+                        mev_revenue: 30,
                     }],
                 })
             });
 
-        let mock_response = get_jito_rewards(&jito_mock_fetcher, validator_ids, epoch)
+        let mock_response = get_jito_rewards(&jito_mock_fetcher, validator_ids.as_slice(), epoch)
             .await
             .unwrap();
 
-        assert_eq!(mock_response.get(pubkey), Some(&expected_mev_revenue));
+        assert_eq!(mock_response.get(validator_a), Some(&10));
+        assert_eq!(mock_response.get(validator_b), Some(&20));
+        assert_eq!(mock_response.get(validator_c), Some(&30));
+    }
+
+    #[tokio::test]
+    async fn get_jito_rewards_stops_on_empty_page() {
+        let mut jito_mock_fetcher = MockValidatorRewards::new();
+        let validator_a = "ValidatorA";
+        let validator_b = "ValidatorB";
+        let validator_c = "ValidatorC";
+        let validator_ids = vec![
+            validator_a.to_string(),
+            validator_b.to_string(),
+            validator_c.to_string(),
+        ];
+        let epoch = 901;
+
+        let mut seq = Sequence::new();
+        jito_mock_fetcher
+            .expect_get::<JitoRewards>()
+            .withf(move |url| url.contains(&format!("epoch={epoch}")) && url.contains("page=1"))
+            .times(1)
+            .in_sequence(&mut seq)
+            .return_once(move |_| {
+                Ok(JitoRewards {
+                    total_count: 4,
+                    rewards: vec![
+                        JitoReward {
+                            vote_account: validator_a.to_string(),
+                            mev_revenue: 5,
+                        },
+                        JitoReward {
+                            vote_account: validator_b.to_string(),
+                            mev_revenue: 15,
+                        },
+                    ],
+                })
+            });
+
+        jito_mock_fetcher
+            .expect_get::<JitoRewards>()
+            .withf(move |url| url.contains(&format!("epoch={epoch}")) && url.contains("page=2"))
+            .times(1)
+            .in_sequence(&mut seq)
+            .return_once(move |_| {
+                Ok(JitoRewards {
+                    total_count: 4,
+                    rewards: vec![],
+                })
+            });
+
+        let mock_response = get_jito_rewards(&jito_mock_fetcher, validator_ids.as_slice(), epoch)
+            .await
+            .unwrap();
+
+        assert_eq!(mock_response.get(validator_a), Some(&5));
+        assert_eq!(mock_response.get(validator_b), Some(&15));
+        assert_eq!(mock_response.get(validator_c), Some(&0));
     }
 }

--- a/crates/validator-debt/src/rewards.rs
+++ b/crates/validator-debt/src/rewards.rs
@@ -125,7 +125,7 @@ mod tests {
     use solana_client::rpc_response::{
         RpcInflationReward, RpcVoteAccountInfo, RpcVoteAccountStatus,
     };
-    use solana_sdk::{epoch_info::EpochInfo, reward_type::RewardType::Fee};
+    use solana_sdk::{epoch_info::EpochInfo, pubkey::Pubkey, reward_type::RewardType::Fee};
     use solana_transaction_status_client_types::UiConfirmedBlock;
 
     use super::*;
@@ -208,11 +208,11 @@ mod tests {
         let first_slot = 9900010;
         mock_solana_debt_calculator
             .expect_get::<JitoRewards>()
-            .withf(move |url| url.contains(&format!("epoch={epoch}")))
+            .withf(move |url| url.contains(&format!("epoch={epoch}")) && url.contains("page=1"))
             .times(1)
             .returning(move |_| {
                 Ok(JitoRewards {
-                    total_count: 1000,
+                    total_count: 1,
                     rewards: vec![JitoReward {
                         vote_account: validator_id.to_string(),
                         mev_revenue: jito_reward,
@@ -391,11 +391,11 @@ mod tests {
 
         mock_solana_debt_calculator
             .expect_get::<JitoRewards>()
-            .withf(move |url| url.contains(&format!("epoch={epoch}")))
+            .withf(move |url| url.contains(&format!("epoch={epoch}")) && url.contains("page=1"))
             .times(1)
             .returning(move |_| {
                 Ok(JitoRewards {
-                    total_count: 1000,
+                    total_count: 1,
                     rewards: vec![JitoReward {
                         vote_account: validator_id.to_string(),
                         mev_revenue: jito_reward,
@@ -424,5 +424,202 @@ mod tests {
             reward.block_base + reward.inflation + reward.jito + reward.block_priority
         );
         assert_eq!(reward.block_priority + reward.block_base, block_reward);
+    }
+
+    #[tokio::test]
+    async fn test_get_total_rewards_treats_missing_jito_as_zero() {
+        let mut mock_solana_debt_calculator = MockValidatorRewards::new();
+        let epoch: u64 = 10;
+
+        let validator_a = Pubkey::new_from_array([1u8; 32]).to_string();
+        let validator_b = Pubkey::new_from_array([2u8; 32]).to_string();
+        let validator_c = Pubkey::new_from_array([3u8; 32]).to_string();
+        let validator_ids = vec![
+            validator_a.clone(),
+            validator_b.clone(),
+            validator_c.clone(),
+        ];
+
+        let vote_a = Pubkey::new_from_array([4u8; 32]).to_string();
+        let vote_b = Pubkey::new_from_array([5u8; 32]).to_string();
+        let vote_c = Pubkey::new_from_array([6u8; 32]).to_string();
+
+        let inflation_rewards = vec![
+            Some(RpcInflationReward {
+                epoch,
+                effective_slot: 0,
+                amount: 1_000,
+                post_balance: 1_000,
+                commission: Some(0),
+            }),
+            Some(RpcInflationReward {
+                epoch,
+                effective_slot: 0,
+                amount: 2_000,
+                post_balance: 2_000,
+                commission: Some(0),
+            }),
+            Some(RpcInflationReward {
+                epoch,
+                effective_slot: 0,
+                amount: 3_000,
+                post_balance: 3_000,
+                commission: Some(0),
+            }),
+        ];
+
+        let mut leader_schedule = HashMap::new();
+        leader_schedule.insert(validator_a.clone(), vec![0]);
+        leader_schedule.insert(validator_b.clone(), vec![1]);
+        leader_schedule.insert(validator_c.clone(), vec![2]);
+
+        let mock_epoch_info = EpochInfo {
+            epoch: epoch + 1,
+            slot_index: 5,
+            absolute_slot: 100,
+            block_height: 0,
+            slots_in_epoch: 10,
+            transaction_count: Some(0),
+        };
+
+        let first_slot_in_current_epoch =
+            mock_epoch_info.absolute_slot - mock_epoch_info.slot_index;
+        let expected_first_slot = first_slot_in_current_epoch
+            - (mock_epoch_info.slots_in_epoch * (mock_epoch_info.epoch - epoch));
+
+        mock_solana_debt_calculator
+            .expect_get_epoch_info()
+            .times(1)
+            .returning(move || Ok(mock_epoch_info.clone()));
+
+        mock_solana_debt_calculator
+            .expect_get_leader_schedule()
+            .withf(move |slot| *slot == Some(expected_first_slot))
+            .times(1)
+            .returning(move |_| Ok(leader_schedule.clone()));
+
+        let block_for_validator = |validator: &String, lamports: u64| UiConfirmedBlock {
+            num_reward_partitions: Some(1),
+            signatures: None,
+            rewards: Some(vec![solana_transaction_status_client_types::Reward {
+                pubkey: validator.clone(),
+                lamports: lamports as i64,
+                post_balance: lamports,
+                reward_type: Some(Fee),
+                commission: None,
+            }]),
+            previous_blockhash: "".to_string(),
+            blockhash: "".to_string(),
+            parent_slot: 0,
+            transactions: None,
+            block_time: None,
+            block_height: None,
+        };
+
+        let slots_and_blocks: HashMap<u64, UiConfirmedBlock> = HashMap::from([
+            (expected_first_slot, block_for_validator(&validator_a, 100)),
+            (
+                expected_first_slot + 1,
+                block_for_validator(&validator_b, 200),
+            ),
+            (
+                expected_first_slot + 2,
+                block_for_validator(&validator_c, 300),
+            ),
+        ]);
+
+        mock_solana_debt_calculator
+            .expect_get_block_with_config()
+            .times(3)
+            .returning(move |slot| Ok(slots_and_blocks.get(&slot).cloned().unwrap()));
+
+        let mock_rpc_vote_account_status = RpcVoteAccountStatus {
+            current: vec![
+                RpcVoteAccountInfo {
+                    vote_pubkey: vote_a.clone(),
+                    node_pubkey: validator_a.clone(),
+                    activated_stake: 0,
+                    epoch_vote_account: true,
+                    epoch_credits: vec![(epoch, 0, 0)],
+                    commission: 0,
+                    last_vote: 0,
+                    root_slot: 0,
+                },
+                RpcVoteAccountInfo {
+                    vote_pubkey: vote_b.clone(),
+                    node_pubkey: validator_b.clone(),
+                    activated_stake: 0,
+                    epoch_vote_account: true,
+                    epoch_credits: vec![(epoch, 0, 0)],
+                    commission: 0,
+                    last_vote: 0,
+                    root_slot: 0,
+                },
+                RpcVoteAccountInfo {
+                    vote_pubkey: vote_c.clone(),
+                    node_pubkey: validator_c.clone(),
+                    activated_stake: 0,
+                    epoch_vote_account: true,
+                    epoch_credits: vec![(epoch, 0, 0)],
+                    commission: 0,
+                    last_vote: 0,
+                    root_slot: 0,
+                },
+            ],
+            delinquent: vec![],
+        };
+
+        mock_solana_debt_calculator
+            .expect_get_vote_accounts_with_config()
+            .times(1)
+            .returning(move || Ok(mock_rpc_vote_account_status.clone()));
+
+        mock_solana_debt_calculator
+            .expect_get_inflation_reward()
+            .times(1)
+            .returning(move |_, _| Ok(inflation_rewards.clone()));
+
+        let jito_validator_a = validator_a.clone();
+        let jito_validator_b = validator_b.clone();
+        let jito_reward_a = 10;
+        let jito_reward_b = 20;
+        mock_solana_debt_calculator
+            .expect_get::<JitoRewards>()
+            .withf(move |url| url.contains(&format!("epoch={epoch}")) && url.contains("page=1"))
+            .times(1)
+            .return_once(move |_| {
+                Ok(JitoRewards {
+                    total_count: 2,
+                    rewards: vec![
+                        JitoReward {
+                            vote_account: jito_validator_a,
+                            mev_revenue: jito_reward_a,
+                        },
+                        JitoReward {
+                            vote_account: jito_validator_b,
+                            mev_revenue: jito_reward_b,
+                        },
+                    ],
+                })
+            });
+
+        let rewards = get_total_rewards(
+            &mock_solana_debt_calculator,
+            validator_ids.as_slice(),
+            epoch,
+        )
+        .await
+        .unwrap();
+
+        let reward_for_c = rewards
+            .rewards
+            .iter()
+            .find(|reward| reward.validator_id == validator_c)
+            .unwrap();
+        assert_eq!(reward_for_c.jito, 0);
+        assert_eq!(
+            reward_for_c.total,
+            reward_for_c.block_base + reward_for_c.block_priority + reward_for_c.inflation
+        );
     }
 }


### PR DESCRIPTION
## Summary of Changes

This PR fixes an under-accounting issue in the Jito MEV rewards used by `validator-debt`.

Previously, `get_jito_rewards` fetched Jito rewards with a single request:

- It called `validator_rewards?epoch={epoch}&limit={JITO_REWARDS_LIMIT}`
- It assumed all rewards fit into one response, even when `total_count` exceeded the `limit`
- As a result, only the first page of results was used, and any additional rewards on later pages were silently ignored

This meant that for epochs where Jito returned more entries than the configured limit, validator MEV revenue could be underestimated and downstream debt calculations would be based on incomplete data.

This PR:

- Implements proper pagination for the Jito `validator_rewards` API
- Adds a safety cap (`MAX_JITO_PAGES`) to prevent runaway pagination if the API misbehaves
- Aggregates MEV revenue per validator across all fetched pages
- Improves logging around pagination and retries
- Extends tests to cover pagination and the “missing Jito entry” case

## Detailed Changes

### Jito rewards fetching

In `crates/validator-debt/src/jito.rs`:

- Switched from a single-request flow to a paginated loop using:
  - `page` parameter
  - `limit={JITO_REWARDS_LIMIT}`
- Track:
  - `total_count` from the API
  - `collected` number of rewards across all pages
- Continue fetching pages until one of the following conditions is met:
  - We have collected at least `total_count` entries
  - We hit an empty page (defensive stop)
  - We reach `MAX_JITO_PAGES` (safety cap), in which case we return partial results with a log message

Additional improvements:

- Use a reusable exponential backoff retry strategy for each page fetch
- Upgrade error handling to use `anyhow::Context` so failures clearly indicate:
  - Which epoch failed
  - Which page failed
  - That retries were exhausted
- Aggregate rewards into a `HashMap<String, u64>` so that if a validator appears on multiple pages, their `mev_revenue` is summed
- Convert the aggregated map back into `HashMap<&str, u64>` keyed by the input `validator_ids`, defaulting to `0` when a validator has no Jito entry

### Reward aggregation

In `crates/validator-debt/src/rewards.rs`:

- `get_total_rewards` still combines:
  - Inflation rewards
  - Jito rewards
  - Block base + priority fees
- Behavior is now explicitly validated for the case where:
  - A validator has block and inflation rewards
  - But **no** Jito entry is returned
- In that case, the Jito component is treated as `0`, and the total is computed as:
  - `total = block_base + block_priority + inflation + jito (0)`

This makes the expected behavior around “missing Jito entries” explicit and tested.

## Testing

### Unit tests

Added and updated tests in `crates/validator-debt/src/jito.rs`:

- `get_jito_rewards_handles_single_page_when_total_under_limit`
  - Verifies behavior when `total_count` fits within a single page
- `get_jito_rewards_fetches_all_pages_when_total_exceeds_page_size`
  - Uses a `Sequence` to ensure multiple pages are fetched in order
  - Asserts that rewards from all pages are correctly merged
- `get_jito_rewards_stops_on_empty_page`
  - Verifies that an empty page stops pagination and that missing validators get `0` as Jito rewards

Extended tests in `crates/validator-debt/src/rewards.rs`:

- Updated existing tests to account for the new paginated Jito API shape (`total_count` and `page=1` in URLs)
- Added:
  - `test_get_total_rewards_treats_missing_jito_as_zero`
    - Covers the scenario where some validators have Jito rewards and others don’t
    - Ensures validators without Jito entries:
      - Get `jito = 0`
      - Have their `total` computed only from block + inflation rewards

### Testing
I followed the existing CI workflow locally to validate this change:

- Ran the relevant Rust test suite for `validator-debt`, including the new pagination tests
- Ran `bash sh/test_doublezero_solana_clean.sh` 
- Confirmed all tests pass successfully with the updated Jito pagination logic

This gives confidence that:

- The new pagination behavior is covered by unit tests
- Existing behavior for inflation and block rewards remains intact
- Callers of `get_total_rewards` and `get_rewards_between_timestamps` now receive correct Jito rewards even when the API response spans multiple pages
