### PR TITLE
solana-cli: shreds list falls back to all seats when no default keypair

### DIFF
--- a/crates/solana-cli/src/command/shreds/list.rs
+++ b/crates/solana-cli/src/command/shreds/list.rs
@@ -30,7 +30,7 @@ pub struct ListCommand {
 
     /// Filter seats by funder (withdraw authority). Accepts a public key or a
     /// path to a keypair file. When omitted, defaults to the default keypair's
-    /// public key (use --all to show every seat instead).
+    /// public key; if no default keypair is found, shows all seats.
     #[arg(long, short = 'k')]
     funder: Option<String>,
 
@@ -134,8 +134,7 @@ impl ListCommand {
                 Some(keypair.pubkey())
             }
         } else if !self.all {
-            let keypair = try_load_keypair(None)?;
-            Some(keypair.pubkey())
+            try_load_keypair(None).ok().map(|kp| kp.pubkey())
         } else {
             None
         };


### PR DESCRIPTION
Resolves: https://github.com/malbeclabs/infra/issues/998

## Summary
- When no `--all` or `-k` flag is passed, `shreds list` defaults to filtering by the default keypair's public key
- Previously, if no default keypair was found, the command errored out
- Now it gracefully falls back to showing all seats instead of failing

## Lines of Code
| Section | Added | Removed |
|---------|-------|---------|
| SDKs | +2 | -3 |