### PR TITLE
chore: bump stable rust to 1.92.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup | Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
           components: clippy, rustfmt, llvm-tools-preview
 
       - name: Setup | Rust cache

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91.0"
+channel = "1.92.0"
 components = ["clippy", "rust-analyzer", "rustfmt"]


### PR DESCRIPTION
# Summary

Bump stable rust to 1.92.0