### PR TITLE
fix credo warnings

### DIFF
--- a/scheduler/lib/scheduler/validator_debt/debt_collection.ex
+++ b/scheduler/lib/scheduler/validator_debt/debt_collection.ex
@@ -1,4 +1,5 @@
 defmodule Scheduler.ValidatorDebt.DebtCollection do
+  @moduledoc false
   defstruct total_paid: 0,
             already_paid: 0,
             total_debt: 0,
@@ -7,5 +8,6 @@ defmodule Scheduler.ValidatorDebt.DebtCollection do
 end
 
 defmodule Scheduler.ValidatorDebt.Debt do
+  @moduledoc false
   defstruct [:validator_id, :amount, :result, :success]
 end

--- a/scheduler/lib/scheduler/worker/calculate_distribution.ex
+++ b/scheduler/lib/scheduler/worker/calculate_distribution.ex
@@ -15,7 +15,6 @@ defmodule Scheduler.Worker.CalculateDistribution do
     {:ok, state, {:continue, :calculate_distribution}}
   end
 
-
   def handle_continue(:calculate_distribution, %{count: 2} = state) do
     case nif_module().calculate_distribution(
            solana_rpc(),

--- a/scheduler/test/worker_integration_test.exs
+++ b/scheduler/test/worker_integration_test.exs
@@ -13,6 +13,10 @@ defmodule Scheduler.WorkerIntegrationTest do
   import ExUnit.CaptureLog
   import Mox
 
+  alias Scheduler.Worker.CalculateDistribution
+  alias Scheduler.Worker.CollectAllDebt
+  alias Scheduler.Worker.InitializeDistribution
+
   # Use global mode for cross-process mocking (GenServers spawn in separate processes)
   setup :set_mox_global
   setup :verify_on_exit!
@@ -24,7 +28,7 @@ defmodule Scheduler.WorkerIntegrationTest do
 
     on_exit(fn ->
       Application.delete_env(:scheduler, :nif_module)
-       Application.delete_env(:scheduler, :solana_rpc)
+      Application.delete_env(:scheduler, :solana_rpc)
     end)
 
     :ok
@@ -40,7 +44,7 @@ defmodule Scheduler.WorkerIntegrationTest do
         capture_log(fn ->
           # Trap exits so we can monitor without crashing
           Process.flag(:trap_exit, true)
-          {:ok, pid} = Scheduler.Worker.InitializeDistribution.start_link()
+          {:ok, pid} = InitializeDistribution.start_link()
 
           receive do
             {:EXIT, ^pid, reason} ->
@@ -61,7 +65,7 @@ defmodule Scheduler.WorkerIntegrationTest do
       log =
         capture_log(fn ->
           Process.flag(:trap_exit, true)
-          {:ok, pid} = Scheduler.Worker.InitializeDistribution.start_link()
+          {:ok, pid} = InitializeDistribution.start_link()
 
           receive do
             {:EXIT, ^pid, reason} ->
@@ -85,7 +89,7 @@ defmodule Scheduler.WorkerIntegrationTest do
       log =
         capture_log(fn ->
           Process.flag(:trap_exit, true)
-          {:ok, pid} = Scheduler.Worker.CollectAllDebt.start_link()
+          {:ok, pid} = CollectAllDebt.start_link()
 
           receive do
             {:EXIT, ^pid, reason} ->
@@ -106,7 +110,7 @@ defmodule Scheduler.WorkerIntegrationTest do
       log =
         capture_log(fn ->
           Process.flag(:trap_exit, true)
-          {:ok, pid} = Scheduler.Worker.CollectAllDebt.start_link()
+          {:ok, pid} = CollectAllDebt.start_link()
 
           receive do
             {:EXIT, ^pid, reason} ->
@@ -145,7 +149,7 @@ defmodule Scheduler.WorkerIntegrationTest do
       log =
         capture_log(fn ->
           Process.flag(:trap_exit, true)
-          {:ok, pid} = Scheduler.Worker.CalculateDistribution.start_link()
+          {:ok, pid} = CalculateDistribution.start_link()
 
           receive do
             {:EXIT, ^pid, reason} ->
@@ -176,7 +180,7 @@ defmodule Scheduler.WorkerIntegrationTest do
       log =
         capture_log(fn ->
           Process.flag(:trap_exit, true)
-          {:ok, pid} = Scheduler.Worker.CalculateDistribution.start_link()
+          {:ok, pid} = CalculateDistribution.start_link()
 
           receive do
             {:EXIT, ^pid, reason} -> assert reason == :normal
@@ -197,7 +201,7 @@ defmodule Scheduler.WorkerIntegrationTest do
       log =
         capture_log(fn ->
           Process.flag(:trap_exit, true)
-          {:ok, pid} = Scheduler.Worker.CalculateDistribution.start_link()
+          {:ok, pid} = CalculateDistribution.start_link()
 
           receive do
             {:EXIT, ^pid, reason} ->
@@ -225,7 +229,7 @@ defmodule Scheduler.WorkerIntegrationTest do
       log =
         capture_log(fn ->
           Process.flag(:trap_exit, true)
-          {:ok, pid} = Scheduler.Worker.CalculateDistribution.start_link()
+          {:ok, pid} = CalculateDistribution.start_link()
 
           receive do
             {:EXIT, ^pid, reason} ->
@@ -258,7 +262,7 @@ defmodule Scheduler.WorkerIntegrationTest do
       log =
         capture_log(fn ->
           Process.flag(:trap_exit, true)
-          {:ok, pid} = Scheduler.Worker.CalculateDistribution.start_link()
+          {:ok, pid} = CalculateDistribution.start_link()
 
           receive do
             {:EXIT, ^pid, reason} ->
@@ -288,7 +292,7 @@ defmodule Scheduler.WorkerIntegrationTest do
       log =
         capture_log(fn ->
           Process.flag(:trap_exit, true)
-          {:ok, pid} = Scheduler.Worker.CalculateDistribution.start_link()
+          {:ok, pid} = CalculateDistribution.start_link()
 
           receive do
             {:EXIT, ^pid, reason} ->


### PR DESCRIPTION
## Summary of Changes

This fixes some credo (static analysis) warnings. In a subsequent PR, will add this to the workflow. 


## Testing Verification
```
mix credo --strict
Checking 12 source files ...

Please report incorrect results: https://github.com/rrrene/credo/issues

Analysis took 0.03 seconds (0.01s to load, 0.02s running 67 checks on 12 files)
44 mods/funs, found no issues.
```
