### PR TITLE
solana-cli: uptick crate to v0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-solana-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.1](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.1)
+## [0.5.2](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.2)
 
+- uptick crate to v0.5.2 (#345)
 - uptick crate to v0.5.1 (#344)
 - add `--withdraw-excess-balance` to `revenue-distribution validator-deposit` (#343)
 - `shreds`: prepend `CheckCliVersion` instruction to all write transactions (pay, withdraw, validator-client-rewards) for onchain minimum CLI version enforcement (#342)
+
+## [0.5.1](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.1)
+
 - `shreds list`: filter by funder (withdraw-authority) by default, add `--all` flag (#328)
 - `shreds pay`: block duplicate client IP across devices — prevent creating a seat for an IP that already has an active seat on a different device (#340)
 - `shreds validator-client-rewards`: add hidden command to set validator client rewards proportion (#339)

--- a/crates/solana-cli/Cargo.toml
+++ b/crates/solana-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "doublezero-solana-cli"
 description = "Command line to interact with DoubleZero Solana programs"
-version = "0.5.1"
+version = "0.5.2"
 
 # Workspace inherited keys
 edition.workspace = true


### PR DESCRIPTION
## Summary of Changes
Uptick `doublezero-solana-cli` crate to v0.5.2.

## Testing Verification
N/A
