### PR TITLE
solana-cli: add `--withdraw-excess-balance` to `revenue-distribution validator-deposit`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2457,7 +2457,7 @@ dependencies = [
 [[package]]
 name = "doublezero-passport"
 version = "0.2.0"
-source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.3#e4d4edc771338a284bea654c4def2fa8a81129bf"
+source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.4#9823d799635e19ddbdec6d09e03c104f21839516"
 dependencies = [
  "borsh 1.5.7",
  "bytemuck",
@@ -2501,7 +2501,7 @@ dependencies = [
 [[package]]
 name = "doublezero-program-tools"
 version = "0.0.0"
-source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.3#e4d4edc771338a284bea654c4def2fa8a81129bf"
+source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.4#9823d799635e19ddbdec6d09e03c104f21839516"
 dependencies = [
  "bincode 1.3.3",
  "borsh 1.5.7",
@@ -2533,8 +2533,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-revenue-distribution"
-version = "0.3.3"
-source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.3#e4d4edc771338a284bea654c4def2fa8a81129bf"
+version = "0.3.4"
+source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.4#9823d799635e19ddbdec6d09e03c104f21839516"
 dependencies = [
  "borsh 1.5.7",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,15 +95,15 @@ url = "2"
 [workspace.dependencies.doublezero-passport]
 features = ["offchain"]
 git = "https://github.com/doublezerofoundation/doublezero-solana"
-tag = "revenue-distribution/v0.3.3"
+tag = "revenue-distribution/v0.3.4"
 
 [workspace.dependencies.doublezero-program-tools]
 git = "https://github.com/doublezerofoundation/doublezero-solana"
-tag = "revenue-distribution/v0.3.3"
+tag = "revenue-distribution/v0.3.4"
 
 [workspace.dependencies.doublezero-revenue-distribution]
 git = "https://github.com/doublezerofoundation/doublezero-solana"
-tag = "revenue-distribution/v0.3.3"
+tag = "revenue-distribution/v0.3.4"
 
 ### Dependencies found in github.com/malbeclabs/doublezero
 

--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- `shreds`: prepend `CheckCliVersion` instruction to all write transactions (pay, withdraw, validator-client-rewards) for onchain minimum CLI version enforcement
-- `shreds pay`: block duplicate client IP across devices — prevent creating a seat for an IP that already has an active seat on a different device
-- `shreds validator-client-rewards`: add hidden command to set validator client rewards proportion
-- `shreds list`: filter by funder (withdraw-authority) by default, add `--all` flag
+- add `--withdraw-excess-balance` to `revenue-distribution validator-deposit` (#343)
+- `shreds`: prepend `CheckCliVersion` instruction to all write transactions (pay, withdraw, validator-client-rewards) for onchain minimum CLI version enforcement (#342)
+- `shreds list`: filter by funder (withdraw-authority) by default, add `--all` flag (#328)
+- `shreds pay`: block duplicate client IP across devices — prevent creating a seat for an IP that already has an active seat on a different device (#340)
+- `shreds validator-client-rewards`: add hidden command to set validator client rewards proportion (#339)
 
 ## [0.5.0](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.0)
 

--- a/crates/solana-cli/src/command/revenue_distribution/fetch/validator_debts.rs
+++ b/crates/solana-cli/src/command/revenue_distribution/fetch/validator_debts.rs
@@ -130,7 +130,7 @@ async fn try_print_validator_debts_outstanding_table(
     let deposit_balances = deposit_account_infos
         .iter()
         .map(|account_info| {
-            doublezero_solana_client_tools::account::balance(&account_info, &rent_sysvar)
+            doublezero_solana_client_tools::account::balance(account_info, &rent_sysvar)
         })
         .collect::<Vec<_>>();
 

--- a/crates/solana-cli/src/command/revenue_distribution/fetch/validator_debts.rs
+++ b/crates/solana-cli/src/command/revenue_distribution/fetch/validator_debts.rs
@@ -195,7 +195,6 @@ async fn try_print_validator_debts_outstanding_table(
         );
 
         if excess_mode {
-            // TODO: Strictly greater than?
             if total_debt >= deposit_balance {
                 continue;
             }

--- a/crates/solana-cli/src/command/revenue_distribution/fetch/validator_debts.rs
+++ b/crates/solana-cli/src/command/revenue_distribution/fetch/validator_debts.rs
@@ -19,6 +19,7 @@ use solana_sdk::{native_token::LAMPORTS_PER_SOL, pubkey::Pubkey};
 pub enum ValidatorDebtsViewMode {
     Outstanding,
     Node,
+    ExcessBalance,
 }
 
 #[derive(Debug, Args)]
@@ -78,12 +79,13 @@ impl ValidatorDebtsCommand {
         .unzip::<_, _, Vec<_>, Vec<_>>();
 
         match view {
-            ValidatorDebtsViewMode::Outstanding => {
+            ValidatorDebtsViewMode::Outstanding | ValidatorDebtsViewMode::ExcessBalance => {
                 try_print_validator_debts_outstanding_table(
                     &solana_connection,
                     &debt_records,
                     &distributions,
                     node_id.as_ref(),
+                    view == ValidatorDebtsViewMode::ExcessBalance,
                 )
                 .await
             }
@@ -102,6 +104,7 @@ async fn try_print_validator_debts_outstanding_table(
     debt_records: &[BorshRecordAccountData<ComputedSolanaValidatorDebts>],
     distributions: &[ZeroCopyAccountOwnedData<Distribution>],
     node_id: Option<&Pubkey>,
+    excess_mode: bool,
 ) -> Result<()> {
     let node_ids = match node_id {
         Some(node_id) => HashSet::from_iter([*node_id]),
@@ -120,18 +123,32 @@ async fn try_print_validator_debts_outstanding_table(
         .map(|node_id| SolanaValidatorDeposit::find_address(node_id).0)
         .collect::<Vec<_>>();
 
-    let deposit_balances = solana_connection
+    let deposit_account_infos = solana_connection
         .try_fetch_multiple_accounts(&deposit_keys)
-        .await?
-        .into_iter()
+        .await?;
+
+    let deposit_balances = deposit_account_infos
+        .iter()
         .map(|account_info| {
             doublezero_solana_client_tools::account::balance(&account_info, &rent_sysvar)
-        });
+        })
+        .collect::<Vec<_>>();
+
+    let deposit_accounts = deposit_account_infos
+        .into_iter()
+        .map(ZeroCopyAccountOwnedData::<SolanaValidatorDeposit>::try_from)
+        .collect::<Result<Vec<_>>>()?;
 
     let mut outputs = Vec::with_capacity(debt_records.len());
 
-    for (node_id, deposit_balance) in node_ids.into_iter().zip(deposit_balances) {
+    for ((node_id, deposit_balance), deposit_account) in node_ids
+        .into_iter()
+        .zip(deposit_balances)
+        .zip(deposit_accounts)
+    {
         let mut total_debt = 0;
+
+        let mut recorded_written_off_debt = 0;
 
         for (debt_record, distribution) in debt_records.iter().zip(distributions) {
             if debt_record.debts.is_empty() {
@@ -157,6 +174,10 @@ async fn try_print_validator_debts_outstanding_table(
                     false
                 };
 
+                if is_written_off {
+                    recorded_written_off_debt += debt_record.data.debts[index].amount;
+                }
+
                 // If the debt is not processed or if it is processed but
                 // written off, we should include it in the total debt.
                 if !try_is_processed_leaf(processed_leaf_data, index).unwrap() || is_written_off {
@@ -165,19 +186,44 @@ async fn try_print_validator_debts_outstanding_table(
             }
         }
 
-        if deposit_balance >= total_debt {
-            continue;
-        }
+        // Out of paranoia, make sure the debt written in the records equals the
+        // written-off debt amount in the deposit account.
+        anyhow::ensure!(
+            recorded_written_off_debt == deposit_account.written_off_sol_debt,
+            "Recorded written off debt {recorded_written_off_debt} is not equal to deposit balance {}",
+            deposit_account.written_off_sol_debt
+        );
 
-        outputs.push(ValidatorDebtsOutstandingTableRow {
-            node_id,
-            total_amount: format!("{:.9} SOL", total_debt as f64 * 1e-9),
-            deposit_balance: format!("{:.9} SOL", deposit_balance as f64 * 1e-9),
-            note: format!(
-                "{:.9} SOL needed",
-                (total_debt - deposit_balance) as f64 / LAMPORTS_PER_SOL as f64
-            ),
-        });
+        if excess_mode {
+            // TODO: Strictly greater than?
+            if total_debt >= deposit_balance {
+                continue;
+            }
+
+            outputs.push(ValidatorDebtsOutstandingTableRow {
+                node_id,
+                total_amount: format!("{:.9} SOL", total_debt as f64 * 1e-9),
+                deposit_balance: format!("{:.9} SOL", deposit_balance as f64 * 1e-9),
+                note: format!(
+                    "{:.9} SOL in excess",
+                    (deposit_balance - total_debt) as f64 / LAMPORTS_PER_SOL as f64
+                ),
+            });
+        } else {
+            if deposit_balance >= total_debt {
+                continue;
+            }
+
+            outputs.push(ValidatorDebtsOutstandingTableRow {
+                node_id,
+                total_amount: format!("{:.9} SOL", total_debt as f64 * 1e-9),
+                deposit_balance: format!("{:.9} SOL", deposit_balance as f64 * 1e-9),
+                note: format!(
+                    "{:.9} SOL needed",
+                    (total_debt - deposit_balance) as f64 / LAMPORTS_PER_SOL as f64
+                ),
+            });
+        }
     }
 
     outputs.sort_by_key(|row| row.node_id.to_string());

--- a/crates/solana-cli/src/command/revenue_distribution/validator_deposit.rs
+++ b/crates/solana-cli/src/command/revenue_distribution/validator_deposit.rs
@@ -100,10 +100,11 @@ impl ValidatorDepositCommand {
         let wallet = Wallet::try_from(solana_payer_options)?;
         let wallet_key = wallet.pubkey();
 
+        let exclusive_flag_count = u8::from(should_withdraw_excess_balance)
+            + u8::from(should_fund_outstanding_debt)
+            + u8::from(fund_amount_str.is_some());
         ensure!(
-            !should_withdraw_excess_balance
-                || !should_fund_outstanding_debt
-                || fund_amount_str.is_none(),
+            exclusive_flag_count <= 1,
             "Cannot use --withdraw-excess-balance, --fund-outstanding-debt or --fund together"
         );
 

--- a/crates/solana-cli/src/command/revenue_distribution/validator_deposit.rs
+++ b/crates/solana-cli/src/command/revenue_distribution/validator_deposit.rs
@@ -103,7 +103,7 @@ impl ValidatorDepositCommand {
         ensure!(
             !should_withdraw_excess_balance
                 || !should_fund_outstanding_debt
-                || !fund_amount_str.is_some(),
+                || fund_amount_str.is_none(),
             "Cannot use --withdraw-excess-balance, --fund-outstanding-debt or --fund together"
         );
 

--- a/crates/solana-cli/src/command/revenue_distribution/validator_deposit.rs
+++ b/crates/solana-cli/src/command/revenue_distribution/validator_deposit.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, ensure};
+use anyhow::{Context, Result, ensure};
 use clap::Args;
 use doublezero_solana_client_tools::{
     instruction::take_instruction,
@@ -11,7 +11,10 @@ use doublezero_solana_sdk::{
         ID,
         fetch::SolConversionState,
         instruction::{
-            RevenueDistributionInstructionData, account::InitializeSolanaValidatorDepositAccounts,
+            RevenueDistributionInstructionData,
+            account::{
+                InitializeSolanaValidatorDepositAccounts, WithdrawSolanaValidatorDepositAccounts,
+            },
         },
         state::SolanaValidatorDeposit,
         try_is_processed_leaf,
@@ -46,6 +49,19 @@ pub struct ValidatorDepositCommand {
     #[arg(long)]
     fund_outstanding_debt: bool,
 
+    /// Withdraw excess balance from the Solana validator deposit account. This
+    /// argument cannot be used with `--fund` or `--fund-outstanding-debt`.
+    #[arg(long)]
+    withdraw_excess_balance: bool,
+
+    /// The public key of the account that will receive the excess balance. This
+    /// argument is required when `--withdraw-excess-balance` is specified.
+    ///
+    /// NOTE: The keypair invoking the command must be the validator identity
+    /// relevant to the deposit account.
+    #[arg(long, value_name = "PUBKEY")]
+    excess_balance_beneficiary: Option<Pubkey>,
+
     /// Fund with 2Z limited by specified conversion rate for 2Z -> SOL.
     #[arg(long, value_name = "PRICE_LIMIT")]
     convert_2z_limit_price: Option<String>,
@@ -72,6 +88,8 @@ impl ValidatorDepositCommand {
             initialize: mut should_initialize,
             fund: fund_amount_str,
             fund_outstanding_debt: should_fund_outstanding_debt,
+            withdraw_excess_balance: should_withdraw_excess_balance,
+            excess_balance_beneficiary: excess_balance_beneficiary_key,
             convert_2z_limit_price: convert_2z_limit_price_str,
             source_2z_account: source_2z_account_key,
             solana_payer_options,
@@ -81,6 +99,22 @@ impl ValidatorDepositCommand {
 
         let wallet = Wallet::try_from(solana_payer_options)?;
         let wallet_key = wallet.pubkey();
+
+        ensure!(
+            !should_withdraw_excess_balance
+                || !should_fund_outstanding_debt
+                || !fund_amount_str.is_some(),
+            "Cannot use --withdraw-excess-balance, --fund-outstanding-debt or --fund together"
+        );
+
+        if should_withdraw_excess_balance {
+            return try_withdraw_excess_balance(
+                &wallet,
+                &node_id,
+                excess_balance_beneficiary_key.as_ref(),
+            )
+            .await;
+        }
 
         // First check if the Solana validator deposit is already initialized.
         let (deposit_key, deposit, mut deposit_balance) =
@@ -326,4 +360,51 @@ async fn try_compute_outstanding_debt(
         amount: total_debt.saturating_sub(deposit_balance),
         last_solana_epoch,
     })
+}
+
+async fn try_withdraw_excess_balance(
+    wallet: &Wallet,
+    node_id: &Pubkey,
+    excess_balance_beneficiary_key: Option<&Pubkey>,
+) -> Result<()> {
+    ensure!(
+        excess_balance_beneficiary_key.is_none() || wallet.pubkey() == *node_id,
+        "The keypair invoking the command must be the validator identity relevant to the deposit account"
+    );
+
+    let (deposit_key, deposit, deposit_balance) =
+        super::try_fetch_solana_validator_deposit(&wallet.connection, node_id).await?;
+
+    let deposit =
+        deposit.with_context(|| format!("No deposit account found for node ID {node_id}"))?;
+    ensure!(
+        deposit_balance.saturating_sub(deposit.written_off_sol_debt) > 0,
+        "No excess balance found for node ID {node_id}"
+    );
+
+    let mut instructions = vec![
+        try_build_instruction(
+            &ID,
+            WithdrawSolanaValidatorDepositAccounts::new(node_id, excess_balance_beneficiary_key),
+            &RevenueDistributionInstructionData::WithdrawSolanaValidatorDeposit,
+        )?,
+        build_memo_instruction(b"Withdrawn excess balance"),
+        ComputeBudgetInstruction::set_compute_unit_limit(20_000),
+    ];
+
+    if let Some(ref compute_unit_price_ix) = wallet.compute_unit_price_ix {
+        instructions.push(compute_unit_price_ix.clone());
+    }
+
+    let transaction = wallet.new_transaction(&instructions).await?;
+    let tx_sig = wallet.send_or_simulate_transaction(&transaction).await?;
+
+    if let TransactionOutcome::Executed(tx_sig) = tx_sig {
+        println!("Solana validator deposit: {deposit_key}");
+        println!("Withdrawn excess balance: {tx_sig}");
+        println!("Node ID: {node_id}");
+        println!("Withdrawn {:.9} SOL", deposit_balance as f64 * 1e-9);
+    }
+
+    Ok(())
 }

--- a/crates/validator-debt/CHANGELOG.md
+++ b/crates/validator-debt/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fix fetching multiple accounts (#343)
 - update instruction call with optional memo ([#330](https://github.com/doublezerofoundation/doublezero-offchain/pull/330)))
 - fix `fetch validator-debts` record logic ([#327](https://github.com/doublezerofoundation/doublezero-offchain/pull/327))
 - conditionally sweep 2Z based on balance ([#322](https://github.com/doublezerofoundation/doublezero-offchain/pull/322))

--- a/crates/validator-debt/src/rpc.rs
+++ b/crates/validator-debt/src/rpc.rs
@@ -330,11 +330,9 @@ pub async fn try_fetch_debt_records_and_distributions(
         .collect::<Vec<_>>();
 
     let distributions = solana_connection
-        .get_multiple_accounts(&distribution_keys)
+        .try_fetch_multiple_zero_copy_data::<Distribution>(&distribution_keys)
         .await?
-        .iter()
-        .flatten()
-        .filter_map(ZeroCopyAccountOwnedData::<Distribution>::from_account)
+        .into_iter()
         .filter(|distribution| {
             distribution.solana_validator_debt_merkle_root != Default::default()
                 && distribution.is_debt_calculation_finalized()
@@ -356,7 +354,7 @@ pub async fn try_fetch_debt_records_and_distributions(
         .collect::<Vec<_>>();
 
     let debt_records = dz_connection
-        .get_multiple_accounts(&debt_record_keys)
+        .try_fetch_multiple_accounts(&debt_record_keys)
         .await?
         .iter()
         .flatten()

--- a/sh/test_doublezero_solana_fork.sh
+++ b/sh/test_doublezero_solana_fork.sh
@@ -205,6 +205,14 @@ echo "doublezero-solana revenue-distribution fetch validator-debts -ul --node-id
 $CLI_BIN revenue-distribution fetch validator-debts -ul --node-id $NODE_ID --dz-env mainnet-beta
 echo
 
+echo "doublezero-solana revenue-distribution validator-deposit --withdraw-excess-balance -ul -v --node-id $DUMMY_KEY"
+$CLI_BIN revenue-distribution validator-deposit \
+    --withdraw-excess-balance \
+    -ul \
+    -v \
+    --node-id $DUMMY_KEY
+echo
+
 ### Clean up.
 
 echo "rm dummy.json another_payer.json rewards_manager.json " \


### PR DESCRIPTION
## Summary of Changes
- Add `--view excess-balance` to `revenue-distribution fetch validator-debts` command to list all validators who have an excess amount in their deposit accounts.
  - Same functionality to filter by `--node-id`.
- Add `--withdraw-excess-balance` to `revenue-distribution validator-deposit` command to transfer any excess SOL from a validator's deposit account directly to the validator identity.

Also fixes a bug in the `doublezero-solana-validator-debt` crate where >100 accounts fetching was causing an error in fetching records.

## Testing Verification
Added calling `--withdraw-excess-balance` to _test_doublezero_solana_fork.sh_.
