### PR TITLE
feat(validator-debt): remove dz_ledger as argument (#2442)

### DIFF
--- a/crates/validator-debt/CHANGELOG.md
+++ b/crates/validator-debt/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- remove dz_ledger as argument ([#255](https://github.com/doublezerofoundation/doublezero-offchain/pull/255))
 - Make “Total Debt Collection” Slack summary a global (unfiltered) total while keeping the per-epoch “Debt Collected” table filtered ([#252](https://github.com/doublezerofoundation/doublezero-offchain/pull/252))
 - use vote key from past ([#250](https://github.com/doublezerofoundation/doublezero-offchain/pull/250))
 - bail early when Revenue Distribution program is paused ([#244](https://github.com/doublezerofoundation/doublezero-offchain/pull/244))

--- a/crates/validator-debt/src/command/calculate.rs
+++ b/crates/validator-debt/src/command/calculate.rs
@@ -26,9 +26,6 @@ pub enum ExportFormat {
 #[derive(Debug, Args, Clone)]
 pub struct CalculateValidatorDebtCommand {
     #[arg(long)]
-    epoch: Option<u64>,
-
-    #[arg(long)]
     force: bool,
 
     #[command(flatten)]
@@ -49,24 +46,12 @@ pub struct CalculateValidatorDebtCommand {
 impl CalculateValidatorDebtCommand {
     pub async fn try_into_execute(self) -> Result<()> {
         let Self {
-            epoch,
             force,
             solana_payer_options,
             dz_ledger_connection_options,
             post_to_ledger_only,
             export,
         } = self;
-
-        let epoch = match epoch {
-            Some(epoch) => epoch,
-            None => {
-                latest_distribution_epoch(
-                    &solana_payer_options.connection_options,
-                    &dz_ledger_connection_options,
-                )
-                .await?
-            }
-        };
 
         let connection_options = SolanaValidatorDebtConnectionOptions {
             solana_url_or_moniker: solana_payer_options
@@ -87,7 +72,6 @@ impl CalculateValidatorDebtCommand {
         let write_summary = crate::worker::calculate_distribution(
             &solana_debt_calculator,
             transaction,
-            epoch,
             post_to_ledger_only,
         )
         .await?;

--- a/crates/validator-debt/src/worker/mod.rs
+++ b/crates/validator-debt/src/worker/mod.rs
@@ -145,10 +145,10 @@ pub async fn verify_validator_debt(
 pub async fn calculate_distribution(
     solana_debt_calculator: &impl ValidatorRewards,
     transaction: Transaction,
-    dz_epoch: u64,
     post_to_ledger_only: bool,
 ) -> Result<WriteSummary> {
     let config = fetch_config_from_rpc(solana_debt_calculator.solana_rpc_client()).await?;
+    let dz_epoch = config.last_completed_epoch().unwrap_or_default().value();
     if is_config_paused(&config) {
         // Return an empty summary when paused (skip work).
         return Ok(WriteSummary {

--- a/scheduler/CHANGELOG.md
+++ b/scheduler/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- remove dz_ledger as argument ([#255](https://github.com/doublezerofoundation/doublezero-offchain/pull/255))
 - add check and filter for 0 total debt messages posted to slack ([#247](https://github.com/doublezerofoundation/doublezero-offchain/pull/247))
 
 ## [v0.1.6] - 2026-01-12
@@ -32,4 +33,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add GenServer and Rust NIF to automatically calculate a distribution on a configurable interval ([#199](https://github.com/doublezerofoundation/doublezero-offchain/pull/199))
 - add GenServer and Rust NIF to automatically initialize a distribution on a configurable interval ([#197](https://github.com/doublezerofoundation/doublezero-offchain/pull/197))
 - add GenServer and Rust NIF to automatically collect debt on a configurable interval ([#183](https://github.com/doublezerofoundation/doublezero-offchain/pull/183))
-- add Elixir app that manages scheduling and executing Rust processes for debt collection and payment  ([#183](https://github.com/doublezerofoundation/doublezero-offchain/pull/183))
+- add Elixir app that manages scheduling and executing Rust processes for debt collection and payment ([#183](https://github.com/doublezerofoundation/doublezero-offchain/pull/183))

--- a/scheduler/lib/scheduler/scheduler_doublezero.ex
+++ b/scheduler/lib/scheduler/scheduler_doublezero.ex
@@ -7,18 +7,16 @@ defmodule Scheduler.DoubleZero do
 
   def initialize_tracing_subscriber, do: :erlang.nif_error(:nif_not_loaded)
 
-  def collect_all_debt(_ledger_rpc, _solana_rpc), do: :erlang.nif_error(:nif_not_loaded)
+  def collect_all_debt(_solana_rpc), do: :erlang.nif_error(:nif_not_loaded)
 
-  def collect_epoch_debt(_dz_epoch, _ledger_rpc, _solana_rpc),
+  def collect_epoch_debt(_dz_epoch, _solana_rpc),
     do: :erlang.nif_error(:nif_not_loaded)
 
   def initialize_distribution(_solana_rpc), do: :erlang.nif_error(:nif_not_loaded)
 
-  def calculate_distribution(_dz_epoch, _ledger_rpc, _solana_rpc, _post_to_slack),
+  def calculate_distribution(_solana_rpc, _post_to_slack),
     do: :erlang.nif_error(:nif_not_loaded)
 
-  def finalize_distribution(_dz_epoch, _ledger_rpc, _solana_rpc),
+  def finalize_distribution(_dz_epoch, _solana_rpc),
     do: :erlang.nif_error(:nif_not_loaded)
-
-  def current_dz_epoch(_ledger_rpc), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/scheduler/lib/scheduler/worker/calculate_distribution.ex
+++ b/scheduler/lib/scheduler/worker/calculate_distribution.ex
@@ -7,35 +7,17 @@ defmodule Scheduler.Worker.CalculateDistribution do
   require Logger
 
   def start_link(_var \\ []) do
-    state = %{count: 0, dz_epoch: nil}
+    state = %{count: 0}
     GenServer.start_link(__MODULE__, state, name: __MODULE__)
   end
 
   def init(state) do
-    {:ok, state, {:continue, :get_current_dz_epoch}}
+    {:ok, state, {:continue, :calculate_distribution}}
   end
 
-  def handle_continue(:get_current_dz_epoch, state) do
-    case Scheduler.DoubleZero.current_dz_epoch(ledger_rpc()) do
-      dz_epoch when is_integer(dz_epoch) ->
-        # dz_epoch - 1 gets the most recently closed dz_epoch
-        epoch_to_calculate = dz_epoch - 1
-
-        Logger.info("Calculating debt for dz epoch #{epoch_to_calculate}")
-
-        state = %{state | dz_epoch: epoch_to_calculate}
-        {:noreply, state, {:continue, :calculate_distribution}}
-
-      error ->
-        Logger.error("calculate_distribution: failed to get dz_epoch: #{inspect(error)}")
-        {:stop, :shutdown, state}
-    end
-  end
 
   def handle_continue(:calculate_distribution, %{count: 2} = state) do
     case Scheduler.DoubleZero.calculate_distribution(
-           state.dz_epoch,
-           ledger_rpc(),
            solana_rpc(),
            true
          ) do
@@ -51,8 +33,6 @@ defmodule Scheduler.Worker.CalculateDistribution do
 
   def handle_continue(:calculate_distribution, state) do
     case Scheduler.DoubleZero.calculate_distribution(
-           state.dz_epoch,
-           ledger_rpc(),
            solana_rpc(),
            false
          ) do
@@ -70,7 +50,7 @@ defmodule Scheduler.Worker.CalculateDistribution do
   def handle_continue(:finalize_distribution, state) do
     Logger.info("Finalizing debt for dz epoch #{state.dz_epoch}")
 
-    case Scheduler.DoubleZero.finalize_distribution(state.dz_epoch, ledger_rpc(), solana_rpc()) do
+    case Scheduler.DoubleZero.finalize_distribution(state.dz_epoch, solana_rpc()) do
       {:error, error} ->
         Logger.error("calculate_distribution: received error: #{inspect(error)}")
 
@@ -86,10 +66,6 @@ defmodule Scheduler.Worker.CalculateDistribution do
   def handle_info(msg, state) do
     Logger.warning("Received unexpected msg: #{msg}")
     {:noreply, state}
-  end
-
-  defp ledger_rpc do
-    Application.get_env(:scheduler, :ledger_rpc)
   end
 
   defp solana_rpc do

--- a/scheduler/lib/scheduler/worker/collect_all_debt.ex
+++ b/scheduler/lib/scheduler/worker/collect_all_debt.ex
@@ -25,10 +25,7 @@ defmodule Scheduler.Worker.CollectAllDebt do
   end
 
   def handle_continue(:collect_all_debt, state) do
-    # TODO: figure out why the remote env sends out an empty
-    # total debt collection
-    Process.sleep(100)
-    case Scheduler.DoubleZero.collect_all_debt(ledger_rpc(), solana_rpc()) do
+    case Scheduler.DoubleZero.collect_all_debt(solana_rpc()) do
       {} ->
         Logger.info("Successfully collected debts for all epochs")
 
@@ -37,10 +34,6 @@ defmodule Scheduler.Worker.CollectAllDebt do
     end
 
     {:stop, :normal, state}
-  end
-
-  defp ledger_rpc do
-    Application.get_env(:scheduler, :ledger_rpc)
   end
 
   defp solana_rpc do


### PR DESCRIPTION
## Summary of Changes

This PR removes the ledger_rpc url as a value passed in to functions and instead derives it from the `NetworkEnvironment`. This is largely a cosmetic change but does make the codebase more consistent.

Closes https://github.com/malbeclabs/doublezero/issues/2442

## Testing Verification
* Show evidence of testing the change
