### PR TITLE
solana-cli: add validator-client-rewards shreds command

### DIFF
--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `shreds validator-client-rewards`: add hidden command to set validator client rewards proportion
+
 ## [0.5.0](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.0)
 
 - uptick version 0.5.0 (#337)

--- a/crates/solana-cli/src/command/shreds/mod.rs
+++ b/crates/solana-cli/src/command/shreds/mod.rs
@@ -2,6 +2,7 @@ pub mod list;
 pub mod pay;
 pub mod payments;
 pub mod price;
+pub mod validator_client_rewards;
 pub mod withdraw;
 
 use anyhow::{Result, bail};
@@ -45,6 +46,9 @@ pub enum ShredsSubcommand {
     Payments(payments::PaymentsCommand),
     /// Show current device pricing.
     Price(price::PriceCommand),
+    /// Set the rewards proportion for a validator client.
+    #[command(hide = true)]
+    ValidatorClientRewards(validator_client_rewards::ValidatorClientRewardsCommand),
 }
 
 impl ShredsSubcommand {
@@ -55,6 +59,7 @@ impl ShredsSubcommand {
             Self::List(command) => command.try_into_execute(dz_ledger_url).await,
             Self::Payments(command) => command.try_into_execute(dz_ledger_url).await,
             Self::Price(command) => command.try_into_execute(dz_ledger_url).await,
+            Self::ValidatorClientRewards(command) => command.try_into_execute().await,
         }
     }
 }

--- a/crates/solana-cli/src/command/shreds/payments.rs
+++ b/crates/solana-cli/src/command/shreds/payments.rs
@@ -211,7 +211,10 @@ impl PaymentsCommand {
                             ShredSubscriptionInstructionData::InitializePaymentEscrow
                             | ShredSubscriptionInstructionData::InitializeClientSeat { .. }
                             | ShredSubscriptionInstructionData::RequestInstantSeatAllocation
-                            | ShredSubscriptionInstructionData::RequestInstantSeatWithdrawal,
+                            | ShredSubscriptionInstructionData::RequestInstantSeatWithdrawal
+                            | ShredSubscriptionInstructionData::SetValidatorClientRewardsProportion(
+                                _,
+                            ),
                         ) => {}
                         // TODO: oracle instructions (BatchAllocateSeats,
                         // InstantAllocateSeat) debit the escrow. Their

--- a/crates/solana-cli/src/command/shreds/validator_client_rewards.rs
+++ b/crates/solana-cli/src/command/shreds/validator_client_rewards.rs
@@ -1,0 +1,81 @@
+use anyhow::{Result, bail};
+use clap::Args;
+use doublezero_solana_client_tools::payer::{SolanaPayerOptions, TransactionOutcome, Wallet};
+use doublezero_solana_sdk::{
+    shred_subscription::{
+        ID,
+        instruction::{
+            ShredSubscriptionInstructionData, account::SetValidatorClientRewardsProportionAccounts,
+        },
+    },
+    try_build_instruction,
+};
+use solana_sdk::compute_budget::ComputeBudgetInstruction;
+
+/*
+   doublezero-solana shreds validator-client-rewards \
+       --client-id <ID> --proportion <PERCENT>
+*/
+
+#[derive(Debug, Args)]
+pub struct ValidatorClientRewardsCommand {
+    /// Validator client ID.
+    #[arg(long)]
+    client_id: u16,
+    /// Rewards proportion as a percentage (0–100, e.g. 50.5 for 50.5%).
+    #[arg(long)]
+    proportion: f64,
+    #[command(flatten)]
+    solana_payer_options: SolanaPayerOptions,
+}
+
+impl ValidatorClientRewardsCommand {
+    pub async fn try_into_execute(self) -> Result<()> {
+        let proportion_bps = percentage_to_bps(self.proportion)?;
+
+        let dz_connection = self
+            .solana_payer_options
+            .connection_options
+            .clone()
+            .into_shred_subscription_connection();
+        let mut wallet = Wallet::try_from(self.solana_payer_options)?;
+        wallet.connection = dz_connection;
+        let wallet_key = wallet.pubkey();
+
+        println!("Shred subscription - Set Validator Client Rewards Proportion");
+        println!(
+            "Client ID: {}, Proportion: {}% ({} bps)",
+            self.client_id, self.proportion, proportion_bps
+        );
+
+        let ix = try_build_instruction(
+            &ID,
+            SetValidatorClientRewardsProportionAccounts::new(&wallet_key, self.client_id),
+            &ShredSubscriptionInstructionData::SetValidatorClientRewardsProportion(proportion_bps),
+        )?;
+
+        let mut instructions = vec![ix];
+
+        instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(30_000));
+        if let Some(ref compute_unit_price_ix) = wallet.compute_unit_price_ix {
+            instructions.push(compute_unit_price_ix.clone());
+        }
+
+        let transaction = wallet.new_transaction(&instructions).await?;
+        let tx_outcome = wallet.send_or_simulate_transaction(&transaction).await?;
+
+        if let TransactionOutcome::Executed(tx_sig) = tx_outcome {
+            println!("Set validator client rewards proportion: {tx_sig}");
+            wallet.print_verbose_output(&[tx_sig]).await?;
+        }
+
+        Ok(())
+    }
+}
+
+fn percentage_to_bps(pct: f64) -> Result<u16> {
+    if !(0.0..=100.0).contains(&pct) {
+        bail!("Proportion must be between 0 and 100 (got {pct})");
+    }
+    Ok((pct * 100.0).round() as u16)
+}

--- a/crates/solana-sdk/src/shred_subscription/instruction/account.rs
+++ b/crates/solana-sdk/src/shred_subscription/instruction/account.rs
@@ -236,6 +236,34 @@ impl From<RequestInstantSeatWithdrawalAccounts> for Vec<AccountMeta> {
     }
 }
 
+/// Accounts for the `SetValidatorClientRewardsProportion` instruction (3 accounts).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetValidatorClientRewardsProportionAccounts {
+    pub program_config_key: Pubkey,
+    pub manager_key: Pubkey,
+    pub validator_client_rewards_key: Pubkey,
+}
+
+impl SetValidatorClientRewardsProportionAccounts {
+    pub fn new(manager_key: &Pubkey, client_id: u16) -> Self {
+        Self {
+            program_config_key: state::find_program_config_address().0,
+            manager_key: *manager_key,
+            validator_client_rewards_key: state::find_validator_client_rewards_address(client_id).0,
+        }
+    }
+}
+
+impl From<SetValidatorClientRewardsProportionAccounts> for Vec<AccountMeta> {
+    fn from(accounts: SetValidatorClientRewardsProportionAccounts) -> Self {
+        vec![
+            AccountMeta::new(accounts.program_config_key, false),
+            AccountMeta::new_readonly(accounts.manager_key, true),
+            AccountMeta::new_readonly(accounts.validator_client_rewards_key, false),
+        ]
+    }
+}
+
 /// Accounts for the `FundPaymentEscrowUsdc` instruction (10 accounts).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FundPaymentEscrowUsdcAccounts {

--- a/crates/solana-sdk/src/shred_subscription/instruction/mod.rs
+++ b/crates/solana-sdk/src/shred_subscription/instruction/mod.rs
@@ -19,6 +19,8 @@ pub enum ShredSubscriptionInstructionData {
     RequestInstantSeatAllocation,
     /// Request instant seat withdrawal.
     RequestInstantSeatWithdrawal,
+    /// Set the rewards proportion for a validator client.
+    SetValidatorClientRewardsProportion(u16),
 }
 
 impl ShredSubscriptionInstructionData {
@@ -34,6 +36,8 @@ impl ShredSubscriptionInstructionData {
         Discriminator::new_sha2(b"dz::ix::request_instant_seat_allocation");
     pub const REQUEST_INSTANT_SEAT_WITHDRAWAL: Discriminator<DISCRIMINATOR_LEN> =
         Discriminator::new_sha2(b"dz::ix::request_instant_seat_withdrawal");
+    pub const SET_VALIDATOR_CLIENT_REWARDS_PROPORTION: Discriminator<DISCRIMINATOR_LEN> =
+        Discriminator::new_sha2(b"dz::ix::set_validator_client_rewards_proportion");
 }
 
 impl BorshSerialize for ShredSubscriptionInstructionData {
@@ -55,6 +59,10 @@ impl BorshSerialize for ShredSubscriptionInstructionData {
             Self::RequestInstantSeatWithdrawal => {
                 Self::REQUEST_INSTANT_SEAT_WITHDRAWAL.serialize(writer)
             }
+            Self::SetValidatorClientRewardsProportion(proportion) => {
+                Self::SET_VALIDATOR_CLIENT_REWARDS_PROPORTION.serialize(writer)?;
+                proportion.serialize(writer)
+            }
         }
     }
 }
@@ -74,6 +82,10 @@ impl BorshDeserialize for ShredSubscriptionInstructionData {
             }
             Self::REQUEST_INSTANT_SEAT_ALLOCATION => Ok(Self::RequestInstantSeatAllocation),
             Self::REQUEST_INSTANT_SEAT_WITHDRAWAL => Ok(Self::RequestInstantSeatWithdrawal),
+            Self::SET_VALIDATOR_CLIENT_REWARDS_PROPORTION => {
+                let proportion = u16::deserialize_reader(reader)?;
+                Ok(Self::SetValidatorClientRewardsProportion(proportion))
+            }
             _ => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Invalid discriminator",

--- a/crates/solana-sdk/src/shred_subscription/state.rs
+++ b/crates/solana-sdk/src/shred_subscription/state.rs
@@ -10,6 +10,7 @@ pub const CLIENT_SEAT_SEED_PREFIX: &[u8] = b"client_seat";
 pub const METRO_HISTORY_SEED_PREFIX: &[u8] = b"metro_history";
 pub const TOKEN_PDA_SEED_PREFIX: &[u8] = b"token";
 pub const PAYMENT_ESCROW_SEED_PREFIX: &[u8] = b"payment_escrow";
+pub const VALIDATOR_CLIENT_REWARDS_SEED_PREFIX: &[u8] = b"validator_client_rewards";
 pub const INSTANT_ALLOCATION_REQUEST_SEED_PREFIX: &[u8] = b"instant_seat_allocation_request";
 pub const WITHDRAW_SEAT_REQUEST_SEED_PREFIX: &[u8] = b"withdraw_seat_request";
 
@@ -58,6 +59,16 @@ pub fn find_token_pda_address(token_owner_key: &Pubkey, mint_key: &Pubkey) -> (P
             TOKEN_PDA_SEED_PREFIX,
             token_owner_key.as_ref(),
             mint_key.as_ref(),
+        ],
+        &crate::shred_subscription::ID,
+    )
+}
+
+pub fn find_validator_client_rewards_address(client_id: u16) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[
+            VALIDATOR_CLIENT_REWARDS_SEED_PREFIX,
+            &client_id.to_le_bytes(),
         ],
         &crate::shred_subscription::ID,
     )


### PR DESCRIPTION
Resolves: malbeclabs/infra#894

## Summary
- Add hidden `shreds validator-client-rewards` CLI command to set the rewards proportion for a validator client ID
- Mirrors the `SetValidatorClientRewardsProportion` onchain instruction introduced in doublezero-shreds PR #205
- Accepts `--proportion` as a percentage (0–100) and converts to basis points for the instruction
- The wallet keypair (`-k`) acts as the manager signer; `--fee-payer` can be used for a separate fee payer

## Lines of Code
| Section | Added | Removed |
|---------|-------|---------|
| solana-cli | +93 | -1 |
| solana-sdk | +52 | -0 |

## Testing Verification
- Manual dry-run verification of CLI arg parsing and percentage-to-bps conversion