### PR TITLE
fix(goreleaser): publish packages to cloudsmith doublezero-testnet repo in addition to doublezero repo

### DIFF
--- a/release/.goreleaser.contributor-rewards.yaml
+++ b/release/.goreleaser.contributor-rewards.yaml
@@ -100,3 +100,8 @@ cloudsmiths:
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"
+  - organization: malbeclabs
+    repository: doublezero-testnet
+    distributions:
+      deb: "any-distro/any-version"
+      rpm: "any-distro/any-version"

--- a/release/.goreleaser.doublezero-offchain-scheduler.yaml
+++ b/release/.goreleaser.doublezero-offchain-scheduler.yaml
@@ -107,3 +107,8 @@ cloudsmiths:
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"
+  - organization: malbeclabs
+    repository: doublezero-testnet
+    distributions:
+      deb: "any-distro/any-version"
+      rpm: "any-distro/any-version"

--- a/release/.goreleaser.doublezero-solana-cli.yaml
+++ b/release/.goreleaser.doublezero-solana-cli.yaml
@@ -92,3 +92,8 @@ cloudsmiths:
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"
+  - organization: malbeclabs
+    repository: doublezero-testnet
+    distributions:
+      deb: "any-distro/any-version"
+      rpm: "any-distro/any-version"

--- a/release/.goreleaser.doublezero-solana-validator-debt.yaml
+++ b/release/.goreleaser.doublezero-solana-validator-debt.yaml
@@ -100,3 +100,8 @@ cloudsmiths:
     distributions:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"
+  - organization: malbeclabs
+    repository: doublezero-testnet
+    distributions:
+      deb: "any-distro/any-version"
+      rpm: "any-distro/any-version"

--- a/release/.goreleaser.sentinel.yaml
+++ b/release/.goreleaser.sentinel.yaml
@@ -101,6 +101,11 @@ cloudsmiths:
       deb: "any-distro/any-version"
       rpm: "any-distro/any-version"
   - organization: malbeclabs
+    repository: doublezero-testnet
+    distributions:
+      deb: "any-distro/any-version"
+      rpm: "any-distro/any-version"
+  - organization: malbeclabs
     repository: doublezero-devnet
     distributions:
       deb: "any-distro/any-version"


### PR DESCRIPTION
## Summary of Changes
* fix(goreleaser): publish packages to cloudsmith doublezero-testnet repo in addition to doublezero repo
