### PR TITLE
cli: default shreds list to funder keypair, add --all and -k flags

### DIFF
--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `shreds pay`: block duplicate client IP across devices — prevent creating a seat for an IP that already has an active seat on a different device
 - `shreds validator-client-rewards`: add hidden command to set validator client rewards proportion
+- `shreds list`: filter by funder (withdraw-authority) by default, add `--all` flag
 
 ## [0.5.0](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.0)
 

--- a/crates/solana-cli/src/command/shreds/list.rs
+++ b/crates/solana-cli/src/command/shreds/list.rs
@@ -28,10 +28,11 @@ pub struct ListCommand {
     #[command(flatten)]
     device_args: super::DeviceArgs,
 
-    /// Filter seats by funder public key. When omitted, defaults to the
-    /// keypair's public key (use --all to show every seat instead).
-    #[arg(long)]
-    funder: Option<Pubkey>,
+    /// Filter seats by funder (withdraw authority). Accepts a public key or a
+    /// path to a keypair file. When omitted, defaults to the default keypair's
+    /// public key (use --all to show every seat instead).
+    #[arg(long, short = 'k')]
+    funder: Option<String>,
 
     /// Filter seats by client IPv4 address.
     #[arg(long)]
@@ -40,10 +41,6 @@ pub struct ListCommand {
     /// Show all seats regardless of funder.
     #[arg(long)]
     all: bool,
-
-    /// Filepath or URL to a keypair. Used to derive the default funder filter.
-    #[arg(long = "keypair", short = 'k', value_name = "KEYPAIR")]
-    keypair_path: Option<String>,
 
     #[command(flatten)]
     connection_options: SolanaConnectionOptions,
@@ -129,11 +126,15 @@ impl ListCommand {
             .collect();
 
         // Resolve the funder (withdraw authority) filter.
-        let funder: Option<Pubkey> = if let Some(funder) = self.funder {
-            Some(funder)
+        let funder: Option<Pubkey> = if let Some(ref funder_str) = self.funder {
+            if let Ok(pubkey) = funder_str.parse::<Pubkey>() {
+                Some(pubkey)
+            } else {
+                let keypair = try_load_keypair(Some(funder_str.into()))?;
+                Some(keypair.pubkey())
+            }
         } else if !self.all {
-            let keypair =
-                try_load_keypair(self.keypair_path.map(Into::into)).map_err(anyhow::Error::from)?;
+            let keypair = try_load_keypair(None)?;
             Some(keypair.pubkey())
         } else {
             None

--- a/crates/solana-cli/src/command/shreds/list.rs
+++ b/crates/solana-cli/src/command/shreds/list.rs
@@ -3,14 +3,17 @@ use std::{collections::HashMap, net::Ipv4Addr};
 use anyhow::Result;
 use clap::Args;
 use doublezero_serviceability::state::device::Device;
-use doublezero_solana_client_tools::rpc::{SolanaConnection, SolanaConnectionOptions};
+use doublezero_solana_client_tools::{
+    payer::try_load_keypair,
+    rpc::{SolanaConnection, SolanaConnectionOptions},
+};
 use doublezero_solana_sdk::shred_subscription::{self, state};
 use solana_account_decoder_client_types::UiAccountEncoding;
 use solana_client::{
     rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
     rpc_filter::{Memcmp, RpcFilterType},
 };
-use solana_sdk::{account::Account, pubkey::Pubkey};
+use solana_sdk::{account::Account, pubkey::Pubkey, signer::Signer};
 use tabled::{Table, Tabled, settings::Style};
 
 use super::make_dz_connection;
@@ -25,13 +28,22 @@ pub struct ListCommand {
     #[command(flatten)]
     device_args: super::DeviceArgs,
 
-    /// Filter seats by withdraw authority (wallets that have payment escrows).
+    /// Filter seats by funder public key. When omitted, defaults to the
+    /// keypair's public key (use --all to show every seat instead).
     #[arg(long)]
-    withdraw_authority: Option<Pubkey>,
+    funder: Option<Pubkey>,
 
     /// Filter seats by client IPv4 address.
     #[arg(long)]
     client_ip: Option<Ipv4Addr>,
+
+    /// Show all seats regardless of funder.
+    #[arg(long)]
+    all: bool,
+
+    /// Filepath or URL to a keypair. Used to derive the default funder filter.
+    #[arg(long = "keypair", short = 'k', value_name = "KEYPAIR")]
+    keypair_path: Option<String>,
 
     #[command(flatten)]
     connection_options: SolanaConnectionOptions,
@@ -116,9 +128,19 @@ impl ListCommand {
             })
             .collect();
 
+        // Resolve the funder (withdraw authority) filter.
+        let funder: Option<Pubkey> = if let Some(funder) = self.funder {
+            Some(funder)
+        } else if !self.all {
+            let keypair =
+                try_load_keypair(self.keypair_path.map(Into::into)).map_err(anyhow::Error::from)?;
+            Some(keypair.pubkey())
+        } else {
+            None
+        };
+
         // Fetch escrow balances.
-        let (escrow_balances, filtered_seats) = if let Some(ref authority) = self.withdraw_authority
-        {
+        let (escrow_balances, filtered_seats) = if let Some(ref authority) = funder {
             let escrow_keys: Vec<Pubkey> = parsed_seats
                 .iter()
                 .map(|(seat_key, _, _, _)| {
@@ -160,7 +182,11 @@ impl ListCommand {
                     balances.insert(seat_key, balance);
                 }
             }
-            (balances, parsed_seats)
+            let matching_seats: Vec<_> = parsed_seats
+                .into_iter()
+                .filter(|(seat_key, _, _, _)| balances.contains_key(seat_key))
+                .collect();
+            (balances, matching_seats)
         };
 
         if filtered_seats.is_empty() {


### PR DESCRIPTION
## Summary
- Default `shreds list` to filter by the local keypair's pubkey (withdraw authority), so users see only their own seats
- Add `--all` flag to opt out and show every seat (previous default)
- Add `-k` / `--keypair` to specify a non-default keypair for the funder filter
- Rename `--withdraw-authority` to `--funder`

Closes https://github.com/malbeclabs/infra/issues/872