### PR TITLE
feat(validator-debt): abort calculation if fees are zero (#3244)

### DIFF
--- a/.github/workflows/local-validator.yml
+++ b/.github/workflows/local-validator.yml
@@ -73,9 +73,10 @@ jobs:
       - name: Run `doublezero-solana-validator-debt` tests
         run: bash sh/test_validator_debt_fork.sh
 
-  test-full-debt-flow:
-    runs-on: ubuntu-latest
-    needs: [test-doublezero-solana-validator-debt-fork-current]
+# Commenting out as we may bring this back in the future
+  # test-full-debt-flow:
+  #   runs-on: ubuntu-latest
+  #   needs: [test-doublezero-solana-validator-debt-fork-current]
     steps:
       - uses: actions/checkout@v4
 

--- a/crates/validator-debt/CHANGELOG.md
+++ b/crates/validator-debt/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- feat(validator-debt): abort calculation if fees are zero ([#286](https://github.com/doublezerofoundation/doublezero-offchain/pull/286))
 - feat(contributor-rewards): add on-chain reward distribution ([#269](https://github.com/doublezerofoundation/doublezero-offchain/pull/269))
 - ensure debt is finalized before collection ([#268](https://github.com/doublezerofoundation/doublezero-offchain/pull/268))
 - use inclusive range for completed DZ epochs ([#2815](https://github.com/malbeclabs/doublezero/issues/2815))

--- a/crates/validator-debt/src/worker/mod.rs
+++ b/crates/validator-debt/src/worker/mod.rs
@@ -20,7 +20,7 @@ use doublezero_solana_sdk::{
             RevenueDistributionInstructionData, account::InitializeSolanaValidatorDepositAccounts,
         },
         state::{Distribution, ProgramConfig, SolanaValidatorDeposit},
-        types::SolanaValidatorDebt,
+        types::{SolanaValidatorDebt, UnitShare16},
     },
     try_build_instruction,
 };
@@ -175,6 +175,15 @@ pub async fn calculate_distribution(
     let distribution = transaction
         .read_distribution(dz_epoch, solana_debt_calculator.solana_rpc_client())
         .await?;
+
+    if distribution
+        .solana_validator_fee_parameters
+        .base_block_rewards_pct
+        == UnitShare16::default()
+    {
+        tracing::warn!("No fees collected - aborting distribution calculation");
+        return Ok(WriteSummary::default());
+    }
 
     if distribution.is_debt_calculation_finalized() {
         bail!("distribution has already been finalized for dz epoch {dz_epoch}");

--- a/sh/test_validator_debt_fork.sh
+++ b/sh/test_validator_debt_fork.sh
@@ -1,3 +1,4 @@
+
 #!/bin/bash
 
 MAINNET_BETA_DEBT_ACCOUNTANT_KEY=acLisxTpNkoctPZoqssyo58pcdnHzJyRFhod7Wxkz5a


### PR DESCRIPTION
## Summary of Changes
This PR short circuits the debt calculation if fees are set to zero. 

Closes https://github.com/malbeclabs/doublezero/issues/3244

## Testing Verification
* Ran locally and validated that the fees are expected