### PR TITLE
solana-cli: prepend CheckCliVersion to shreds write transactions

### DIFF
--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `shreds`: prepend `CheckCliVersion` instruction to all write transactions (pay, withdraw, validator-client-rewards) for onchain minimum CLI version enforcement
 - `shreds pay`: block duplicate client IP across devices — prevent creating a seat for an IP that already has an active seat on a different device
 - `shreds validator-client-rewards`: add hidden command to set validator client rewards proportion
 - `shreds list`: filter by funder (withdraw-authority) by default, add `--all` flag

--- a/crates/solana-cli/src/command/shreds/mod.rs
+++ b/crates/solana-cli/src/command/shreds/mod.rs
@@ -135,8 +135,9 @@ pub(super) fn shred_oracle_key(env: NetworkEnvironment) -> Option<Pubkey> {
 /// Handles version strings like "0.5.0" or "0.5.0-rc1" by only considering
 /// the first three numeric components.
 fn cli_version() -> (u32, u32, u32) {
-    let version_str =
-        option_env!("BUILD_VERSION").unwrap_or(env!("CARGO_PKG_VERSION")).trim_start_matches('v');
+    let version_str = option_env!("BUILD_VERSION")
+        .unwrap_or(env!("CARGO_PKG_VERSION"))
+        .trim_start_matches('v');
     let mut parts = version_str.split('.');
     let major = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
     let minor = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);

--- a/crates/solana-cli/src/command/shreds/mod.rs
+++ b/crates/solana-cli/src/command/shreds/mod.rs
@@ -8,6 +8,10 @@ pub mod withdraw;
 use anyhow::{Result, bail};
 use clap::{Args, Subcommand};
 use doublezero_solana_client_tools::rpc::{DoubleZeroLedgerConnection, NetworkEnvironment};
+use doublezero_solana_sdk::shred_subscription::{
+    ID as SHRED_SUBSCRIPTION_PROGRAM_ID,
+    instruction::{ShredSubscriptionInstructionData, account::CheckCliVersionAccounts},
+};
 use solana_account_decoder_client_types::UiAccountEncoding;
 use solana_client::{
     rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
@@ -124,6 +128,41 @@ pub(super) fn shred_oracle_key(env: NetworkEnvironment) -> Option<Pubkey> {
         )),
         NetworkEnvironment::Localnet => None,
     }
+}
+
+/// Parse the CLI's build version into (major, minor, patch).
+///
+/// Handles version strings like "0.5.0" or "0.5.0-rc1" by only considering
+/// the first three numeric components.
+fn cli_version() -> (u32, u32, u32) {
+    let version_str =
+        option_env!("BUILD_VERSION").unwrap_or(env!("CARGO_PKG_VERSION")).trim_start_matches('v');
+    let mut parts = version_str.split('.');
+    let major = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let minor = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    // Strip any pre-release suffix (e.g. "0-rc1" -> "0").
+    let patch = parts
+        .next()
+        .and_then(|s| s.split('-').next())
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    (major, minor, patch)
+}
+
+/// Build a `CheckCliVersion` instruction to prepend to write transactions.
+pub(super) fn build_check_cli_version_instruction() -> Result<solana_sdk::instruction::Instruction>
+{
+    let (major, minor, patch) = cli_version();
+    let ix = doublezero_solana_sdk::try_build_instruction(
+        &SHRED_SUBSCRIPTION_PROGRAM_ID,
+        CheckCliVersionAccounts::new(),
+        &ShredSubscriptionInstructionData::CheckCliVersion {
+            major,
+            minor,
+            patch,
+        },
+    )?;
+    Ok(ix)
 }
 
 pub(super) fn serviceability_program_id(env: NetworkEnvironment) -> Result<Pubkey> {

--- a/crates/solana-cli/src/command/shreds/pay.rs
+++ b/crates/solana-cli/src/command/shreds/pay.rs
@@ -371,8 +371,8 @@ impl PayCommand {
             );
         }
 
-        let mut instructions = Vec::new();
-        let mut compute_unit_limit = 0u32;
+        let mut instructions = vec![super::build_check_cli_version_instruction()?];
+        let mut compute_unit_limit = 5_000u32;
 
         if !seat_exists {
             let seat_ix = try_build_instruction(

--- a/crates/solana-cli/src/command/shreds/payments.rs
+++ b/crates/solana-cli/src/command/shreds/payments.rs
@@ -214,7 +214,8 @@ impl PaymentsCommand {
                             | ShredSubscriptionInstructionData::RequestInstantSeatWithdrawal
                             | ShredSubscriptionInstructionData::SetValidatorClientRewardsProportion(
                                 _,
-                            ),
+                            )
+                            | ShredSubscriptionInstructionData::CheckCliVersion { .. },
                         ) => {}
                         // TODO: oracle instructions (BatchAllocateSeats,
                         // InstantAllocateSeat) debit the escrow. Their

--- a/crates/solana-cli/src/command/shreds/validator_client_rewards.rs
+++ b/crates/solana-cli/src/command/shreds/validator_client_rewards.rs
@@ -54,9 +54,10 @@ impl ValidatorClientRewardsCommand {
             &ShredSubscriptionInstructionData::SetValidatorClientRewardsProportion(proportion_bps),
         )?;
 
-        let mut instructions = vec![ix];
+        let check_ix = super::build_check_cli_version_instruction()?;
+        let mut instructions = vec![check_ix, ix];
 
-        instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(30_000));
+        instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(35_000));
         if let Some(ref compute_unit_price_ix) = wallet.compute_unit_price_ix {
             instructions.push(compute_unit_price_ix.clone());
         }

--- a/crates/solana-cli/src/command/shreds/withdraw.rs
+++ b/crates/solana-cli/src/command/shreds/withdraw.rs
@@ -94,8 +94,8 @@ impl WithdrawCommand {
             bail!("Client seat {client_seat_key} does not have active service");
         }
 
-        let mut instructions = Vec::new();
-        let mut compute_unit_limit = 30_000;
+        let mut instructions = vec![super::build_check_cli_version_instruction()?];
+        let mut compute_unit_limit = 5_000 + 30_000;
 
         instructions.push(try_build_instruction(
             &ID,

--- a/crates/solana-sdk/src/shred_subscription/instruction/account.rs
+++ b/crates/solana-sdk/src/shred_subscription/instruction/account.rs
@@ -264,6 +264,35 @@ impl From<SetValidatorClientRewardsProportionAccounts> for Vec<AccountMeta> {
     }
 }
 
+/// Accounts for the `CheckCliVersion` instruction (1 account).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckCliVersionAccounts {
+    pub program_config_key: Pubkey,
+}
+
+impl Default for CheckCliVersionAccounts {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CheckCliVersionAccounts {
+    pub fn new() -> Self {
+        Self {
+            program_config_key: state::find_program_config_address().0,
+        }
+    }
+}
+
+impl From<CheckCliVersionAccounts> for Vec<AccountMeta> {
+    fn from(accounts: CheckCliVersionAccounts) -> Self {
+        vec![AccountMeta::new_readonly(
+            accounts.program_config_key,
+            false,
+        )]
+    }
+}
+
 /// Accounts for the `FundPaymentEscrowUsdc` instruction (10 accounts).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FundPaymentEscrowUsdcAccounts {

--- a/crates/solana-sdk/src/shred_subscription/instruction/mod.rs
+++ b/crates/solana-sdk/src/shred_subscription/instruction/mod.rs
@@ -21,6 +21,8 @@ pub enum ShredSubscriptionInstructionData {
     RequestInstantSeatWithdrawal,
     /// Set the rewards proportion for a validator client.
     SetValidatorClientRewardsProportion(u16),
+    /// Validates the provided CLI version against the onchain minimum.
+    CheckCliVersion { major: u32, minor: u32, patch: u32 },
 }
 
 impl ShredSubscriptionInstructionData {
@@ -38,6 +40,8 @@ impl ShredSubscriptionInstructionData {
         Discriminator::new_sha2(b"dz::ix::request_instant_seat_withdrawal");
     pub const SET_VALIDATOR_CLIENT_REWARDS_PROPORTION: Discriminator<DISCRIMINATOR_LEN> =
         Discriminator::new_sha2(b"dz::ix::set_validator_client_rewards_proportion");
+    pub const CHECK_CLI_VERSION: Discriminator<DISCRIMINATOR_LEN> =
+        Discriminator::new_sha2(b"dz::ix::check_cli_version");
 }
 
 impl BorshSerialize for ShredSubscriptionInstructionData {
@@ -63,6 +67,16 @@ impl BorshSerialize for ShredSubscriptionInstructionData {
                 Self::SET_VALIDATOR_CLIENT_REWARDS_PROPORTION.serialize(writer)?;
                 proportion.serialize(writer)
             }
+            Self::CheckCliVersion {
+                major,
+                minor,
+                patch,
+            } => {
+                Self::CHECK_CLI_VERSION.serialize(writer)?;
+                major.serialize(writer)?;
+                minor.serialize(writer)?;
+                patch.serialize(writer)
+            }
         }
     }
 }
@@ -85,6 +99,16 @@ impl BorshDeserialize for ShredSubscriptionInstructionData {
             Self::SET_VALIDATOR_CLIENT_REWARDS_PROPORTION => {
                 let proportion = u16::deserialize_reader(reader)?;
                 Ok(Self::SetValidatorClientRewardsProportion(proportion))
+            }
+            Self::CHECK_CLI_VERSION => {
+                let major = u32::deserialize_reader(reader)?;
+                let minor = u32::deserialize_reader(reader)?;
+                let patch = u32::deserialize_reader(reader)?;
+                Ok(Self::CheckCliVersion {
+                    major,
+                    minor,
+                    patch,
+                })
             }
             _ => Err(io::Error::new(
                 io::ErrorKind::InvalidData,


### PR DESCRIPTION
## Summary

- Add `CheckCliVersion` instruction variant and accounts to the offchain SDK
- Prepend `CheckCliVersion` to all shreds write transactions (pay, withdraw, validator-client-rewards) with 5,000 CU budget
- Version parser handles `BUILD_VERSION` overrides, `v`-prefixed strings, and pre-release suffixes
- Add `CheckCliVersion` to the ignored instruction match arm in payments history parser

## Testing

- `cargo clippy --workspace -- -D warnings` passes clean
- Corresponding onchain changes in malbeclabs/doublezero-shreds#236

Note: this PR depends on the onchain program deploying the `CheckCliVersion` instruction first. Until then, the instruction will fail on mainnet.