### PR TITLE
reservation: fix execution_controller writable flag for InitializeClientSeat

### DIFF
--- a/crates/solana-sdk/src/reservation/instruction/account.rs
+++ b/crates/solana-sdk/src/reservation/instruction/account.rs
@@ -29,7 +29,7 @@ impl From<InitializeClientSeatAccounts> for Vec<AccountMeta> {
     fn from(accounts: InitializeClientSeatAccounts) -> Self {
         vec![
             AccountMeta::new_readonly(accounts.program_config_key, false),
-            AccountMeta::new_readonly(accounts.execution_controller_key, false),
+            AccountMeta::new(accounts.execution_controller_key, false),
             AccountMeta::new_readonly(accounts.device_history_key, false),
             AccountMeta::new(accounts.payer_key, true),
             AccountMeta::new(accounts.new_client_seat_key, false),


### PR DESCRIPTION
## Summary
- The `InitializeClientSeatAccounts` builder incorrectly marked `execution_controller` as readonly
- The on-chain program requires it writable to update the `total_client_seats` counter
- One-line fix: `new_readonly` → `new` for the execution controller account meta