### PR TITLE
reservation: update SDK and CLI for on-chain USDC custody changes

### DIFF
--- a/crates/solana-cli/src/command/reservation/initialize_seat.rs
+++ b/crates/solana-cli/src/command/reservation/initialize_seat.rs
@@ -14,12 +14,12 @@ use doublezero_solana_sdk::{
     },
     try_build_instruction,
 };
-use solana_sdk::{compute_budget::ComputeBudgetInstruction, pubkey::Pubkey};
+use solana_sdk::compute_budget::ComputeBudgetInstruction;
 
 /*
    doublezero-solana reservation initialize-seat \
        --device <PUBKEY> | --device-code <CODE> \
-       --client-ip <IP> [--usdc-mint <PUBKEY>]
+       --client-ip <IP>
 */
 
 #[derive(Debug, Args)]
@@ -29,9 +29,6 @@ pub struct InitializeSeatCommand {
     /// Client IPv4 address
     #[arg(long)]
     client_ip: Ipv4Addr,
-    /// USDC mint (defaults to mainnet USDC)
-    #[arg(long, hide = true)]
-    usdc_mint: Option<Pubkey>,
 
     #[command(flatten)]
     solana_payer_options: SolanaPayerOptions,
@@ -48,12 +45,10 @@ impl InitializeSeatCommand {
         println!("Connected to Solana: {network_env:?}");
 
         let device = self.device_args.resolve(network_env).await?;
-        let usdc_mint_key = self.usdc_mint.unwrap_or(*state::USDC_MINT_KEY);
         let client_ip_bits = u32::from(self.client_ip);
 
         // Derive PDAs.
         let (client_seat_key, seat_bump) = state::find_client_seat_address(&device, client_ip_bits);
-        let (_, token_pda_bump) = state::find_token_pda_address(&client_seat_key, &usdc_mint_key);
         let (_, escrow_bump) = state::find_payment_escrow_address(&client_seat_key, &wallet_key);
 
         // Check if the client seat already exists on-chain.
@@ -71,19 +66,13 @@ impl InitializeSeatCommand {
         } else {
             let seat_ix = try_build_instruction(
                 &ID,
-                InitializeClientSeatAccounts::new(
-                    &wallet_key,
-                    &device,
-                    client_ip_bits,
-                    &usdc_mint_key,
-                ),
+                InitializeClientSeatAccounts::new(&wallet_key, &device, client_ip_bits),
                 &ReservationInstructionData::InitializeClientSeat {
                     client_ip: client_ip_bits,
                 },
             )?;
             instructions.push(seat_ix);
-            compute_unit_limit += Wallet::compute_units_for_bump_seed(seat_bump)
-                + Wallet::compute_units_for_bump_seed(token_pda_bump);
+            compute_unit_limit += Wallet::compute_units_for_bump_seed(seat_bump);
         }
 
         // InitializePaymentEscrow — creates escrow PDA for this payer.

--- a/crates/solana-cli/src/command/reservation/withdraw.rs
+++ b/crates/solana-cli/src/command/reservation/withdraw.rs
@@ -59,7 +59,8 @@ impl WithdrawCommand {
         }
 
         let accounts = ClosePaymentEscrowAccounts::new(
-            &client_seat_key,
+            &device,
+            client_ip_bits,
             &wallet_key,
             &usdc_mint_key,
             self.refund_token_account.as_ref(),

--- a/crates/solana-sdk/src/reservation/instruction/account.rs
+++ b/crates/solana-sdk/src/reservation/instruction/account.rs
@@ -3,7 +3,7 @@ use spl_associated_token_account_interface::address::get_associated_token_addres
 
 use crate::reservation::state;
 
-/// Accounts for the `InitializeClientSeat` instruction (9 accounts).
+/// Accounts for the `InitializeClientSeat` instruction (6 accounts).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InitializeClientSeatAccounts {
     pub program_config_key: Pubkey,
@@ -11,30 +11,16 @@ pub struct InitializeClientSeatAccounts {
     pub device_history_key: Pubkey,
     pub payer_key: Pubkey,
     pub new_client_seat_key: Pubkey,
-    pub new_client_seat_usdc_token_pda_key: Pubkey,
-    pub usdc_mint_key: Pubkey,
 }
 
 impl InitializeClientSeatAccounts {
-    pub fn new(
-        payer: &Pubkey,
-        device_key: &Pubkey,
-        client_ip_bits: u32,
-        usdc_mint: &Pubkey,
-    ) -> Self {
-        let client_seat_key = state::find_client_seat_address(device_key, client_ip_bits).0;
+    pub fn new(payer: &Pubkey, device_key: &Pubkey, client_ip_bits: u32) -> Self {
         Self {
             program_config_key: state::find_program_config_address().0,
             execution_controller_key: state::find_execution_controller_address().0,
             device_history_key: state::find_device_history_address(device_key).0,
             payer_key: *payer,
-            new_client_seat_key: client_seat_key,
-            new_client_seat_usdc_token_pda_key: state::find_token_pda_address(
-                &client_seat_key,
-                usdc_mint,
-            )
-            .0,
-            usdc_mint_key: *usdc_mint,
+            new_client_seat_key: state::find_client_seat_address(device_key, client_ip_bits).0,
         }
     }
 }
@@ -47,9 +33,6 @@ impl From<InitializeClientSeatAccounts> for Vec<AccountMeta> {
             AccountMeta::new_readonly(accounts.device_history_key, false),
             AccountMeta::new(accounts.payer_key, true),
             AccountMeta::new(accounts.new_client_seat_key, false),
-            AccountMeta::new(accounts.new_client_seat_usdc_token_pda_key, false),
-            AccountMeta::new_readonly(accounts.usdc_mint_key, false),
-            AccountMeta::new_readonly(spl_token_interface::ID, false),
             AccountMeta::new_readonly(solana_sdk::system_program::ID, false),
         ]
     }
@@ -91,10 +74,7 @@ impl From<InitializePaymentEscrowAccounts> for Vec<AccountMeta> {
     }
 }
 
-/// Accounts for the `ClosePaymentEscrow` instruction (8 accounts).
-///
-/// Always passes all 8 accounts. The on-chain program only reads accounts 4-7
-/// when `usdc_balance > 0`; extra accounts are harmless when balance is zero.
+/// Accounts for the `ClosePaymentEscrow` instruction (9 accounts).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClosePaymentEscrowAccounts {
     pub program_config_key: Pubkey,
@@ -102,13 +82,15 @@ pub struct ClosePaymentEscrowAccounts {
     pub payment_escrow_key: Pubkey,
     pub withdraw_authority_key: Pubkey,
     pub client_seat_key: Pubkey,
-    pub client_seat_usdc_token_pda_key: Pubkey,
+    pub device_history_key: Pubkey,
+    pub device_history_usdc_token_account_key: Pubkey,
     pub refund_usdc_token_account_key: Pubkey,
 }
 
 impl ClosePaymentEscrowAccounts {
     pub fn new(
-        client_seat_key: &Pubkey,
+        device_key: &Pubkey,
+        client_ip_bits: u32,
         withdraw_authority: &Pubkey,
         usdc_mint: &Pubkey,
         refund_usdc_token_account: Option<&Pubkey>,
@@ -116,18 +98,21 @@ impl ClosePaymentEscrowAccounts {
         let refund_key = refund_usdc_token_account
             .copied()
             .unwrap_or_else(|| get_associated_token_address(withdraw_authority, usdc_mint));
+        let client_seat_key = state::find_client_seat_address(device_key, client_ip_bits).0;
+        let device_history_key = state::find_device_history_address(device_key).0;
         Self {
             program_config_key: state::find_program_config_address().0,
             execution_controller_key: state::find_execution_controller_address().0,
             payment_escrow_key: state::find_payment_escrow_address(
-                client_seat_key,
+                &client_seat_key,
                 withdraw_authority,
             )
             .0,
             withdraw_authority_key: *withdraw_authority,
-            client_seat_key: *client_seat_key,
-            client_seat_usdc_token_pda_key: state::find_token_pda_address(
-                client_seat_key,
+            client_seat_key,
+            device_history_key,
+            device_history_usdc_token_account_key: state::find_token_pda_address(
+                &device_history_key,
                 usdc_mint,
             )
             .0,
@@ -144,7 +129,8 @@ impl From<ClosePaymentEscrowAccounts> for Vec<AccountMeta> {
             AccountMeta::new(accounts.payment_escrow_key, false),
             AccountMeta::new(accounts.withdraw_authority_key, true),
             AccountMeta::new_readonly(accounts.client_seat_key, false),
-            AccountMeta::new(accounts.client_seat_usdc_token_pda_key, false),
+            AccountMeta::new_readonly(accounts.device_history_key, false),
+            AccountMeta::new(accounts.device_history_usdc_token_account_key, false),
             AccountMeta::new(accounts.refund_usdc_token_account_key, false),
             AccountMeta::new_readonly(spl_token_interface::ID, false),
         ]
@@ -160,7 +146,7 @@ pub struct FundPaymentEscrowUsdcAccounts {
     pub device_history_key: Pubkey,
     pub client_seat_key: Pubkey,
     pub payment_escrow_key: Pubkey,
-    pub client_seat_usdc_token_account_key: Pubkey,
+    pub device_history_usdc_token_account_key: Pubkey,
     pub source_usdc_token_account_key: Pubkey,
     pub transfer_authority_key: Pubkey,
 }
@@ -176,19 +162,20 @@ impl FundPaymentEscrowUsdcAccounts {
         transfer_authority_key: &Pubkey,
     ) -> Self {
         let client_seat_key = state::find_client_seat_address(device_key, client_ip_bits).0;
+        let device_history_key = state::find_device_history_address(device_key).0;
         Self {
             program_config_key: state::find_program_config_address().0,
             execution_controller_key: state::find_execution_controller_address().0,
             metro_history_key: state::find_metro_history_address(exchange_key).0,
-            device_history_key: state::find_device_history_address(device_key).0,
+            device_history_key,
             client_seat_key,
             payment_escrow_key: state::find_payment_escrow_address(
                 &client_seat_key,
                 withdraw_authority_key,
             )
             .0,
-            client_seat_usdc_token_account_key: state::find_token_pda_address(
-                &client_seat_key,
+            device_history_usdc_token_account_key: state::find_token_pda_address(
+                &device_history_key,
                 usdc_mint_key,
             )
             .0,
@@ -207,7 +194,7 @@ impl From<FundPaymentEscrowUsdcAccounts> for Vec<AccountMeta> {
             AccountMeta::new_readonly(accounts.device_history_key, false),
             AccountMeta::new(accounts.client_seat_key, false),
             AccountMeta::new(accounts.payment_escrow_key, false),
-            AccountMeta::new(accounts.client_seat_usdc_token_account_key, false),
+            AccountMeta::new(accounts.device_history_usdc_token_account_key, false),
             AccountMeta::new(accounts.source_usdc_token_account_key, false),
             AccountMeta::new_readonly(accounts.transfer_authority_key, true),
             AccountMeta::new_readonly(spl_token_interface::ID, false),

--- a/crates/solana-sdk/src/reservation/state.rs
+++ b/crates/solana-sdk/src/reservation/state.rs
@@ -88,8 +88,7 @@ pub fn find_payment_escrow_address(
 //   [0..8)    discriminator
 //   [8..40)   device_key: Pubkey
 //   [40..44)  client_ip_bits: u32
-//   [44)      bump_seed: u8
-//   [45)      usdc_token_pda_bump_seed: u8
+//   [44..46)  _padding: [u8; 2]
 //   [46..48)  tenure_epochs: u16
 //   [48..56)  _flags: Flags (u64)
 //   [56..64)  funded_epoch: u64
@@ -102,8 +101,6 @@ pub const CLIENT_SEAT_DISCRIMINATOR: Discriminator<DISCRIMINATOR_LEN> =
 
 pub const CLIENT_SEAT_DEVICE_KEY_OFFSET: usize = DISCRIMINATOR_LEN;
 pub const CLIENT_SEAT_CLIENT_IP_OFFSET: usize = DISCRIMINATOR_LEN + 32;
-pub const CLIENT_SEAT_BUMP_OFFSET: usize = DISCRIMINATOR_LEN + 36;
-pub const CLIENT_SEAT_TOKEN_PDA_BUMP_OFFSET: usize = DISCRIMINATOR_LEN + 37;
 pub const CLIENT_SEAT_TENURE_OFFSET: usize = DISCRIMINATOR_LEN + 38;
 pub const CLIENT_SEAT_FUNDED_EPOCH_OFFSET: usize = DISCRIMINATOR_LEN + 48;
 pub const CLIENT_SEAT_ACTIVE_EPOCH_OFFSET: usize = DISCRIMINATOR_LEN + 56;
@@ -194,10 +191,13 @@ pub fn parse_payment_escrow(data: &[u8]) -> Option<(Pubkey, Pubkey, u64)> {
 // DeviceHistory raw-byte parsing.
 //
 // Layout (ZeroCopy with 8-byte discriminator prefix):
-//   [0..8)   discriminator
-//   [8..40)  device_key: Pubkey
-//   [40..48) flags: u64
-//   [48..80) metro_exchange_key: Pubkey
+//   [0..8)    discriminator
+//   [8..40)   device_key: Pubkey
+//   [40..48)  flags: u64
+//   [48)      bump_seed: u8
+//   [49)      usdc_token_pda_bump_seed: u8
+//   [50..56)  _padding: [u8; 6]
+//   [56..88)  metro_exchange_key: Pubkey
 // ---------------------------------------------------------------------------
 
 pub const DEVICE_HISTORY_DISCRIMINATOR: Discriminator<DISCRIMINATOR_LEN> =
@@ -205,8 +205,8 @@ pub const DEVICE_HISTORY_DISCRIMINATOR: Discriminator<DISCRIMINATOR_LEN> =
 
 pub const DEVICE_HISTORY_DEVICE_KEY_OFFSET: usize = DISCRIMINATOR_LEN;
 pub const DEVICE_HISTORY_FLAGS_OFFSET: usize = DISCRIMINATOR_LEN + 32;
-pub const DEVICE_HISTORY_EXCHANGE_KEY_OFFSET: usize = DISCRIMINATOR_LEN + 32 + 8;
-const DEVICE_HISTORY_RING_OFFSET: usize = DISCRIMINATOR_LEN + 200; // after StorageGap<4> (128 bytes)
+pub const DEVICE_HISTORY_EXCHANGE_KEY_OFFSET: usize = DISCRIMINATOR_LEN + 32 + 16;
+const DEVICE_HISTORY_RING_OFFSET: usize = DISCRIMINATOR_LEN + 208; // after StorageGap<4> (128 bytes)
 const DEVICE_HISTORY_ENTRY_SIZE: usize = 88; // EpochEntry<DeviceSubscription>
 
 /// Parse the metro exchange pubkey directly from raw `DeviceHistory` account data.


### PR DESCRIPTION
## Summary of Changes
- Move USDC token custody from client seat to device history due to redesign
- `InitializeClientSeat`: remove `usdc_mint_key` parameter and token PDA account (no longer creates a token account)
- `ClosePaymentEscrow`: change constructor from `(client_seat_key, ...)` to `(device_key, client_ip_bits, ...)`; use `device_history_usdc_token_account_key` instead of `client_seat_usdc_token_pda_key`
- `FundPaymentEscrowUsdc`: derive USDC token PDA from device history instead of client seat
- Update `DeviceHistory` raw-byte offsets for new `bump_seed`/`usdc_token_pda_bump_seed` fields
- Remove `CLIENT_SEAT_BUMP_OFFSET` and `CLIENT_SEAT_TOKEN_PDA_BUMP_OFFSET` constants (now padding)

## Testing Verification
- `cargo fmt` and `cargo clippy` pass clean
- SDK and CLI compile with `--features experimental`