### PR TITLE
bugfix(scheduler): result returns value only, not ok tuple

### DIFF
--- a/scheduler/CHANGELOG.md
+++ b/scheduler/CHANGELOG.md
@@ -6,13 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- ensure debt is finalized before collection ([#268](https://github.com/doublezerofoundation/doublezero-offchain/pull/268))
+- result from calculate_distribution_returns value only, not ok tuple ([#270](https://github.com/doublezerofoundation/doublezero-offchain/pull/270))
+
+## [v0.1.8](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/offchain-scheduler/v0.1.8) - 2026-02-12
+
 - remove dz_ledger as argument ([#255](https://github.com/doublezerofoundation/doublezero-offchain/pull/255))
+
+## [v0.1.7](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/offchain-scheduler/v0.1.7) - 2026-01-14
+
+- use vote key from past ([#250](https://github.com/doublezerofoundation/doublezero-offchain/pull/250))
 - add check and filter for 0 total debt messages posted to slack ([#247](https://github.com/doublezerofoundation/doublezero-offchain/pull/247))
 
-## [v0.1.6] - 2026-01-12
+## [v0.1.6](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/offchain-scheduler/v0.1.6) - 2026-01-12
 
-## [v0.1.5] - 2026-01-08
+- ensure debt is finalized before collection ([#268](https://github.com/doublezerofoundation/doublezero-offchain/pull/268))
+
+## [v0.1.5](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/offchain-scheduler/v0.1.5) - 2026-01-08
 
 - shutdown `:normal` after successful distribution initialized ([#245](https://github.com/doublezerofoundation/doublezero-offchain/pull/245))
 - add compute unit price handling for wallet ([#243](https://github.com/doublezerofoundation/doublezero-offchain/pull/243))

--- a/scheduler/lib/scheduler/doublezero_nif.ex
+++ b/scheduler/lib/scheduler/doublezero_nif.ex
@@ -97,7 +97,7 @@ defmodule Scheduler.DoubleZeroNIF do
     - `{:error, reason}` on failure
   """
   @callback calculate_distribution(solana_rpc :: String.t(), post_to_slack :: boolean()) ::
-              {:ok, non_neg_integer()} | {:error, term()}
+              non_neg_integer() | {:error, term()}
 
   @doc """
   Finalize the distribution for a specific epoch.

--- a/scheduler/lib/scheduler/worker/calculate_distribution.ex
+++ b/scheduler/lib/scheduler/worker/calculate_distribution.ex
@@ -20,14 +20,14 @@ defmodule Scheduler.Worker.CalculateDistribution do
            solana_rpc(),
            true
          ) do
-      {:error, error} ->
-        Logger.error("calculate_distribution: received error: #{inspect(error)}")
-        {:stop, :shutdown, state}
-
-      {:ok, dz_epoch} ->
+      dz_epoch when is_integer(dz_epoch) ->
         Logger.info("Proceeding to finalize debt for dz epoch #{dz_epoch}")
         state = Map.put(state, :dz_epoch, dz_epoch)
         {:noreply, state, {:continue, :finalize_distribution}}
+
+      {:error, error} ->
+        Logger.error("calculate_distribution: received error: #{inspect(error)}")
+        {:stop, :shutdown, state}
     end
   end
 
@@ -36,14 +36,14 @@ defmodule Scheduler.Worker.CalculateDistribution do
            solana_rpc(),
            false
          ) do
-      {:error, error} ->
-        Logger.error("calculate_distribution: received error: #{inspect(error)}")
-        {:stop, :shutdown, state}
-
-      {:ok, _dz_epoch} ->
+      dz_epoch when is_integer(dz_epoch) ->
         state = %{state | count: state.count + 1}
         Logger.info("Completed calculation for debt ##{state.count}")
         {:noreply, state, {:continue, :calculate_distribution}}
+
+      {:error, error} ->
+        Logger.error("calculate_distribution: received error: #{inspect(error)}")
+        {:stop, :shutdown, state}
     end
   end
 

--- a/scheduler/test/worker_integration_test.exs
+++ b/scheduler/test/worker_integration_test.exs
@@ -129,16 +129,16 @@ defmodule Scheduler.WorkerIntegrationTest do
     test "runs calculate 3 times then finalizes on success" do
       # First two calls with post_to_slack=false
       expect(Scheduler.MockNIF, :calculate_distribution, fn _rpc, false ->
-        {:ok, 42}
+        42
       end)
 
       expect(Scheduler.MockNIF, :calculate_distribution, fn _rpc, false ->
-        {:ok, 42}
+        42
       end)
 
       # Third call with post_to_slack=true (count == 2)
       expect(Scheduler.MockNIF, :calculate_distribution, fn _rpc, true ->
-        {:ok, 42}
+        42
       end)
 
       # Then finalize with dz_epoch=42
@@ -169,9 +169,9 @@ defmodule Scheduler.WorkerIntegrationTest do
     test "passes dz_epoch from calculate to finalize" do
       dz_epoch = 99
 
-      expect(Scheduler.MockNIF, :calculate_distribution, fn _rpc, false -> {:ok, dz_epoch} end)
-      expect(Scheduler.MockNIF, :calculate_distribution, fn _rpc, false -> {:ok, dz_epoch} end)
-      expect(Scheduler.MockNIF, :calculate_distribution, fn _rpc, true -> {:ok, dz_epoch} end)
+      expect(Scheduler.MockNIF, :calculate_distribution, fn _rpc, false -> dz_epoch end)
+      expect(Scheduler.MockNIF, :calculate_distribution, fn _rpc, false -> dz_epoch end)
+      expect(Scheduler.MockNIF, :calculate_distribution, fn _rpc, true -> dz_epoch end)
 
       expect(Scheduler.MockNIF, :finalize_distribution, fn ^dz_epoch, _rpc ->
         {}
@@ -218,7 +218,7 @@ defmodule Scheduler.WorkerIntegrationTest do
     test "stops with shutdown on second calculation error" do
       # First call succeeds
       expect(Scheduler.MockNIF, :calculate_distribution, fn _rpc, false ->
-        {:ok, 42}
+        42
       end)
 
       # Second call fails
@@ -247,11 +247,11 @@ defmodule Scheduler.WorkerIntegrationTest do
     test "stops with shutdown on third calculation error" do
       # First two calls succeed
       expect(Scheduler.MockNIF, :calculate_distribution, fn _rpc, false ->
-        {:ok, 42}
+        42
       end)
 
       expect(Scheduler.MockNIF, :calculate_distribution, fn _rpc, false ->
-        {:ok, 42}
+        42
       end)
 
       # Third call fails
@@ -280,9 +280,9 @@ defmodule Scheduler.WorkerIntegrationTest do
 
     test "finalization error logs but worker stops normally" do
       # All three calculations succeed
-      expect(Scheduler.MockNIF, :calculate_distribution, fn _rpc, false -> {:ok, 42} end)
-      expect(Scheduler.MockNIF, :calculate_distribution, fn _rpc, false -> {:ok, 42} end)
-      expect(Scheduler.MockNIF, :calculate_distribution, fn _rpc, true -> {:ok, 42} end)
+      expect(Scheduler.MockNIF, :calculate_distribution, fn _rpc, false -> 42 end)
+      expect(Scheduler.MockNIF, :calculate_distribution, fn _rpc, false -> 42 end)
+      expect(Scheduler.MockNIF, :calculate_distribution, fn _rpc, true -> 42 end)
 
       # Finalization fails
       expect(Scheduler.MockNIF, :finalize_distribution, fn 42, _rpc ->


### PR DESCRIPTION
## Summary of Changes

This is a weird bug because according to the rustler docs, a result should return an `{:ok, value}` or {:error, error}` tuple but it seems to be only returning the value. This PR updates the function to pattern match on the value rather than the tuple.  One can see in the [log line](https://doublezero.grafana.net/goto/dfdqlsiu8622od?orgId=stacks-1114882) that a value is returned and the surrounding log lines show the error. 

Closes https://github.com/malbeclabs/doublezero/issues/3048


## Testing Verification
* Updated the tests to match the expected return value
