### PR TITLE
solana-cli: shreds withdraw supports stale seats and --funds-only

### DIFF
--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `shreds withdraw`: allow withdrawing funds from stale seats and add `--funds-only` flag
+
 ## [0.5.2](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.2)
 
 - uptick crate to v0.5.2 (#345)

--- a/crates/solana-cli/src/command/shreds/withdraw.rs
+++ b/crates/solana-cli/src/command/shreds/withdraw.rs
@@ -99,9 +99,9 @@ impl WithdrawCommand {
         // (or --funds-only) skip the request and just close the payment escrow.
         let request_instant_withdrawal = has_active_service && !self.funds_only;
 
-        if !has_active_service && !escrow_exists {
+        if !request_instant_withdrawal && !escrow_exists {
             bail!(
-                "Client seat {client_seat_key} does not have active service and no payment escrow exists"
+                "Client seat {client_seat_key} has no payment escrow to close and no active service to withdraw"
             );
         }
 

--- a/crates/solana-cli/src/command/shreds/withdraw.rs
+++ b/crates/solana-cli/src/command/shreds/withdraw.rs
@@ -20,7 +20,7 @@ use solana_sdk::{compute_budget::ComputeBudgetInstruction, pubkey::Pubkey};
 /*
    doublezero-solana shreds withdraw \
        --device <PUBKEY> | --device-code <CODE> \
-       --client-ip <IP> [--usdc-mint <PUBKEY>] [--refund-token-account <PUBKEY>]
+       --client-ip <IP> [--funds-only] [--usdc-mint <PUBKEY>] [--refund-token-account <PUBKEY>]
 */
 
 #[derive(Debug, Args)]
@@ -30,6 +30,10 @@ pub struct WithdrawCommand {
     /// Client IPv4 address
     #[arg(long)]
     client_ip: Ipv4Addr,
+    /// Only close the payment escrow and withdraw USDC funds, without
+    /// requesting an instant seat withdrawal.
+    #[arg(long)]
+    funds_only: bool,
     /// USDC mint (auto-detected from network: mainnet or development)
     #[arg(long, hide = true)]
     usdc_mint: Option<Pubkey>,
@@ -82,7 +86,6 @@ impl WithdrawCommand {
         // Pop in reverse order: escrow (index 1) first, then seat (index 0).
         let escrow_exists = accounts.pop().flatten().is_some();
 
-        // The seat must exist and be active in the current epoch to withdraw.
         let seat_data = accounts
             .pop()
             .flatten()
@@ -90,19 +93,29 @@ impl WithdrawCommand {
         let (_, _, _, _, active_epoch) = state::parse_client_seat(&seat_data.data)
             .with_context(|| format!("Failed to parse client seat {client_seat_key}"))?;
         let current_epoch = wallet.connection.get_epoch_info().await?.epoch;
-        if active_epoch < current_epoch {
-            bail!("Client seat {client_seat_key} does not have active service");
+        let has_active_service = active_epoch >= current_epoch;
+
+        // Only request instant withdrawal when the seat is active. Stale seats
+        // (or --funds-only) skip the request and just close the payment escrow.
+        let request_instant_withdrawal = has_active_service && !self.funds_only;
+
+        if !has_active_service && !escrow_exists {
+            bail!(
+                "Client seat {client_seat_key} does not have active service and no payment escrow exists"
+            );
         }
 
         let mut instructions = vec![super::build_check_cli_version_instruction()?];
         let mut compute_unit_limit = 5_000 + 30_000;
 
-        instructions.push(try_build_instruction(
-            &ID,
-            RequestInstantSeatWithdrawalAccounts::new(&device, client_ip_bits, &wallet_key),
-            &ShredSubscriptionInstructionData::RequestInstantSeatWithdrawal,
-        )?);
-        compute_unit_limit += 50_000;
+        if request_instant_withdrawal {
+            instructions.push(try_build_instruction(
+                &ID,
+                RequestInstantSeatWithdrawalAccounts::new(&device, client_ip_bits, &wallet_key),
+                &ShredSubscriptionInstructionData::RequestInstantSeatWithdrawal,
+            )?);
+            compute_unit_limit += 50_000;
+        }
 
         if escrow_exists {
             instructions.push(try_build_instruction(


### PR DESCRIPTION
## Summary
- Previously `shreds withdraw` required the seat to have active service, leaving users with stale seats unable to recover USDC from their payment escrow
- The CLI now auto-detects stale seats and skips `RequestInstantSeatWithdrawal`, closing only the payment escrow to return funds
- Adds `--funds-only` flag to explicitly skip the instant withdrawal request even when the seat is active

## Lines of Code
| Section | Added | Removed |
|---------|-------|---------|
| SDKs | +25 | -10 |