### PR TITLE
solana-cli: uptick crate to v0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-solana-cli"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- `shreds withdraw`: allow withdrawing funds from stale seats and add `--funds-only` flag
+## [0.5.3](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.3)
+
+- uptick crate to v0.5.3 (#348)
+- `shreds withdraw`: allow withdrawing funds from stale seats and add `--funds-only` flag (#347)
+- `shreds list`: fall back to showing all seats when no default keypair is found (#346)
 
 ## [0.5.2](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.2)
 

--- a/crates/solana-cli/Cargo.toml
+++ b/crates/solana-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "doublezero-solana-cli"
 description = "Command line to interact with DoubleZero Solana programs"
-version = "0.5.2"
+version = "0.5.3"
 
 # Workspace inherited keys
 edition.workspace = true


### PR DESCRIPTION
## Summary of Changes
Uptick `doublezero-solana-cli` crate to v0.5.3.

Includes:
- `shreds list`: fall back to showing all seats when no default keypair is found (#346)
- `shreds withdraw`: allow withdrawing funds from stale seats and add `--funds-only` flag (#347)

## Testing Verification
N/A