### PR TITLE
sentinel: wire up multicast publisher with validator client filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,7 +1371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.4",
- "hashbrown 0.13.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2350,8 +2350,8 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "doublezero-config"
-version = "0.10.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787#f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+version = "0.18.0"
+source = "git+https://github.com/malbeclabs/doublezero?rev=ebd28bdf0245724615d2699e0c8d85aec784f2b4#ebd28bdf0245724615d2699e0c8d85aec784f2b4"
 dependencies = [
  "eyre",
  "serde",
@@ -2414,8 +2414,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-geolocation"
-version = "0.10.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787#f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+version = "0.18.0"
+source = "git+https://github.com/malbeclabs/doublezero?rev=ebd28bdf0245724615d2699e0c8d85aec784f2b4#ebd28bdf0245724615d2699e0c8d85aec784f2b4"
 dependencies = [
  "borsh 1.5.7",
  "borsh-incremental",
@@ -2445,6 +2445,7 @@ dependencies = [
  "doublezero-program-tools",
  "doublezero-record",
  "doublezero-revenue-distribution",
+ "doublezero-sentinel",
  "doublezero-serviceability",
  "doublezero_sdk",
  "metrics",
@@ -2462,7 +2463,7 @@ dependencies = [
  "solana-transaction-status-client-types",
  "spl-associated-token-account-interface",
  "spl-token-interface",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.17",
  "tokio",
  "tokio-util",
@@ -2505,8 +2506,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-program-common"
-version = "0.10.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787#f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+version = "0.18.0"
+source = "git+https://github.com/malbeclabs/doublezero?rev=ebd28bdf0245724615d2699e0c8d85aec784f2b4#ebd28bdf0245724615d2699e0c8d85aec784f2b4"
 dependencies = [
  "borsh 1.5.7",
  "byteorder",
@@ -2541,8 +2542,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-record"
-version = "0.10.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787#f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+version = "0.18.0"
+source = "git+https://github.com/malbeclabs/doublezero?rev=ebd28bdf0245724615d2699e0c8d85aec784f2b4#ebd28bdf0245724615d2699e0c8d85aec784f2b4"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -2600,9 +2601,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "doublezero-sentinel"
+version = "0.0.1"
+source = "git+https://github.com/malbeclabs/doublezero?rev=ebd28bdf0245724615d2699e0c8d85aec784f2b4#ebd28bdf0245724615d2699e0c8d85aec784f2b4"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "backon",
+ "borsh 1.5.7",
+ "clap",
+ "doublezero-config",
+ "doublezero-serviceability",
+ "doublezero-telemetry",
+ "doublezero_sdk",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "solana-account-decoder",
+ "solana-client",
+ "solana-sdk",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "tabled",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "doublezero-serviceability"
-version = "0.10.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787#f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+version = "0.18.0"
+source = "git+https://github.com/malbeclabs/doublezero?rev=ebd28bdf0245724615d2699e0c8d85aec784f2b4#ebd28bdf0245724615d2699e0c8d85aec784f2b4"
 dependencies = [
  "bitflags",
  "borsh 1.5.7",
@@ -2807,8 +2841,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-telemetry"
-version = "0.10.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787#f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+version = "0.18.0"
+source = "git+https://github.com/malbeclabs/doublezero?rev=ebd28bdf0245724615d2699e0c8d85aec784f2b4#ebd28bdf0245724615d2699e0c8d85aec784f2b4"
 dependencies = [
  "borsh 1.5.7",
  "borsh-incremental",
@@ -2822,8 +2856,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero_sdk"
-version = "0.10.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787#f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+version = "0.18.0"
+source = "git+https://github.com/malbeclabs/doublezero?rev=ebd28bdf0245724615d2699e0c8d85aec784f2b4#ebd28bdf0245724615d2699e0c8d85aec784f2b4"
 dependencies = [
  "async-trait",
  "backon",
@@ -4605,7 +4639,7 @@ dependencies = [
 [[package]]
 name = "network-shapley"
 version = "0.1.0"
-source = "git+https://github.com/doublezerofoundation/network-shapley-rs?tag=v0.5.0#932b40eba7b13ca1310be351eb2d71b3e3107538"
+source = "git+https://github.com/doublezerofoundation/network-shapley-rs?tag=v0.4.0#579d07d9cdde98a055d8b7c51fb46ab2fd9cb935"
 dependencies = [
  "borsh 1.5.7",
  "csv",
@@ -9160,11 +9194,30 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.110",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,33 +109,37 @@ tag = "revenue-distribution/v0.3.4"
 
 [workspace.dependencies.doublezero-program-common]
 git = "https://github.com/malbeclabs/doublezero"
-rev="f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+rev = "ebd28bdf0245724615d2699e0c8d85aec784f2b4"
 
 [workspace.dependencies.doublezero-record]
 features = ["no-entrypoint"]
 git = "https://github.com/malbeclabs/doublezero"
-rev="f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+rev = "ebd28bdf0245724615d2699e0c8d85aec784f2b4"
 
 [workspace.dependencies.doublezero_sdk]
 git = "https://github.com/malbeclabs/doublezero"
-rev="f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+rev = "ebd28bdf0245724615d2699e0c8d85aec784f2b4"
 
 [workspace.dependencies.doublezero-serviceability]
 features = ["no-entrypoint", "serde"]
 git = "https://github.com/malbeclabs/doublezero"
-rev="f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+rev = "ebd28bdf0245724615d2699e0c8d85aec784f2b4"
+
+[workspace.dependencies.doublezero-sentinel]
+git = "https://github.com/malbeclabs/doublezero"
+rev = "ebd28bdf0245724615d2699e0c8d85aec784f2b4"
 
 [workspace.dependencies.doublezero-telemetry]
 features = ["no-entrypoint", "serde"]
 git = "https://github.com/malbeclabs/doublezero"
-rev="f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+rev = "ebd28bdf0245724615d2699e0c8d85aec784f2b4"
 
 ### Other git dependencies
 
 [workspace.dependencies.network-shapley]
 features = ["serde", "borsh"]
 git = "https://github.com/doublezerofoundation/network-shapley-rs"
-tag = "v0.5.0"
+tag = "v0.4.0"
 
 ### Local dependencies
 

--- a/crates/contributor-rewards/tests/testnet_snapshot.json
+++ b/crates/contributor-rewards/tests/testnet_snapshot.json
@@ -996,7 +996,9 @@
         "side_a_iface_name": "Switch1/1/1.1003",
         "side_z_iface_name": "Switch1/1/1.1003",
         "link_health": "ReadyForService",
-        "desired_status": "Activated"
+        "desired_status": "Activated",
+        "link_topologies": [],
+        "link_flags": 0
       },
       "6PWVQE6pqbpwcU4pn7UvRoEEG1dpa2nQwbD3DLR4AkRT": {
         "account_type": "Link",
@@ -1019,7 +1021,9 @@
         "side_a_iface_name": "Switch1/1/1.1006",
         "side_z_iface_name": "Switch1/1/1.1006",
         "link_health": "ReadyForService",
-        "desired_status": "Activated"
+        "desired_status": "Activated",
+        "link_topologies": [],
+        "link_flags": 0
       },
       "9BPmBzZSBDUkRVYWAbEDmDxqAaCHFQFCymxLguiz2drj": {
         "account_type": "Link",
@@ -1042,7 +1046,9 @@
         "side_a_iface_name": "Switch1/1/1.1001",
         "side_z_iface_name": "Switch1/1/1.1001",
         "link_health": "ReadyForService",
-        "desired_status": "Activated"
+        "desired_status": "Activated",
+        "link_topologies": [],
+        "link_flags": 0
       },
       "9WAHrNe8R8X7TaAx7Ge7bowExDtjD2M1nbVNNxXDgnGg": {
         "account_type": "Link",
@@ -1065,7 +1071,9 @@
         "side_a_iface_name": "Switch1/1/1.1005",
         "side_z_iface_name": "Switch1/1/1.1005",
         "link_health": "ReadyForService",
-        "desired_status": "Activated"
+        "desired_status": "Activated",
+        "link_topologies": [],
+        "link_flags": 0
       },
       "9kHVMSBtRs75mpchpDviP2dihQ32nTqoEPb73shn4DU5": {
         "account_type": "Link",
@@ -1088,7 +1096,9 @@
         "side_a_iface_name": "Switch1/11/1",
         "side_z_iface_name": "Switch1/5/1",
         "link_health": "ReadyForService",
-        "desired_status": "Activated"
+        "desired_status": "Activated",
+        "link_topologies": [],
+        "link_flags": 0
       },
       "AWHkNcwF7PSNCJq4vgypxuAYfyeyHTWMySGefSN7VpFn": {
         "account_type": "Link",
@@ -1111,7 +1121,9 @@
         "side_a_iface_name": "Switch1/1/1.1004",
         "side_z_iface_name": "Switch1/1/1.1004",
         "link_health": "ReadyForService",
-        "desired_status": "Activated"
+        "desired_status": "Activated",
+        "link_topologies": [],
+        "link_flags": 0
       },
       "As7SQm9RggEi1Bp6hpfHMC5TETushYgR7uWbykMZkt4w": {
         "account_type": "Link",
@@ -1134,7 +1146,9 @@
         "side_a_iface_name": "Switch1/1/1.1000",
         "side_z_iface_name": "Switch1/1/1.1000",
         "link_health": "ReadyForService",
-        "desired_status": "Activated"
+        "desired_status": "Activated",
+        "link_topologies": [],
+        "link_flags": 0
       },
       "HhnwWoUM1Yw8X7RGWsvG7jHLrBfzzLMdfndsLUWcHPrT": {
         "account_type": "Link",
@@ -1157,7 +1171,9 @@
         "side_a_iface_name": "Switch1/1/1",
         "side_z_iface_name": "Vlan4001",
         "link_health": "ReadyForService",
-        "desired_status": "Activated"
+        "desired_status": "Activated",
+        "link_topologies": [],
+        "link_flags": 0
       },
       "YnBTcwD87rvh2zpor9PchchUo28xtgba7w88F16VhZK": {
         "account_type": "Link",
@@ -1180,7 +1196,9 @@
         "side_a_iface_name": "Switch1/1/1.1002",
         "side_z_iface_name": "Switch1/1/1.1002",
         "link_health": "ReadyForService",
-        "desired_status": "Activated"
+        "desired_status": "Activated",
+        "link_topologies": [],
+        "link_flags": 0
       }
     },
     "users": {
@@ -1201,7 +1219,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "ciTyjzN9iyobidMycjyqRRM7vXAHXkFzH3m8vEr6cQj",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "12jooTcob13HLka1BJq6cP249qXde5CRne1FKeUTMeXp": {
         "account_type": "User",
@@ -1220,7 +1242,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "1P5R6bhrzncYnu1U2gtPCKSP8DVRTX6EKESSHnpk8Ek": {
         "account_type": "User",
@@ -1239,7 +1265,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "21QP3y3ieZ5kqQ4usrnX9SDJj7mo79DbdYbMti3r5V6K": {
         "account_type": "User",
@@ -1258,7 +1288,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "6dtVKjb6vRwNAekki2FXhKv8WTNzQ3xW6HWMCNWqtoDy",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "21hj65uwj1r1YH8VtoSXBF3YeBf9dp5S3ofNC9xzxucp": {
         "account_type": "User",
@@ -1277,7 +1311,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "25ePX7ChoG5j9KgdMax1av4Fk4m3HKmw5bD3fZNzkvsa": {
         "account_type": "User",
@@ -1296,7 +1334,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "EN5F2BU5juUEWr9zRNNqKuQMi9zBUY1YLPHV5EyMrvnW",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "27jtqG5KSZ3wPpcUS5ZY53noyF1io8JmfiCLAb8AMSZY": {
         "account_type": "User",
@@ -1315,7 +1357,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "E4397FTJ4B6m1MK6Gm1BovBKShjVe5QttJ3uXxTBjtSV",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2BW2KSM1R8PDq4zQHZYv276L27D2UKAWJEc1GoAhNCoj": {
         "account_type": "User",
@@ -1334,7 +1380,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "rapXHroUoGG3KvZ3qwjvGMdA7siWXwXpiNC1bYarvSC",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2CeafPVBjNYe8R3yusKU3Gys1t1XozXfs6FRyPypbugV": {
         "account_type": "User",
@@ -1353,7 +1403,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2DNYqVnz1nv1NWmjZnF9v2rBBjwN42sXbnS6RYkgjUxU": {
         "account_type": "User",
@@ -1372,7 +1426,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "BPKAfGkkzF5u1QRjjB1nWYYbPMUCMPJe1xZPmwEMNMCT",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2E9xb1DEU9wQvzyUhNTipH5ckmFDL79VP8mvvT57q6pU": {
         "account_type": "User",
@@ -1391,7 +1449,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "CeC95ByA5rd3cFELBgK5nx2hB8o7FynrB2ciNNwHYEib",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2GqPAY8cAs4RJn2yopbG7aGvCvwXSyXR1yqeWHFbwiER": {
         "account_type": "User",
@@ -1410,7 +1472,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2HMPpihcmgiYLVpVKBNfc1GG7P6nG5KVwkJNRehwgwVM": {
         "account_type": "User",
@@ -1429,7 +1495,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2JXEzQ5WkMUrHGnDsUgsrgp9LyPkxssEpHyJmioMNcki": {
         "account_type": "User",
@@ -1448,7 +1518,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "6122X5K3mo8QMwXZW6wnP2n1j2wQoa1Ks21Ckwj7L6st",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2MDmTJLRqYMBFiustC39CDedGS5qRG2QEkvKVK4dFgRe": {
         "account_type": "User",
@@ -1467,7 +1541,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2NSxuUx4X9zkPEGt4Fbij8jEJADYs8bSdBKjUzzqoXsm": {
         "account_type": "User",
@@ -1486,7 +1564,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "A963nwma1r6tr6VgASiHgj9VKmvXvbFeZHoMW6XT1aiQ",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2PhkrMVHAe6jvNQLky6N8bKvJGh2WyGGbbWKUXvir6BG": {
         "account_type": "User",
@@ -1505,7 +1587,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "huinBRP3muBuqZLMW8ARjdn4mBnEmFFcxiBzrkQz553",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2RHySNikH9pD1rz7gMZ7diw2U89EjfY7UojFohfzhoXP": {
         "account_type": "User",
@@ -1524,7 +1610,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "DtY5Bzxd75iWQRvKwM2xLUxqwLT1RRoeNwmVvgS2JANA",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2Ti4H1et5pnmpw93utbq6np9uZmdozKGHmUty4YvUGUF": {
         "account_type": "User",
@@ -1543,7 +1633,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "3s97yjq2MhoPVPC3U9VeE3Z5S643Pweovg88ysvrQPw5",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2VCgEDiQvRaNiWNgz8HghdQ8byqU9AEYL2PkoFJPSfS9": {
         "account_type": "User",
@@ -1562,7 +1656,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2ZhEdHajXanEiwgXAK4RMrCdn81w6iBngiSvmJGjSSXe": {
         "account_type": "User",
@@ -1581,7 +1679,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2cwmhPnRTDZxAuAWvstb9EfVDopSaseczHvmor9jqWaJ": {
         "account_type": "User",
@@ -1600,7 +1702,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2ddAuVZYhgFAE1pHubcVpZ8aK6Vca2zpopWy6PDo7bCR": {
         "account_type": "User",
@@ -1619,7 +1725,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "SP9K2c8Z1aaQaqdQgC6hZMJ5UCTTnE76XNYVse7H94b",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2di4ndmXvWBRbaA3oAb4WZdRdFoKMp5BizbNQZMhNSRu": {
         "account_type": "User",
@@ -1638,7 +1748,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "DiveRaPKviyDnQyiiMFdV4rujsCBJzMNvPjKfvGNLGvL",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2drzCuNXWXH7omMwHaEASkdNVjo2B7L6u3gvMd9H3Whe": {
         "account_type": "User",
@@ -1657,7 +1771,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2ei723aANyKXeX5U4zxEyBdBKdkguSrUxqY4KhxZrMAb": {
         "account_type": "User",
@@ -1676,7 +1794,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2mbuq2KpGnczboiD4gV3CFPvcmWkos9UBVvmQnMKDbMH": {
         "account_type": "User",
@@ -1695,7 +1817,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "FnRqe316RrxVBv85EzMgcuWaVLZYYuyEq9znJnSZAu55",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2oLhjYacfF62pn4PPWEgSKKn7c19SErSU7YsyvPxgD9q": {
         "account_type": "User",
@@ -1714,7 +1840,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "CHED86J97RCtt8HxhNxvUSQWPqFsiftNpWWQd9HZvqvw",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2prjSpKYzWDs7f8sEZjt4ueX1ny9Azj3LxSy5tSFeUPY": {
         "account_type": "User",
@@ -1733,7 +1863,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "Pid6HQnMCFb9izqX9i7X6ePdUPieGmjHoPxC1Jfooix",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2ptHYNMxREfEjMVc4m9HgwF4cN9ZtMcSuqZaijTcpewa": {
         "account_type": "User",
@@ -1752,7 +1886,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "DTELykegBxxEn9c15GbH1zbYFr9CFd8VHQnhTGfz5JLb",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2pvMni476EVxVETM3WkW3NRV1m7uMtxui5X3byve2P6h": {
         "account_type": "User",
@@ -1771,7 +1909,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "GS7tvhfiU36vp8q2d92buz3dgENidvA3bWNpRDFcvnR2",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2q79gbbaVguEaxfFWZ9tf2JvgfTYAWsF5jpKD1C8mLBv": {
         "account_type": "User",
@@ -1790,7 +1932,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2snTWTepW3xXDMYRz5s4yvR6bJDtyrDgPGV1snAHupxi": {
         "account_type": "User",
@@ -1809,7 +1955,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2t8Wz3BQj7XgwoJnwdfdG2HUNJJnjyYotWs1gSBbHbLZ": {
         "account_type": "User",
@@ -1828,7 +1978,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2uAG6B3X2kq9MjNjt6SJbd3TjG7XMrJtnc5Dtah3Pz5Y": {
         "account_type": "User",
@@ -1847,7 +2001,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2uXP9qntqnBSYt6vBmjwRVrxhhQUN5SSJEb9ZveiD3V8": {
         "account_type": "User",
@@ -1866,7 +2024,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "2xdfGVkEwPxTVXkKc77pjrek7JZB8d22in5DXhcuJ97M": {
         "account_type": "User",
@@ -1885,7 +2047,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "7Nu9ckgtjobZ3MkbadGFKEvRymYuah9HmcxiUJKMM9NB",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "32X2h6L3CNrfte6e8WYvcMnUZNwSuanZC6wh4wzTpFFD": {
         "account_type": "User",
@@ -1904,7 +2070,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "32bReWPrR1cEwU6zANAPg3z7kgczZ38ukGs9brztdYNj": {
         "account_type": "User",
@@ -1923,7 +2093,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "34gavgYK35Y4CyZhEY4vUp5vxAmbgr7F5ZYnWBWibs3U": {
         "account_type": "User",
@@ -1942,7 +2116,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "mrgn4sJJu5GBa5wbKyjuASzhyCifvcedGoLtpKjB3Wf",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "35174riqgEScpAQDK3uDsgmk9YNuHXc8DpqKRHQtPXAU": {
         "account_type": "User",
@@ -1961,7 +2139,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "36D2oEBRqrQsPerh2Y6RXaUWnQ9WPK27qDEtjEFJXktW": {
         "account_type": "User",
@@ -1980,7 +2162,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "meshRrDTME9cL2FSQ9E56EncfkZ7vL8apwcCFsw3o6Y",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "39UK9WxyKRuALdBywPo2QvfLqLgHsnmZC7DcuQDMrwWW": {
         "account_type": "User",
@@ -1999,7 +2185,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "GQqxGEmi6aMBZtcfmfmC5Jgx33X57ksvNYoo8bMH52T9",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "39XNZxWfrcnkuvWJyZnhKz8C29eQ2iageFJegLjQwsrA": {
         "account_type": "User",
@@ -2018,7 +2208,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3BF4b2QRSwnqGnaYfY6tzGHsPLT8g5MdeF2UuyUm15zi": {
         "account_type": "User",
@@ -2037,7 +2231,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "SscQkTYV2BFQYGGffAmTzvefrFrw6z9GNYiWHstVZ77",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3BRFqt9R5TSWbYWYnNXCueZT14oDpT6De51mqYHjBYaL": {
         "account_type": "User",
@@ -2056,7 +2254,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3DJsizFTcskUNWqnfLwmF89Ep9v5EGM3RJH1LYLyBDbg": {
         "account_type": "User",
@@ -2075,7 +2277,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3DnmLt3VdQMG4hk1nWJWAq8DoQuktKHmi2dQn7cZUcEd": {
         "account_type": "User",
@@ -2094,7 +2300,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3FhJUGyMDCWTTMLMMN9DmhJnUZtepxgXLLzCyYXnTWZ5": {
         "account_type": "User",
@@ -2113,7 +2323,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "mrgn28BhocwdAUEenen3Sw2MR9cPKDpLkDvzDdR7DBD",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3HvRakNUKvuXtWJWK8Dd9E8bX2dQkECs1LByTMsHdfRV": {
         "account_type": "User",
@@ -2132,7 +2346,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3JBrcfwGarRBRWpp5cB6D15eEXWbvnfZXYLmNx4HZ24V": {
         "account_type": "User",
@@ -2151,7 +2369,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3LDwDDFbPLGf384DBTr8HYsBFPdLVW33PAAQ1zcWUMuC": {
         "account_type": "User",
@@ -2170,7 +2392,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3PARqM9kcWtAuNJhuzKctGBBWjQYLFcPQ68ZtyDsmsBL": {
         "account_type": "User",
@@ -2189,7 +2415,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "FJN8ryNvkm3QAQufsjJmJ9eGPpK1D8hG4MawATqZfFhx",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3VMoo6wmDxnNZJv82vNtzgzK8RdFzgJyxMxQRfAZHZzk": {
         "account_type": "User",
@@ -2208,7 +2438,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3WxGJGfswE5Kcc4CouWw64UKG5YP5sdAHnZ4sTkrLigU": {
         "account_type": "User",
@@ -2227,7 +2461,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3XQ96MFP3UT4CFdnEhpMezntj2fCYvgnHCxTLcFn97t1": {
         "account_type": "User",
@@ -2246,7 +2484,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "DqBvkYXi7HjdaKz78yakiDsaGuq1BKrQi3Z5JV6STctz",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3ZAmqrrDJEGdDFQXqz9RWMhj9ftCb8VK4u465naaKAKj": {
         "account_type": "User",
@@ -2265,7 +2507,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "Ste1115xFGdAYK5jaWA3dEFcUc1S5jEbVvD8e327zty",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3aFPbNqX1EVQkF8qmdK1a8VE9g5JuGrt63jkvCxukGgJ": {
         "account_type": "User",
@@ -2284,7 +2530,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3aGiQwaLnwk7btLUZyUurxQUukvVZy6PF13Zxpz1oUW6": {
         "account_type": "User",
@@ -2303,7 +2553,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3bJx4qZ5FWYps7NaRwGQHUSnvTQNfNfaT38faz4odYAN": {
         "account_type": "User",
@@ -2322,7 +2576,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3bKVpMuCWiPwxnT3SAFJh7fX4GYo2Fegtxbt9Hspi6yg": {
         "account_type": "User",
@@ -2341,7 +2599,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "CBUGET5PnvLc3HvEeFYj64iTvdKhYV6pujTPDdDh785K",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3dbW7NLqubRb1hYADPJkTrcSovzs6jgxadfHQusDnqqZ": {
         "account_type": "User",
@@ -2360,7 +2622,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "6xFDLX751L7H9d5fQT9sf2SM5RWWE9LDgqz25pPDbWoJ",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3eB1ZqNFbBEREZzfx7hPYusE3GTvMKm1tBf7n7eipbDx": {
         "account_type": "User",
@@ -2379,7 +2645,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3ej55kGMPYKJzpQ9XkCoN9Nh8V9ukemYmsf6tawA2tpu": {
         "account_type": "User",
@@ -2398,7 +2668,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3jGZmYHP11WEYPtyTp8tiWo7oba1cJEkFThFCQf7HpcJ": {
         "account_type": "User",
@@ -2417,7 +2691,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "FugJZepeGfh1Ruunhep19JC4F3Hr2FL3oKUMezoK8ajp",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3opRaUTTyMTNj9cp3CJE6vpj16CCxgbhMCKqEiuxCtMw": {
         "account_type": "User",
@@ -2436,7 +2714,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3xhKxNf7GUqVHWF5LqrQbpzTZT5rj6D75KQFyFCHiZSi": {
         "account_type": "User",
@@ -2455,7 +2737,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "3z1RdPfKQK82Fdkz55BHm1N2uaLMzySscV47pWaEzJsn": {
         "account_type": "User",
@@ -2474,7 +2760,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "GK1VfMARYQh3JTq54VB32CY6vCpw1cpbeqDjr82usHGm",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "42MYYG4e9Jy8pf4jmppPcDowyXKKVzcZNwkwWg1rPxeA": {
         "account_type": "User",
@@ -2493,7 +2783,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "43NPYGDB6J5nzag4D27gDo9DRRniQfspjEphJFfXDe36": {
         "account_type": "User",
@@ -2512,7 +2806,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "dzBhD4wikyy7xqwiJvT49gdrKqWVjfs9M6cTssmRX8Y",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "43xJgFCrP2HmSHpaCqXc5u6UDgBUQDvMAWqxi8rvA9qT": {
         "account_type": "User",
@@ -2531,7 +2829,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "3PqzpBbdozpuqLPDBF2j29gGGmC2TSyzujABFQXhKM9E",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "44LbqfACC8dJkPMiE9A9x84CaMQnno3C6UsAdkFaneUB": {
         "account_type": "User",
@@ -2550,7 +2852,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "8Zh5A5Hs6bJFAyWrLGMaF2VEUVbXFANtfuw7824Hd5XV",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "48cSyoZ4fXxgssgZYBQqD6DTCkSvpqyipdaYCouafoDA": {
         "account_type": "User",
@@ -2569,7 +2875,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "48zfhFs1Dt7vEQWJSZbA51PcGmvHuTmLnfkKanMSLWCn": {
         "account_type": "User",
@@ -2588,7 +2898,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "G52Uke6Ss5FHWtZqDX75Yy3SvBFLqwsWBUiGopergvqG",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "498rCXiuHiNSwbGCBiAyTRBsAgb5SPdvKgGGJ8bxTXQ2": {
         "account_type": "User",
@@ -2607,7 +2921,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "4BSfS92HouiYiFca4KmccDcizm2dEtpkQX6WHDzeURDT": {
         "account_type": "User",
@@ -2626,7 +2944,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "4BxUrhfuRgwKvrjf8GB6DMh66EgJL2rZq1BhWuG6Fuvy": {
         "account_type": "User",
@@ -2645,7 +2967,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "4E1XQkYcLvi4gzWtBNu4wiMi1qv7RVSQELisb59HD5Hq": {
         "account_type": "User",
@@ -2664,7 +2990,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "4Gpsye4KFNKnX9PZ6bPFaRRiQ7UzrSrfmJ53HVQjMVpf": {
         "account_type": "User",
@@ -2683,7 +3013,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "5hV7UqAFiW3HtP6CjLNB2NYaYPfzt8N1S6NQsToZTHBq",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "4MXUpYRobnJdpNJJk5ssXPhhd56BBDPsqniZ3Tw4t2xK": {
         "account_type": "User",
@@ -2702,7 +3036,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "pidrcoD3t88h8MzJU2EACHL8A6iMoQqwueXPA8KLwUS",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "4SC6nQTXbhVMnhXRaM4zqTf9VYxk5dtAHQKDn7hH9TQb": {
         "account_type": "User",
@@ -2721,7 +3059,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "4bCdLPBiQdXANimXUyis6D9exmNXwTDtj26qRwR8K65P": {
         "account_type": "User",
@@ -2740,7 +3082,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "4cKcqpxujXgkdCTk5TVeNiQYZuBfw6xqPqmPRx5WtEYo": {
         "account_type": "User",
@@ -2759,7 +3105,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "hnhCMmnrmod4rcyc3QRKkLEC9XnPTvYJ2gBvjgFiV4o",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "4ep6nJGcS4X8PzcrCv9xJ4vdwdb94BeApisgrxCFDjWA": {
         "account_type": "User",
@@ -2778,7 +3128,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "4fekFsVYdgLiEpA1nxTzSWPMJN19faRYX2iE5ZD9FLaY": {
         "account_type": "User",
@@ -2797,7 +3151,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "faiCpbit1D1SZYysWiKXaDRo2JHCoKyD3zeGEVTWsxQ",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "4gXiQP5CPrkucETYR2tmRhg8B5TYkYHJSyv7PZXef4MT": {
         "account_type": "User",
@@ -2816,7 +3174,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "D3htsc6iRQJLqCNWcC2xcZgUuvcd1JT8zoYNqraNcTQz",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "4jKoZr5dBd3u1nLoVMw5gTJAxX9GQS1MTPmLyV1qRipr": {
         "account_type": "User",
@@ -2835,7 +3197,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "4s9tGUT17Ghh7NaWsRBHkFq5ZxS8bw49oyT2zSwfDvzm": {
         "account_type": "User",
@@ -2854,7 +3220,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "FJN8ryNvkm3QAQufsjJmJ9eGPpK1D8hG4MawATqZfFhx",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "4soouq1KtRFkXAhiXwS4h9ZZUF36nNXyD9MjF2yLxdSu": {
         "account_type": "User",
@@ -2873,7 +3243,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "4y4Vk4nm4yyzJHmnqwRGFFkkML9hGNmKjtRCkuG1PyZA": {
         "account_type": "User",
@@ -2892,7 +3266,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "9srVyMfpuqGZjTBAZTdStaVEvbaBdx8rNf7stSSr7CUn",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "4zModDPLoYuYzu6fELrwHaMMdd9RyHKyGDfmEnWqC9eg": {
         "account_type": "User",
@@ -2911,7 +3289,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "Ccw4n1JNzcjdEUTYorfZPATWHfmBKV7BHnJ8YDyzqh5s",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "53kVJxyEzohaheTZkxp49s7PNhda1jV8D3ojJWFBvSYZ": {
         "account_type": "User",
@@ -2930,7 +3312,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "54NE95J2kfzk7giaWG12yMigfdrd6QjTzCfefTwBgLnB": {
         "account_type": "User",
@@ -2949,7 +3335,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "D8kuk3qEiVBGwYkuMGKfBDwuRi6jjRkzjAZg45fdaRLx",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "56ogghoLMQequTdi8h9u8Wt7hNwg9noo3YdHrzJW6hcV": {
         "account_type": "User",
@@ -2968,7 +3358,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "RoYLttggWwa2st3KAGEjnPhsq4NPD5QwaNVyyR8pTz4",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "57GZGL3q3Fv6WHKK88SszBPruF6vA7ZNSWYyt7QX4DqP": {
         "account_type": "User",
@@ -2987,7 +3381,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "dmycoyQrZsMbW3xUtAUkRVTQVDUsBMbjruvmoX5b9v6",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5Cayr8C9Rc13zcMxrtRg4ZpZMjj4yLperot4oRtd2n6L": {
         "account_type": "User",
@@ -3006,7 +3404,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5DewKiW35uzN5QjBFT6A5cK1PGZDfWgpz4sbicAD3vRw": {
         "account_type": "User",
@@ -3025,7 +3427,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5GBq8segS8iQCR3EV7umibwaGsP5Qeu7mJRkZoDevyVF": {
         "account_type": "User",
@@ -3044,7 +3450,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "82vucuWCTTQEz6nYe3VetnL3pJYBrfDF2gDAjec9sPUy",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5GhvQQEoKvJkTKLKyuhxsD4vTFxvMqwZG3aGMHwvQiDQ": {
         "account_type": "User",
@@ -3063,7 +3473,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "DCKyEmMENQMtLXgbmUoHRmgP9XdJ9HsR5WxrKnSDCzKA",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5GtPTkYbAPF4xgPvLXiDoQzTZbi2VaPJFKXgJqeoY4WE": {
         "account_type": "User",
@@ -3082,7 +3496,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5L3HnhvAY6h6FtAoPwrymgZp3Dc3MDHjHiJaswwQ4K4o": {
         "account_type": "User",
@@ -3101,7 +3519,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5P72YUV21yWQAooGMCdk7gfvManU5xeExUBUk6hR2KHs": {
         "account_type": "User",
@@ -3120,7 +3542,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "4guS5XP2wgDWecZGgvN5UQmV8iywTrKGaA7kv9hj3tk7",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5PZQx6ch4Qh5FxvMnevujQgPXzNaSx963W8ppDX4Dbr2": {
         "account_type": "User",
@@ -3139,7 +3565,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5RFZd3GXePEdEHxewWbwwNSfY7QHY6ZYx8JUuuEfmmYi": {
         "account_type": "User",
@@ -3158,7 +3588,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "D8xKNftHzFcCekENuTEcFC1eoL9y8wNHEg4Q5z57KK4e",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5Saf2pyJRktXnU1V8gXkcXkkxR5mXXsmai9D6f2oFhBN": {
         "account_type": "User",
@@ -3177,7 +3611,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "DZVqmD4QqSWM2gUyEXdQhvt4u3NZtCRxdsn2n2nNiBRL",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5Td6nUeJkScxsdFfiYkbZDe5j6JtyuQydpzXHvg7z5Cj": {
         "account_type": "User",
@@ -3196,7 +3634,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "ana2y2YvQ3ZPMwm6qhnN3nJoUSiT3qx5Pvetkq9xcfY",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5VYNPLhJkhu6TKxLCYyDF4q7NYSG8sHd9gpGc98M5c2j": {
         "account_type": "User",
@@ -3215,7 +3657,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5WTarbRLpa8QLJ2BSHbP9yesv7brusH7tAJjS9VfjGRD": {
         "account_type": "User",
@@ -3234,7 +3680,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "spcti6GQVvinbtHU9UAkbXhjTcBJaba1NVx4tmK4M5F",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5YeR9MZAVQv1F3n9n7C4C1QnUAtJHsU4qeLQtbm6Pm4P": {
         "account_type": "User",
@@ -3253,7 +3703,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5ZwrJi3ok7UJqe1xxUAgt22Gpig2s25AGY1P5NfHNBcT": {
         "account_type": "User",
@@ -3272,7 +3726,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "hy1oMaD3ViyJ8i6w1xjP79zAWBBaRd1zWdTW8zYXnwu",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5amns9qJj45HZMSFcLt3PEncgxBmXUDFPpEdsHRa9tPB": {
         "account_type": "User",
@@ -3291,7 +3749,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5c2CRutV5aewrFLneB9rKburx5rvFgd5Ayux7Cp7o5ka": {
         "account_type": "User",
@@ -3310,7 +3772,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5gAe4KogvQU4TU3jpAdXymrsBsJBPxCyebv9hUjvJKN6": {
         "account_type": "User",
@@ -3329,7 +3795,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5h4GhLtpjxPXb3rxqjina55NYhhm6aVSqNUwj9AE3s9F": {
         "account_type": "User",
@@ -3348,7 +3818,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "G1eAmANVWf6ZeoxG4aMbS1APauyEDHqLxHFytzk5hZqN",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5iAP4uQPVuLVproH6MLQGv6Mqi2fYc4sweN1VBS1TLDN": {
         "account_type": "User",
@@ -3367,7 +3841,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5jfqTbPFtqruEK7usrBycXiwxBwWVyAxfDKq7mVSA6kr": {
         "account_type": "User",
@@ -3386,7 +3864,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "NLMSHTjmSiRxGJPs3uaqtsFBC2dTGYwK41U18Nmw5kH",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5jsXCuYaFR1Wzpvwgazz1dZPMawMy337pm8c8iwX7cxh": {
         "account_type": "User",
@@ -3405,7 +3887,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5kqg4MEfcAuhMQcHe5fTCdLBiuhjLAhfmdPCy1HU3o5V": {
         "account_type": "User",
@@ -3424,7 +3910,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "Aap8GJLjWFP4oEiWBer1PWDVsv35eqC1LPkuTyh4qUEn",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5mGrkiZ3Gh87VdMrSUADjGXDNTgWerofcUAtUrG5ac9h": {
         "account_type": "User",
@@ -3443,7 +3933,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5p1NE1jcKgsUotMTTKeDdDFqCjQfBKQFX1eK9r7bjVxV": {
         "account_type": "User",
@@ -3462,7 +3956,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "PRGNnb8DxVcP2WjSHfVRGgc8SkA5u6dbMwoTVV1BGKN",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5qhbHrepx3L9J8S1CRwrU6s9RqG1mpSZEQEsgsHuQGHd": {
         "account_type": "User",
@@ -3481,7 +3979,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5qiU8LqDD75bsbipPuPGNiiGuKhLsweHkUFLgAJEdko5": {
         "account_type": "User",
@@ -3500,7 +4002,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "4SxZEAasqgiaFRJQJ6NqoTFPoCAVjQTQRiuRZasfnZv7",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5rkTG2LC5CUr7hwW9YAM2M4qM62yxu47jcxoxKtKyATE": {
         "account_type": "User",
@@ -3519,7 +4025,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "Love31pnbDJNVzZZVbtV4h2ftvTPVcBpXW11BSTCa6s",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5sQjz6s3zhdg8bV5kcgk4CM364eg27i91b67WwD4EcXV": {
         "account_type": "User",
@@ -3538,7 +4048,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5shcDoSErKAKxAt9SEvgYA1Y7f4ajdWzszVwxhWTpDgB": {
         "account_type": "User",
@@ -3557,7 +4071,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "StkZAmzUiaUPmg6AhytiWLoRZ1bqefJSjDsqctjCmHb",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5v9ytkKhHMbpPyfxzTbCR9xq2AFPjKwXE7d3LnuxVf7N": {
         "account_type": "User",
@@ -3576,7 +4094,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "9T6SNsBimjCRJpkEjiVsc8AcxTBa1XVA7RjnBGGfWP23",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5w4pn9gRQuxnH1eKYqKco9AYKBdwQgG9nKgph15E2Z3j": {
         "account_type": "User",
@@ -3595,7 +4117,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "sTEVErNNwF2qPnV6DuNPkWpEyCt4UU6k2Y3Hyn7WUFu",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5xffC18vawFPBj3ykj1iMKpLN2qjvd59YTCmJmPqRF1m": {
         "account_type": "User",
@@ -3614,7 +4140,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "5zxMTq1dKVhpWhXwbiDPyC1FCoSUZjDtmfvtMBK6P2F8": {
         "account_type": "User",
@@ -3633,7 +4163,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "GvfaiJUhNCRZGVGumsEF1eHDb8JpAeFAyHSrTifyhrbt",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "65VRZQGkcuNiya6vQxftfHXHc7d3CxYjPy7Gi5wYjzNS": {
         "account_type": "User",
@@ -3652,7 +4186,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "C1ocKDYMCm2ooWptMMnpd5VEB2Nx4UMJgRuYofysyzcA",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "69Tmp2RBbH72Jn41n6KRDijvXKku2fpU79g9Gr7vX3gm": {
         "account_type": "User",
@@ -3671,7 +4209,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "D4ujBcx3Wwc6rHhx1DFdTZL7vfDJDE6Y2BvRfE8HovBF",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6ATaxjH4o4JGGC2NJwaxQB2kzJjtWVN8fEYNzAdrg9EH": {
         "account_type": "User",
@@ -3690,7 +4232,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6BEEQLCVNAFswBc61JCy16oBieMPRXkn5d3wxy8fj699": {
         "account_type": "User",
@@ -3709,7 +4255,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "TrUtH9WTw1jBVuuExpm3MnC5XF7mW6J3x6oXXA9yX4U",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6CsN9qnbbjxZ5ZqN5QpS1bGvBBsoqhFgUv24eVMzC8kP": {
         "account_type": "User",
@@ -3728,7 +4278,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "dst2u7mXMyDvb14cSErRNA1mxH1d5VXbSXgZ3DKE9xH",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6CusU9o9599U9JJC5R1MN853bHzwKbLeZ9BSTsryfWdN": {
         "account_type": "User",
@@ -3747,7 +4301,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "5DY36rimdoHzZxRnQ9Nhjra6Yag8SV9xcM7khgAVHSXw",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6EboTuS7cyd964oJMFhhvmWZYZp16Yizr5XscWBTz3Gt": {
         "account_type": "User",
@@ -3766,7 +4324,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "EK6SjLmNm37ui8mCx6WqZ8dg4aeSfTZkrmHUW3zcegsx",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6GKnpZtuPFr3mW1TCF2yZfS7u2x99pxgZPxSZ2HoxCRM": {
         "account_type": "User",
@@ -3785,7 +4347,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6KFpzSGCkQ4w94M131Sfrx5JN5tCH91gMWe3YToA9qEE": {
         "account_type": "User",
@@ -3804,7 +4370,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6KXCB99njPMmQMXa1XnVhnSmwpCZR1DhpmnMD5RUS7Ui": {
         "account_type": "User",
@@ -3823,7 +4393,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6LVx2APfS9ArCv4di18rHqxdrpNqGgoKkQd1DzoDv5Lb": {
         "account_type": "User",
@@ -3842,7 +4416,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "AfZTWYoFQbzqCMmUBTD7XwxFvjob1FVyCvkaXRryxtKc",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6M25VkQRRJFAXAxKEYMNqcHp6yKEpE3aB2xxMAdG7epg": {
         "account_type": "User",
@@ -3861,7 +4439,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6M8BpTtG7r62PK1jAEqhBsNa8UsnW87VDvrESisRsYhF": {
         "account_type": "User",
@@ -3880,7 +4462,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6QX8i2k3cmqqGVx1seHLBKaNgB8smEKF97nJYpS7Tf7V": {
         "account_type": "User",
@@ -3899,7 +4485,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6Qbd5i52GcRZJAxsQpBDCo1GmExwC43AubNhcxV4Tk9J": {
         "account_type": "User",
@@ -3918,7 +4508,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "2zykwzzo1pd3H2oSj5j5SRLTvmpa9Nr2S2Bh8tTVd5Tq",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6RnwXZkKHzddr7JbvohSuKan5TWFGAodpQpRREwGKH8e": {
         "account_type": "User",
@@ -3937,7 +4531,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6SJyzg1wx1rcLqdSzFhj9wQDbRcqta6yEFGmS21Ak1Yt": {
         "account_type": "User",
@@ -3956,7 +4554,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "eyeYaqg9e2L6xw7YwsSLm27eWJfhLNAm6ETQm8TXNoK",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6TH76wGezhoLtyCK8qbhN1FK8PWmMQsf6iyEHENPWnbc": {
         "account_type": "User",
@@ -3975,7 +4577,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "TxtxXzLTDQ9W4ya3xgwyaqVa6Tky6Yqhi5BLpPCc9tZ",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6VuvfVGe5fCe88Y9M53rwA2Q6HfiyUQACAxuCKTQHDqv": {
         "account_type": "User",
@@ -3994,7 +4600,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6WjUmWAYqM8K2gdaDQBYUr4u37pUR2dgnAxRBJr35JVX": {
         "account_type": "User",
@@ -4013,7 +4623,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "Dm7L1FMRrHBtVpkYDNqQo4ej9MjJKu7EERaHDAPhBmUY",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6XFbaZZ9i6zKrKLx5cRjK4CZtpdeZbWzFMGbp7PEbFJ7": {
         "account_type": "User",
@@ -4032,7 +4646,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "BCjGyexo1i7qpN9CbJ9Zt8avWr4Lb2JRtcm43sJvsgQK",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6XwLiQwh7joRZa8KMf4t4Z4CCPY9pHrJU7TjVDXTjavi": {
         "account_type": "User",
@@ -4051,7 +4669,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6Y4H18rWHc8i7ZGNyWcPKiuTaNUedr92WPXub79t7fWW": {
         "account_type": "User",
@@ -4070,7 +4692,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6ZUmMLeEpZpZTR4xKuuCiXKLAsZWRhLPFiM4u4Zvog7y": {
         "account_type": "User",
@@ -4089,7 +4715,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "phz1CRbEsCtFCh2Ro5tjyu588VU1WPMwW9BJS9yFNn2",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6ccBCyFFpqzvYwJ5Q6XoLcd5tD1WuJ6QACY1wZ78SzRu": {
         "account_type": "User",
@@ -4108,7 +4738,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6duvXkdXtEdRD2VZF3DcsJJieFhCZtGnnaVJ4JWtVRB6": {
         "account_type": "User",
@@ -4127,7 +4761,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "idLi1KLjkzEmLvzdB756HweHRmpuC3AGkGnK2zhWJ45",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6ehwUszjHHZjP3wEqvBJ4VmUrnN8nm2EChMQgBqJ71g6": {
         "account_type": "User",
@@ -4146,7 +4784,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6jWnxJmaCZ5hG85GUWhCSJHxPhje2qo1ZC7xndvVp1yz": {
         "account_type": "User",
@@ -4165,7 +4807,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6kLFWUy5VK7s8pcrPmTEaofKddm4SZw1E3vUCrFwkfsq": {
         "account_type": "User",
@@ -4184,7 +4830,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6qURx43oNimGFZKuSxb9C6iw94d1sMpAwo3FpCAFXabv": {
         "account_type": "User",
@@ -4203,7 +4853,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "dmygEwMFAC3v3npKsFnWRLanNQqx1RrBxZFnKgrwJNi",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6un5B7w94jAjYmyTq6pNmhLzjWHGaxsxg9yTtqogBqHV": {
         "account_type": "User",
@@ -4222,7 +4876,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6vS6fNTpHv7m1HFgRdA6ATTP6eSc9pa4D5RYarCfA3hx": {
         "account_type": "User",
@@ -4241,7 +4899,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6vyeAPTpM6QV3FrtbMFn7m8brqEkPgHDbvMURQFqiCYK": {
         "account_type": "User",
@@ -4260,7 +4922,11 @@
         "publishers": "",
         "subscribers": "AR8DvEn77GRQ19drMhPCjvFx2StcRJ8XbLVKS6yrgQAV",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6w3wCaHju4iUGvvRTg6hdAMb1JoiHnABzqZxidjykGj6": {
         "account_type": "User",
@@ -4279,7 +4945,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6wzHhzpY4srJcwbWVEG5Z9uvE5TmCnuGBoewLMYzM8j5": {
         "account_type": "User",
@@ -4298,7 +4968,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6xfiFYoBkvd3wJPiGWjQGfConhNaPFyoHiA4thnZcucx": {
         "account_type": "User",
@@ -4317,7 +4991,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "4uH4G6YiD5G8rU3mtPg73C2Uqamrqedy3FboTZcZrh6x",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6yK1BFNAD89Lb8uj6eCqWNr9FYibSE7nCvDiSTHyji1n": {
         "account_type": "User",
@@ -4336,7 +5014,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "6yjmPX6NQ8GsRRfKmbuZzr7k8GFwAUgxvLyynQHA34QD": {
         "account_type": "User",
@@ -4355,7 +5037,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "71G6VhHQhAH3a158geEQF5EXZHs14kahuWrLj4NR9nPe": {
         "account_type": "User",
@@ -4374,7 +5060,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "dcntruDNP5SEcGV4RxnsqXFURdDZGT3DTQv68Q8H7Vu",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "72C4Sr4sMhL3YFHym813JCZkWCNzgm7vhWsE9fPHG5ta": {
         "account_type": "User",
@@ -4393,7 +5083,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "74r2uBbqZWUR1JxUzrN8kf6hZ8cEd6bJ4xH3gnLdMK46": {
         "account_type": "User",
@@ -4412,7 +5106,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "79WxJJK6jd954mnbTNVxDVhrETVedvb49T6vBQq2xE9B": {
         "account_type": "User",
@@ -4431,7 +5129,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "5t4shVsKnUqgjmhK3fFNsvyju2E6Rd7cc4S5pmqqEVEW",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7AYFLssBZN5VqjBJSXF1et6QPKqiWQUtvFnxZxyME4gD": {
         "account_type": "User",
@@ -4450,7 +5152,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7AbVcJe9SDtsvb3wGZefiAVtw9cetYZA3HcrTpCzM4WM": {
         "account_type": "User",
@@ -4469,7 +5175,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7C9dKMTRaiEp2R5WRrJGF1BJXaeDneBpMJXffCc3iD16": {
         "account_type": "User",
@@ -4488,7 +5198,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7D2YCxxaLMoBhqT341ixkMj3euC54EtWn5jeJtD3pVSn": {
         "account_type": "User",
@@ -4507,7 +5221,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7EgE9LWULFCT7jTi2ctXUcaetD4yd4AXAsyHvUH6fdNG": {
         "account_type": "User",
@@ -4526,7 +5244,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "jntr1vkzvSujfckGR6ANmFmirVoPBMNr5XJGKP5uDQA",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7F3Z8VvvsbswV29DqmRPfq8fjxQPgtEMe4xCLCiSnvMp": {
         "account_type": "User",
@@ -4545,7 +5267,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "NLMSHTjmSiRxGJPs3uaqtsFBC2dTGYwK41U18Nmw5kH",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7GjowgkxeqL1HqFTbLDB2B1vGozkoGs9HBmQdv7RhwXJ": {
         "account_type": "User",
@@ -4564,7 +5290,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7K7yWESrZMWPLJhs61MC8spnok4B5JW46ZNmF3zCzxx1": {
         "account_type": "User",
@@ -4583,7 +5313,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "95A3UmKrAmTuNJkjipBULk5wHopiFvLWfxTKmhR6AzQc",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7NR7fvdbpUuyLpS52DmoE7kMsyrdzwkZooSdQvfeuje1": {
         "account_type": "User",
@@ -4602,7 +5336,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7PgNrbeWDfTy8MQoBBGh8uqgDWhHUmmctonrrHMn9yH1": {
         "account_type": "User",
@@ -4621,7 +5359,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "radM7PKUpZwJ9bYPAJ7V8FXHeUmH1zim6iaXUKkftP9",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7XRhzjZqUJdsYEAoEvE8qyWaay84j7CH2JAWh7DMJBpY": {
         "account_type": "User",
@@ -4640,7 +5382,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7ZEggTdmVYYt9osSLhk3GQ5bUE4yP4M1pZK5VNb6AuiS": {
         "account_type": "User",
@@ -4659,7 +5405,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "KiNGTLWCgoqLKn266xxT2Zosko3FumNv7Z4V7V9cyKQ",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7b9zq7azQkDWxtEkVKQ3tX2stgt8LirqQpX4EtQ2k9uv": {
         "account_type": "User",
@@ -4678,7 +5428,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7bybpUqukcizhB7c2onX8uLNsTdSTQ1wb8cb4pWjw2L5": {
         "account_type": "User",
@@ -4697,7 +5451,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7dVdkKFmt9CGrvysmHuhzXidqZ8rnVfbtrTMW7WYLr61": {
         "account_type": "User",
@@ -4716,7 +5474,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "ADjyeNzWd8yhEjCVyAqT87eqoyGRbimERQsNhFQcXjop",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7gyh4nnJUkWEGN3TMLabrSKp8JXWEFa6hi6dHipyuf2A": {
         "account_type": "User",
@@ -4735,7 +5497,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "nebu15XQKGpxzhhckADBX9PgvGN5qk9RRJCFLKc118w",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7hTY4etmd72uWSbJFbc7CCt3mTwqB2ge9FFMfVZQt8Mh": {
         "account_type": "User",
@@ -4754,7 +5520,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "pitMDEaMmWmr7qP8HsNqarPQkd3jhZbLJibhhQnL5RG",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7hkH91TziDnPdZydUh1pBYJbfJi33rkrxDMK5gxKy1kP": {
         "account_type": "User",
@@ -4773,7 +5543,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7i3JZyh8Ag67s5nv9ZhMNJpJmgpSGxziAtKwTSVQkgUb": {
         "account_type": "User",
@@ -4792,7 +5566,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7mTSjDCsJJCczBgpK1t1VhS2yY636MJyMkw9YHBrYnFR": {
         "account_type": "User",
@@ -4811,7 +5589,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7tWUCL5r9BdbLygUiLtEssWQ6RfAUZemk7CnFkgHJspS": {
         "account_type": "User",
@@ -4830,7 +5612,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "BM2vE2QqkB9fGtC34WPtM8drbgta13SBkhRq6dRG9J4J",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "7vKcF4fFLDKK9zDne9VJ7DzbAgU1jkXyA93a7Yo6NA2z": {
         "account_type": "User",
@@ -4849,7 +5635,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "81RvG4HXhgfqLfDCFBp4DoLXJ3GBQx4qEe5JihFNDDVy": {
         "account_type": "User",
@@ -4868,7 +5658,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "841uAEnB1Hkjv8gush3pRmx65ihL9wZ4vK6zfDjHh4Bz": {
         "account_type": "User",
@@ -4887,7 +5681,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8717yKFE73cpjvxGhqnAENfKpXqLXRC6sGDFPwCa3aDY": {
         "account_type": "User",
@@ -4906,7 +5704,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "23SUe5fzmLws1M58AnGnvnUBRUKJmzCpnFQwv4M4b9Er",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "88V8ybc1bM938Pu9VVU5tfFQxYWwoRxL9m7xwu5yupEN": {
         "account_type": "User",
@@ -4925,7 +5727,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8BkpUutM9sPpPb7MnbSvqf7W5xNxVboG5UkNNi48MXCm": {
         "account_type": "User",
@@ -4944,7 +5750,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8Cc5cuwCxgJGjJSDJMqjwntHWBfZKWgHQ2aM9REt2772": {
         "account_type": "User",
@@ -4963,7 +5773,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8DHkGES9nekDuE1Mq4Dc4aiE8TfQynAa3s3nH6z1VtWG": {
         "account_type": "User",
@@ -4982,7 +5796,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "8rWDbEsuz4UWF2ZXiHhMECPkTZm51YrRaQSoSz8RPz2H",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8E59GT63EQu5HXtg86QdRHT3mM7afkZrCsinPyCBc3nC": {
         "account_type": "User",
@@ -5001,7 +5819,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "DZVySotZvrvJyVAcgjFtUDm93zoCaq9wBruMAUz83CWW",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8EDkBGgfqQEa9kvjfdJ6tSsk5RbxRCQn9nQQ4X9rHGAT": {
         "account_type": "User",
@@ -5020,7 +5842,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "DZv25oNCWFvGXu9tH63BiAXvG94syweGZhbvdN3HxDxT",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8FVUpfwp7cSJtSTkAQU25CVjGwjqx7eVnQiiwSdNt4Uz": {
         "account_type": "User",
@@ -5039,7 +5865,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8FX86JKM6T2NHBW8AHihTwCvFBk4ByRacUjHFSVJnW1r": {
         "account_type": "User",
@@ -5058,7 +5888,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "2Eq6YD8P8QXTeoz9h6JHjgZ55t8RSxNdx4waMDCoPmQU",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8HseBeLBgPtkpn8H6JNrbovKrdMdpd1SnKDioNR9BqWt": {
         "account_type": "User",
@@ -5077,7 +5911,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8SvGdG35Cf14Q9dw5BD5zG7HiBrfLhJdfq34quLPbBtV": {
         "account_type": "User",
@@ -5096,7 +5934,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8TFcNFAjyMwhpiAoAhTQ9HwqoCE3hDP1zExuxoyyGBeQ": {
         "account_type": "User",
@@ -5115,7 +5957,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8TFrmCzF8kUmBYGRmRUqinepXAW2h29u7opmExES3PkV": {
         "account_type": "User",
@@ -5134,7 +5980,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8ToVZoonW3HfixbA4MkiMP5SG87hcHysMe1U5R22mKJJ": {
         "account_type": "User",
@@ -5153,7 +6003,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "vnd1Ps8w3fsi54qUMJxBhUWARES34Qw7JQXDZxvbysd",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8Vwmi6zLFtMzkRtVA2Bp9k2UAMLSNGyNCGNU1ahuoRir": {
         "account_type": "User",
@@ -5172,7 +6026,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "L3oTghmPSoAqMtxmTaAn5jNJrDehWCB6hYA4GAtsiNr",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8YTfC81HCNYKHuw6sjdYJnamZdAByKUFd2JNM5mf3FNs": {
         "account_type": "User",
@@ -5191,7 +6049,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8YgfHsssPHzQDVA7797Sb6TEKBF8XMZAd3UTFLvuirnS": {
         "account_type": "User",
@@ -5210,7 +6072,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "G4GT8z4AKWNoy3x6nuzxW83UfFXLXzrwn7DZQt4GvWdU",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8e6gKLDq3mp3NrgXSjmpTqDiaEC8gTafVk82yUuPXp2o": {
         "account_type": "User",
@@ -5229,7 +6095,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "CHED86J97RCtt8HxhNxvUSQWPqFsiftNpWWQd9HZvqvw",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8gccZdu9hUg1mWJRUDBEoXN1HxfJ8fbGkXwa3Ph7wJut": {
         "account_type": "User",
@@ -5248,7 +6118,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "kC7mBpLy53EW5U49u9WHVPe65kbQmoRu9Uu3VhwhLhm",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8gu8A3fvVTW3xwhaWGrEXLAket8kxt8oPYB6WWVLEpGp": {
         "account_type": "User",
@@ -5267,7 +6141,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8hCkZf8e5X2ZVFRy6uBB9T1TwjJUczbt7KCoAzKntfgr": {
         "account_type": "User",
@@ -5286,7 +6164,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "N43JWBg42ZoUFMkHsRUVbP7wGVdxaHKanqaF9BBNiFC",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8hcQVtpfdb43Cyc382SrnpJ5iHPi4TEkoLT9kYXgtdyY": {
         "account_type": "User",
@@ -5305,7 +6187,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8iJSAnYwCENFDn4u2rK8Y2FfwFETDwbG37GWYZLDxTzs": {
         "account_type": "User",
@@ -5324,7 +6210,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "EBk678aQvc3cUkfGyoehfw21JQfJXjmWuBeopYc89RSV",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8kANNJqRE1XfcAdUAEJHh4thHoDE4RYnq2vzS497DJFY": {
         "account_type": "User",
@@ -5343,7 +6233,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8khRj2KagpGmvrQ1FD7yWfCwjN7GqTXwJrKKHrS5zmg": {
         "account_type": "User",
@@ -5362,7 +6256,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "LunaowJnt875WWoqDkhHhE93SNYHa6tfFNVn1rqc57c",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8mnF1cNFgdSMrKwf54s8wAFMiG3Eg24ETDc371spNSgN": {
         "account_type": "User",
@@ -5381,7 +6279,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8pEtHvxVUb6z5fahmAM2bqrHD6Ji6YDosasMR4RhCcq1": {
         "account_type": "User",
@@ -5400,7 +6302,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "te1ee9rGf369wxYQkuxkvuvMuTJ9cksgZySmNUF8rNY",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8qYqmTZ4zg1ke32dYQvmaFskCijmdBUasBWFiTVXxE4f": {
         "account_type": "User",
@@ -5419,7 +6325,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8tSPZahQUuASy7BhG3dBP2LJZPiJcLP9Vi4k7EgVNWET": {
         "account_type": "User",
@@ -5438,7 +6348,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "qZMH9GWnnBkx7aM1h98iKSv2Lz5N78nwNSocAxDQrbP",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8ubroiTygp1sCMB6D4rXP1tQjD88nCWBcNCwvmCmpnP": {
         "account_type": "User",
@@ -5457,7 +6371,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "FttTBmXi5tmGJtiRcbVLwfMnY3ngrxw8DNSWRWMrr1WS",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8vgk3xcmXbydu1wWinjP6uk8q7CPHdtkwxARn72qQLgT": {
         "account_type": "User",
@@ -5476,7 +6394,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "gridqZmeBcsUKT2Mv4M9YFHFN3tVLFb2TCtTcLD1cAd",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8xG9KKbwo9VdsM2ZTUVsCNgs8UmtC7sg6mwb9g5sG2mb": {
         "account_type": "User",
@@ -5495,7 +6417,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "popscoyTKVksa4TyTXw488b3vvFxM7qQEyTBeMQopKu",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8zeAaqWje9bWKPkqxVibxWt6BTzAGVcD5NDtdSnbqabo": {
         "account_type": "User",
@@ -5514,7 +6440,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "3RXKQBRv7xKTQeNdLSPhCiD4QcUfxEQ12rtgUkMf5LnS",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "8zwZC5DdfYc51WxYpPB1gGC1yqWD7byhJdGkbNSn26BB": {
         "account_type": "User",
@@ -5533,7 +6463,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "92R7DULSKKLBJzou9hUcBVtLMMp7eW9udUf18mKvjyZ5": {
         "account_type": "User",
@@ -5552,7 +6486,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "95QyzLYhQ5EmnXUCbCr8hXAjM8vr8ZorMLaYnts44o7c": {
         "account_type": "User",
@@ -5571,7 +6509,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "7ZjHeeYEesmBs4N6aDvCQimKdtJX2bs5boXpJmpG2bZJ",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "97yiXSsnxAUtPcQuBjmEhUfcKyZP8a8hV15xH2CRrYnQ": {
         "account_type": "User",
@@ -5590,7 +6532,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "99hmBkcmHUVSsfmvX5i49gvdT9A9ZeTWgYucDziVAhLx": {
         "account_type": "User",
@@ -5609,7 +6555,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9Bm9szAbQ4mGGu97e7Cc4ubbhGtZjSTDc1CcDRqq7rv7": {
         "account_type": "User",
@@ -5628,7 +6578,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9ERLm6oTAdMz4PGaBHZnQCWz6X3saEv2YxcZznXbLrqc": {
         "account_type": "User",
@@ -5647,7 +6601,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9FYezQoskFFRFdVtL9yTRT1auuMTAeuUTZ2is5wJVgnq": {
         "account_type": "User",
@@ -5666,7 +6624,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "EvnRmnMrd69kFdbLMxWkTn1icZ7DCceRhvmb2SJXqDo4",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9GrZXu5PBfts6tQLkXgoinnVYFjNGBXw3URfdfvrvrh6": {
         "account_type": "User",
@@ -5685,7 +6647,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9Hfdeg9tbC1szC6cR6V74q8wqonXkK2HygbAskQDUjZT": {
         "account_type": "User",
@@ -5704,7 +6670,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9JBCXKGpaJw39B9FnrVXeUnmwD5aQD1pEQ626ZYRczad": {
         "account_type": "User",
@@ -5723,7 +6693,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9Q1BiNUSB1pAVASCWaz5aXncCo1cwbkiAmyiMfATntmi": {
         "account_type": "User",
@@ -5742,7 +6716,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "ASTERhckBQwAM82EQm2S2ivVcQ9mHQHZQs5u4BHMv6JH",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9TRQFKdbXQSXYhRAt3VudwuRh3giaNHDWaQRY5vqCrFF": {
         "account_type": "User",
@@ -5761,7 +6739,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "EAW9vxqogvdPNapq7QTDpiVTHK6o7begUhPVnf854VTc",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9b6SnDTZXkbHr6ACxzMmPu6uDmC6ShK7huyMmLwrsG9D": {
         "account_type": "User",
@@ -5780,7 +6762,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9bdLBgPJgK6QtBA26xUWspLcyTfQ3ZGArq9XAzHYKNZX": {
         "account_type": "User",
@@ -5799,7 +6785,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "Hhn4usDjnktbPURJHbi4YrPdKudBD5Qq35mTcaQ3Uu6",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9f22sWrfRycGshdQ5XJN9c5GHTPNZgp2AmGyGcSGoWyd": {
         "account_type": "User",
@@ -5818,7 +6808,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "CNRyYnXZjryxNdSUwztdmVFVuQPXvugQ1d2wtRTjjTb3",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9hAz3ocytFjGSordkoNfTv2Pn2mxxiUeRD4xpUig4A5C": {
         "account_type": "User",
@@ -5837,7 +6831,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9hUWQdU3pCBi3nHSwdYrWJbQMyNK3UgjRHqDc5wdUWKw": {
         "account_type": "User",
@@ -5856,7 +6854,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "GvTwyQnoYLCV2qANCyVYyKEzZ6Q9FzZwfmNCMSZn7xbb",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9iiZX2Qkknp7wKiofF3jN7RBJ3K544C8Zm93PfGp1mE5": {
         "account_type": "User",
@@ -5875,7 +6877,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9mfK9hvGs463X1NAbqsqe8Pe75QiUKWiZZh3tC6USmyX": {
         "account_type": "User",
@@ -5894,7 +6900,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "bookoVmqw4QjVj5BbkFacouadx9M7816wyRkfM7A5Lo",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9ohRXqWrW6Ds2t87SCfA62w3PBFShyPQYiZrvRoU8ivN": {
         "account_type": "User",
@@ -5913,7 +6923,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9qFc5t2fd7Mi4YFFVwwWPY3FQYqxA8RZvHviHdfDvTSa": {
         "account_type": "User",
@@ -5932,7 +6946,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9riq3n6tRybnjHmD7VWAViAUM8ZbAiBqM5TzxQeiHoMi": {
         "account_type": "User",
@@ -5951,7 +6969,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "3ddX9QcC6DjFqPTysrFWtR48v5g3wJjB862sji4s5Tui",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9titXYt6PiNT15UjZJizWMwNFzHgqMt5tBKjP2A3Hx9h": {
         "account_type": "User",
@@ -5970,7 +6992,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "9r2CsyjRTmTRtu8GFk5oJRSQr5YfSENxDkf3eox8iPLa",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9uAY5brspTodjkeo5mXo3684wYGmq44ZGkjUuv7x7NGD": {
         "account_type": "User",
@@ -5989,7 +7015,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9upncEvoPHmcLKRjF39a172BS81VK5Hfi3CXQX2UqwrA": {
         "account_type": "User",
@@ -6008,7 +7038,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "6WgdYhhGE53WrZ7ywJA15hBVkw7CRbQ8yDBBTwmBtAHN",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9v86HpMpVHKsSF32JK2BE58atcWQtRLYg3oZrhG8DSwY": {
         "account_type": "User",
@@ -6027,7 +7061,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "SWiz7QwnYPm61pWWUUkMhj4r5pZLP1SvYibdHcB2cov",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "9xwDmL3cB4LFNfEVJKscWQE6vQV4cqWUkS4wjAHbB73L": {
         "account_type": "User",
@@ -6046,7 +7084,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "C4bgengueVA9cRcprjutgu9XgvgoaaFnCqvpZaPy27xx",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "A3THJoHURkhYYJn9w2zrerSn8RQQvYUHQVVXPNY5iyZB": {
         "account_type": "User",
@@ -6065,7 +7107,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "5XKJwdKB2Hs7pkEXzifAysjSk6q7Rt6k5KfHwmAMPtoQ",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "A6KTNhDgnsFh2pPr8rHTgun4U1X4Gb2d7ZGj1rNcNnDu": {
         "account_type": "User",
@@ -6084,7 +7130,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "FjYEr2UCeFzNfAKiFrbhG34Zv8LxbmfHYAFhAfc7SLQL",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "AESMvVGDBzATtUGhRUCYS9gbPwcGX1c3imUYorzoqVsy": {
         "account_type": "User",
@@ -6103,7 +7153,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "AH1GitZ3uqUTwaMCaHDSaimSWidcdqsua5Njbuo8FEcX": {
         "account_type": "User",
@@ -6122,7 +7176,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "AH4pKkrSwNdRFTvSQgSUYjcJRFY7Xw3NVPWJVxzWFL38": {
         "account_type": "User",
@@ -6141,7 +7199,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "ANtS4s4e5TKCAwuJdJvSPZazk8rx6ax6539SiWniV1fV": {
         "account_type": "User",
@@ -6160,7 +7222,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "J2obR2DK7gnd6H88HjKzEYuMyboDWRNpbzwmGSh31nnu",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "ARgFbuFZoATNvATzNKgotU4zCEHvFUc6MJUsDHGtmkN2": {
         "account_type": "User",
@@ -6179,7 +7245,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "ArMBx6veRq33ffEP9sxHafiPRgrtzww4XvbwZbSMfXiM",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "AUdeNiFrrKmR8gsz77XpXCPjkgWWxqbo1NKxcR7e1mdu": {
         "account_type": "User",
@@ -6198,7 +7268,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "AZ2Bv5Fbhks47rdnnUxgCsJhJu7SoTowwXYdRh4MiZSF": {
         "account_type": "User",
@@ -6217,7 +7291,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Ab58Zxt3UFSu3jwkXHP4uhxKQVpVP4Wo6r8qBfeNsJn2": {
         "account_type": "User",
@@ -6236,7 +7314,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "idCE5k2BtTpwXdwAC7Var1enT9reut9fWECcxQP7LY7",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "AbGDN7L3BAwrAYUtxiZkgGSspm1rnRNm52zPtpXznmJM": {
         "account_type": "User",
@@ -6255,7 +7337,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "A79u1awz7CqnxmNYEVtzWwSzup3eKPNW6w2Jrd56oZ3y",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "AcBxgHW3XtXLL2qgw8Pn4tjAUUjEWkjUHThcKhF8r5Gf": {
         "account_type": "User",
@@ -6274,7 +7360,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Agwaj7G6tsPHWq7puiYeKNmAY4k1suxDaqLtRG1TzKbz": {
         "account_type": "User",
@@ -6293,7 +7383,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "AitCufP8Ut3NWMWJ9ViM7TpvkdbXRv9yts336CbbJ5cn": {
         "account_type": "User",
@@ -6312,7 +7406,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "AkWDG5VJ8JQAcxJpig8qhHGcTqeuXScpZbGtkzgUs9u8": {
         "account_type": "User",
@@ -6331,7 +7429,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "AoHcv4reTNYGp2b8x9pyddDdRdhRpvyZepH6VCpfxfX7": {
         "account_type": "User",
@@ -6350,7 +7452,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "soLStaCk5TiGCpeLKa9Fvv6f5JQGMa6S3uhLh826e9N",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "AtNWNasWfpFULmd7XV7GNbuL2t2k3LqAaXZBB9Jdug2Z": {
         "account_type": "User",
@@ -6369,7 +7475,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "grptonHnt7YSmJokGK9TJJTBXDT8ca4LSWMHCCfzzPa",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "AvW1S3qy6dxkY9MkxQGYxG6XMkVvWUqBvdcQWgNEMtYy": {
         "account_type": "User",
@@ -6388,7 +7498,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "5zuNci3TV79w6zLoJZzbZujMvkVZb2FcSPhgv9aT24AK",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "AxbyUNUgUCDmMJCCZg8osGWpDeLan1cp9XEeBitLtKqR": {
         "account_type": "User",
@@ -6407,7 +7521,11 @@
         "publishers": "AR8DvEn77GRQ19drMhPCjvFx2StcRJ8XbLVKS6yrgQAV",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "B3mcwnK6LeFqu9oBUeVuQvmiDPZN94Bh86ENH5ds3Fyv": {
         "account_type": "User",
@@ -6426,7 +7544,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "B4k27tVSERa8Q9VYUiS6rXfKc472REccLvewiB9Q3Fxm": {
         "account_type": "User",
@@ -6445,7 +7567,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "B6Sq6ihn5kJ5UJYQmnsY4mf1W7efLfM77ZPgLMp7zgrb": {
         "account_type": "User",
@@ -6464,7 +7590,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "9ab9JcweshDxrrd63NwFZSAndDc828L6X3RRMQHpXgJN",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "B87iVeubJjRMWLTsyijLJ3VChYpS6VjFLDmKJJtUEuwt": {
         "account_type": "User",
@@ -6483,7 +7613,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "B8w1oqPPQ5TsrQNrvm1qFe1azd1E9sGPTFHWQrHEa9Wc": {
         "account_type": "User",
@@ -6502,7 +7636,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "B8zmp1WmQdURTKaAfBy6h7iSJHLN4zpq9sBndNBgnrr7": {
         "account_type": "User",
@@ -6521,7 +7659,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "B9bYWiNoVV8ugbw5Q2uV7bJGC6pkirKrSWuSm9TjMdqn": {
         "account_type": "User",
@@ -6540,7 +7682,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "BEpg5KTQEpfMKJcNrEwa3q61arGyaromA3NnynLyb8LW": {
         "account_type": "User",
@@ -6559,7 +7705,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "BG7Wvpd8J4m1JE6xmLpEwovZ72AMqaKxNwngb3KXKdEm": {
         "account_type": "User",
@@ -6578,7 +7728,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "BJJjSMjwNFJKPGPrk7VB71v139ivgmgU2fep1ZYzqs8t": {
         "account_type": "User",
@@ -6597,7 +7751,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "BL1Vy1Bis3trondACcy34dr5QdUzLQT2WH3j4YjrE6oN": {
         "account_type": "User",
@@ -6616,7 +7774,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "tkmaiSoZ3F8MofkQBVWG6JYSCzyN6ioe7ReYXohx3WJ",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "BNcw4pQGveBW2A1cJzkWKrATK6evGA15KBvZ1zmc3DVL": {
         "account_type": "User",
@@ -6635,7 +7797,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "BRh8aRrv9y1Lhpbvwh6HcyHLsorS9zyKsoNC1W8cim31": {
         "account_type": "User",
@@ -6654,7 +7820,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "fotby1ABxpei2EVH9uXJ6KbHYgPjbg4Sny9eRzQjtRN",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "BVJE2G3AtxLiicgV3J75uoK2PANr5xNuxFCLRPzyF2Ww": {
         "account_type": "User",
@@ -6673,7 +7843,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "4b1onMDEasBh4BuPekQWijx3BYR64hAE1z2jJyeZUkck",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "BXrtpd1CKETFWLEgLwby4CyPDJ1B9CfMjWCtsZY3Pean": {
         "account_type": "User",
@@ -6692,7 +7866,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "BY3Ue7x5xAzoE99uWs6FL1buA89MVjFVdCCVZ25zinj7": {
         "account_type": "User",
@@ -6711,7 +7889,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "8KEPEcBY6vLZ8aWLm1eSgCPb3LCPHM2YpwzvSp5Cvi5t",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Bf2rpZeP2ZWURrQzMkcoRkXmZsmVKsV1ECRm8UPkYWbw": {
         "account_type": "User",
@@ -6730,7 +7912,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "FJDmjm2bkR49AxtBvABQphrYwjdjB54BP4XCW7ht4E4M",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "BhkX24EX1JdTfGDfEsJwNPUTFFstqtG2wPRxUnZmPUAW": {
         "account_type": "User",
@@ -6749,7 +7935,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "ChB6C6dmNujAi79XtQLPKLL5SWdNLMShA7KKnrMMFF52",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "BjM44uGZzmWfG8jG9RsrX5F9HHmMZUJMKg5f4wngdUjy": {
         "account_type": "User",
@@ -6768,7 +7958,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "93gu5F4pAh7Af1PU2QC5umWk1owr6NHDAJiQ9jWsBwoU",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Bp7T3qk6odrmcFwZpq7uXWcct4T3zzu7Bdy7ZCE88jCt": {
         "account_type": "User",
@@ -6787,7 +7981,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Bv8VFT63QrcaHRAGYm8xsgXRamPnzAXhjW38QbHyhZcF": {
         "account_type": "User",
@@ -6806,7 +8004,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "MagiCBYNPD9iTBXqiFybAFCREQzG6MSM4LmFLXQZxuV",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Bw3aUcKEzDii7hUgc6p1ysNGtswhw3LHPoNeRVDGGSmu": {
         "account_type": "User",
@@ -6825,7 +8027,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "BwzybrNMDy872YPLLmiQ4voub2GAxueC5qiDeE9PQ6Vz": {
         "account_type": "User",
@@ -6844,7 +8050,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "BxJktEfVcj2XXW6nPCc2XvsSHKMBatFyhE1eNSsgNLFv": {
         "account_type": "User",
@@ -6863,7 +8073,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "BxSz7hoxAuRaHL7py1Y3jTkCazgSoQhyfz8tNp1B5Qk1": {
         "account_type": "User",
@@ -6882,7 +8096,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "Fd7btgySsrjuo25CJCj7oE7VPMyezDhnx7pZkj2v69Nk",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "ByxuiPt1bPdqK5JBAVvqDa9imZ65z8kDtnUg8QUoYqVv": {
         "account_type": "User",
@@ -6901,7 +8119,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "BzYCVR2xba3n29Ya3hz6MuNSzMA483oMDzg8Nesust6K": {
         "account_type": "User",
@@ -6920,7 +8142,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "BziLgbVHN6SMGXBEtsjbB9MKcmomXEcJHmPa6p3LsvKV": {
         "account_type": "User",
@@ -6939,7 +8165,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Bzz3SKSY571WREg2NQx78hkqdQbHH6Lx8zRS9X8uWC4v": {
         "account_type": "User",
@@ -6958,7 +8188,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "C216T3B3wTA378a3GBqbYRGbsWRKV8XtiuxH6ts47RWi": {
         "account_type": "User",
@@ -6977,7 +8211,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "C2QTNoY9St95SyRKPPqkrLqK5TVqDzp42HFSARofU93g": {
         "account_type": "User",
@@ -6996,7 +8234,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "C3yZGLaWVcjMJG9rjwxnjrMDTDNyMKjG8ZWpaPFPzXu4": {
         "account_type": "User",
@@ -7015,7 +8257,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "C6b9Jv7yQP9vxUTwjaXDNrmxRmeQQPoaeJoQ9ynPQmgd": {
         "account_type": "User",
@@ -7034,7 +8280,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "C6nDvypiaMXwKBxvbUGpTKpEJWVhSYw5oyuLReqkHPjj": {
         "account_type": "User",
@@ -7053,7 +8303,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "C6yBxFXtt8LtkugiCrbDbcAf4maodqudap6pdX5PKJSn": {
         "account_type": "User",
@@ -7072,7 +8326,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "C9KmXKRAa2NJq25bW3QMLc9bk27yuuLxCkK1LihxQVX8": {
         "account_type": "User",
@@ -7091,7 +8349,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CAVRWVxW1u4zErzeBuJnFv5EynuYTbsW9foDe2tBVTRc": {
         "account_type": "User",
@@ -7110,7 +8372,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "CaveyttUBTKttncu1e4RF814XjuoGfYv8cEsiKGDNCPX",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CBPyYmEK7NmCKTPawNqEZckZsYr3ZWtGZaDuDmfoQdvV": {
         "account_type": "User",
@@ -7129,7 +8395,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CCUWWZKpj6CKQyE1pP8xeat9JTuKkxbgsNFHXWAaicK5": {
         "account_type": "User",
@@ -7148,7 +8418,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CDFsErWipEX3UTzkb8FCcpaAmbAXtQNVw3AW2UAHk2gK": {
         "account_type": "User",
@@ -7167,7 +8441,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "bay3wXfJsu9ds1zQBoQQ4DUwFGs3NP6q4gca9WM5G1z",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CG7YnYkXdVhEuj14EfKhU8ESQsTMRpaG3ut3yrfkFTgY": {
         "account_type": "User",
@@ -7186,7 +8464,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "PUmpKiNnSVAZ3w4KaFX6jKSjXUNHFShGkXbERo54xjb",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CLob35ugLgnGsGGR5xFQhtaLDnJJmXNhxpAf3AhjF3pd": {
         "account_type": "User",
@@ -7205,7 +8487,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "4W3jdXyqhLCjzA3Liu8ZNjViwrc6N9YjSB7obbxfjcKE",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CMdsHEaxQutLRsyqdd7C3fmjJSPAvRktEySEYzvN5YLU": {
         "account_type": "User",
@@ -7224,7 +8510,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CQDHckKVPXLUNgxAchnZZg8ETDU21SPRKD94n8HcSysh": {
         "account_type": "User",
@@ -7243,7 +8533,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "44ZDKo96gQR1h2afAA3oXgutUzHcRXH72RYxhtGxzWYk",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CQjupmFW3yorE4Lp4hbiBqjsseDXCY3n6PDKMCLVTWbi": {
         "account_type": "User",
@@ -7262,7 +8556,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CR7hKsuDLfKPCDimACVVGT1cK9jXLUVBUCfD1advmns2": {
         "account_type": "User",
@@ -7281,7 +8579,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "soLStaCk5TiGCpeLKa9Fvv6f5JQGMa6S3uhLh826e9N",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CRYnnKgZkQWWbX9YvBk2hVGCzgnUUgx8WJFCUJW2G3t9": {
         "account_type": "User",
@@ -7300,7 +8602,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "FACb6bbTDRBHCK999V8ox8jga5JBnt1r3vvzmAYAMv2o",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CTwJbShsFjUmwZZWr7CoK8JhCf7ctwxopzEsCCDVEoMc": {
         "account_type": "User",
@@ -7319,7 +8625,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "3tm92VTxwyZ5MDhGoYR4tVTkwWYkzfam6hwBjauUACCk",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CV3M3WJ9whfHVFhKQPF45hdWBCNeyzwE8J2V4XmCXQqA": {
         "account_type": "User",
@@ -7338,7 +8648,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CVig6e3b95cx6nttSj5w8VNW46RKjst8RneaUGaZjNZ2": {
         "account_type": "User",
@@ -7357,7 +8671,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CW6uvwNksyYg6q1mU9kBSKehVAVrAdT9A4PVjUHw8J2W": {
         "account_type": "User",
@@ -7376,7 +8694,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CWuX9MygyV5q59AXesdLCHoAePaCPXNCtPuUGoKds41q": {
         "account_type": "User",
@@ -7395,7 +8717,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "2NeqnzhgQBUEyMdWyVAXJjCYA3E2UTYXVdqutSQ27h17",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CcKvbqYBWKBD1Rm9T2e1GShLgCwKYpckwPiXrUJ8YD6j": {
         "account_type": "User",
@@ -7414,7 +8740,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CgPn5rMKyjHMvcCrEcFqwa9AhiWoWfdA9kg4yCBkjQkS": {
         "account_type": "User",
@@ -7433,7 +8763,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "nateKhsYkrVc992UuTfAhEEFQqr2zQfpGg9RafNkxdC",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Cgf5Tf91qBhJUie7tdHWQSDSAShG5gDzr4cWX1rxjqD2": {
         "account_type": "User",
@@ -7452,7 +8786,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "mrgn3H4uBbKAWBjdFKSGks3SpLm4q8YaRxUCMGa5ZBY",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CnhrAcSy4vQ2RuGKuhUFkMAzcEV1zwFkQ8QWVrELUcuL": {
         "account_type": "User",
@@ -7471,7 +8809,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "SP9K2c8Z1aaQaqdQgC6hZMJ5UCTTnE76XNYVse7H94b",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CqbT9gAJN5a8yW6odS2NoyrzESmoMgKb93n4gd1TcS4H": {
         "account_type": "User",
@@ -7490,7 +8832,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CrjfSbLED2cQoWVFSryQaYdTJuE8XeY91QH81Y8pvB5L": {
         "account_type": "User",
@@ -7509,7 +8855,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "5oZ4GSP4waw2fphYoUgdnChN29sH8nRXbBnP5Qa1TnEy",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Crxp1RdjHL1WVQMaWTQoKzwUTZ32P19AVKjfqu9KdPxf": {
         "account_type": "User",
@@ -7528,7 +8878,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "EPFZFVrXuveEQar9LaEkt5kDRPMnbvK54qu5FwCxpkcy",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CrzvyQ6LXnbiWzdhVkqNJhX3RdGy923uzgNj7EBxPv4q": {
         "account_type": "User",
@@ -7547,7 +8901,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CtcgeTiKVHXyK6CbvVyHk3XQ7fLwTJDFT8NeCWjf9z81": {
         "account_type": "User",
@@ -7566,7 +8924,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Cum5NcgZ1osLy9hy1JECSsLWHCXX48kMf4vRtgZnafUN": {
         "account_type": "User",
@@ -7585,7 +8947,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CvrzqWNs7SZqnybSjcFga7mq1sE9FCbPavptRrM2ha6j": {
         "account_type": "User",
@@ -7604,7 +8970,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CyMptNfCgWBmecyy14vwdxE3LGJpa8GafTp3sn8EAKMD": {
         "account_type": "User",
@@ -7623,7 +8993,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CyNP1gVXTcHqDUi4SnECt9LSHFDgdpQ4Z5jmfTAZXwpc": {
         "account_type": "User",
@@ -7642,7 +9016,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "CyodkpwoQJjzAeEv6JufbGpjBZHF1WwVjY4NZBAKfxE4": {
         "account_type": "User",
@@ -7661,7 +9039,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "D1Nfue3ZJ3s1GaWgasDv11vDLpwpojLVdD6rt9obMDr1": {
         "account_type": "User",
@@ -7680,7 +9062,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "D2gHNmoSuKk62zRvKKPtY8sjsYiLQoR8TTFyibccTjse": {
         "account_type": "User",
@@ -7699,7 +9085,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "D2zqupYaAoenrBVX8i9CgFk8C4YTuezncQ9Xae1J7CE1": {
         "account_type": "User",
@@ -7718,7 +9108,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "D4AHB2shWCkU7R6a6kQM6NLsSj4PGhiwmhiWWWm1FXMp": {
         "account_type": "User",
@@ -7737,7 +9131,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "D4zrTH36uzRiVfsgQAqecaSVEArBB4JjYjAz27sziQkG": {
         "account_type": "User",
@@ -7756,7 +9154,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "D5KzV51Tbh1dNZLErcWP8zCBtxA7sJmafKFzMuzwKd3H": {
         "account_type": "User",
@@ -7775,7 +9177,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "D5Pdp3AC4kQkWqVXo2wJLGLyrqvywMrPVzMRfM1vu6eu": {
         "account_type": "User",
@@ -7794,7 +9200,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "SFundNVpuWk89g211WKUZGkuu4BsKSp7PbnmRsPZLos",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "D5PuUAdV22kGuLuhi9kLiGUEd8DihjY2ELrcZwnF96ZQ": {
         "account_type": "User",
@@ -7813,7 +9223,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "D6iA8zA6gKSeZA4ZLzU7rcUdZZ2ttXA9u6XZQ33mDcn2": {
         "account_type": "User",
@@ -7832,7 +9246,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "Asugaagtr1sPMXrspRyNzHEGExdAwWafL7QSHjPyMFJU",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "D7rSWi7Szahikgj8ac65vMt9k39Tap41ExyDqsYLQo1f": {
         "account_type": "User",
@@ -7851,7 +9269,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "D87WpRG8gom5Ni451Tka8ZMqmwgUrF5hchXtpg5JWqLY": {
         "account_type": "User",
@@ -7870,7 +9292,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "D9C68gKEQkxi9Fa8y6HviDtXujYiGFALtzwSV6nMB9mj": {
         "account_type": "User",
@@ -7889,7 +9315,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "SP9K2c8Z1aaQaqdQgC6hZMJ5UCTTnE76XNYVse7H94b",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "D9tjr1AiYVCBjBNFpLagv7SJcPoeQQ39fQHpMrhg6zxg": {
         "account_type": "User",
@@ -7908,7 +9338,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "ByszyWdqC3rVMWy8f6jwK5cmwkpwYdwsr7UL58xS5vnm",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DBcnJgfBbbErdA6Dd2VqVmk4YHvF16ScS7hUVC2sEmqo": {
         "account_type": "User",
@@ -7927,7 +9361,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "J5AsxaHfWn6KpEcPRT9EZ9szvEMBQeHRe947UeaMPG3z",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DBdA3hgPHCKWrWDNgRv8Beg472JeNHCkYwnz6UMSAJRN": {
         "account_type": "User",
@@ -7946,7 +9384,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "dmMwc4RazLHkvDZYrWAfbHQ6cViAvNa5szCJKaiun8S",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DC3nBi3j3E6hGYtX8iHknK7HbDDvBd9CXvxqaKwBx6nw": {
         "account_type": "User",
@@ -7965,7 +9407,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "Ee8dX3qtwrDRnxYK6NGQfmMeKT3Qpp2QZHpxiAiw23W9",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DMunf9rXQtoLbqeY3EMh7TSfQ8y6K7hWnYGLmShKVmEa": {
         "account_type": "User",
@@ -7984,7 +9430,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DNgGnTvNnsVKY5edVbWfmv1ctCqnLVcVJcvyBmQK48ZR": {
         "account_type": "User",
@@ -8003,7 +9453,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "AR8uetaAnHRoPr6jvwKXWqd4YWbkbAXs5yreqo4HQHLQ",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DPQEcpDutJs1qojSVxeSMWFVouCMUuTPetFBJPcUXh8h": {
         "account_type": "User",
@@ -8022,7 +9476,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DPaEURr7JPrcr751MSkCwKhraU5LGdazFG4tNNEGwngf": {
         "account_type": "User",
@@ -8041,7 +9499,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "ByszyWdqC3rVMWy8f6jwK5cmwkpwYdwsr7UL58xS5vnm",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DRRHHQJLzMhEsJvdXHN1DBsxD2Xt9SeBdNcorHhtNYTf": {
         "account_type": "User",
@@ -8060,7 +9522,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DXQwvVP3AgRbBEcvrAG1o31CpjsHZx7MeTW5HapfXKAD": {
         "account_type": "User",
@@ -8079,7 +9545,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "9maF99FLLAMh5v5JKG1ZyRZVBVsT5VkZnAJzDvduCpJa",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DXZ6e3DA1bLioyp426oUFCyC8uLEtQf8nThKMy53WpVP": {
         "account_type": "User",
@@ -8098,7 +9568,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DXoZHceQmrHcw4d52kLYuCSjsfojuGfqTAUrcWm1Fn9F": {
         "account_type": "User",
@@ -8117,7 +9591,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DXyFR6fyjUrkaKJYJiwGSEWRUGFoixGfjvUbVMWgAgip": {
         "account_type": "User",
@@ -8136,7 +9614,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DZL9SKngmJwFh6hsL6kgi6Q69r3zvUwx2HHwhmNSGwEm": {
         "account_type": "User",
@@ -8155,7 +9637,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DbG82ENajH3HMcbmZYhdAKcJ4GJcWL6pY4ZLh5SDunzT": {
         "account_type": "User",
@@ -8174,7 +9660,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "By8MseMKtZQQaQjMHJiyetmc5AC8RZZv8C2ss33ktrHt",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DcsUrQ6KYVWU8r1RMi3H8ggvFu4FkFsAfX19vJWiTtgR": {
         "account_type": "User",
@@ -8193,7 +9683,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Dk4Aqm266DpAQu6NrZSNSzaCztSRSCcQdKN2uxfuVNvM": {
         "account_type": "User",
@@ -8212,7 +9706,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "FFevTkywysWf8PJvH4DZkEp4v9ks9HJPJhZWbhhJiYnr",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DmGKW6MCRKDjDC9wzuitJNTDJNPydyjkoUAB5QdTs1Bx": {
         "account_type": "User",
@@ -8231,7 +9729,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DmoyEH4XfBGk7WGzA16EBs88vtbsup8qEVKLmMeh2EPG": {
         "account_type": "User",
@@ -8250,7 +9752,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DpjpDj4gGVH18opJfcg42xWJVWjeH96C4MqX8xK21nKJ": {
         "account_type": "User",
@@ -8269,7 +9775,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "FSKbsgvtnKtJZcxmWUkcJjwZBytXeqM5giwaBzVjbpim",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DrRFM3mnRELyMUayGz3maCao2wk74XPAfcds7hfGgs6": {
         "account_type": "User",
@@ -8288,7 +9798,11 @@
         "publishers": "",
         "subscribers": "AR8DvEn77GRQ19drMhPCjvFx2StcRJ8XbLVKS6yrgQAV",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DtdychMWj9yiNBtfSvciwuviyn2umZ1tqLmmMQpBNYkD": {
         "account_type": "User",
@@ -8307,7 +9821,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "DyDxUnzxb53c2WQGFnNxTiCNMhi91XJBL9mZHxeRs6qo": {
         "account_type": "User",
@@ -8326,7 +9844,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "nymsHergYedT9CJMgtGMvqXUTGcbs5o3MiWTJUbqTGY",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "E1dJqB41wFU2pnWgW5MGYrpUbToHAMQCAPVbz3441UBS": {
         "account_type": "User",
@@ -8345,7 +9867,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "simpRo1FrQYGa1moicfgnPDp6KyE38d4gYrZzhjXYJb",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "E3fB8UE2SL7x1qdp5HDiBrvSST2xhuoXZLTDaCbZRAWH": {
         "account_type": "User",
@@ -8364,7 +9890,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "E3n7ZLjaBGn2Jrx9Z9W4cfkHK6LwoSXZJM74NDQsJ37Q": {
         "account_type": "User",
@@ -8383,7 +9913,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "E5QEtm5m49KyvYVwi8EEAH74bTd9KqUhLPNr32FDwbJN": {
         "account_type": "User",
@@ -8402,7 +9936,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "hxMhrsuGPDmkLJ4mTxEjyeMST3VGhTiwJvS9XgHwePj",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "E6TM9HBDDS8kQ8177BDJ3DxvYWyzGyqgDLhS3psWxwzB": {
         "account_type": "User",
@@ -8421,7 +9959,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "E75r3QcvUZoxG2zSmdHqm2gPNmJeEqRYymCPtSKQfDZt": {
         "account_type": "User",
@@ -8440,7 +9982,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EBHaiW6YnpDpY1FiUkk58JB7bgtBhVjpchJvqArDBQK8": {
         "account_type": "User",
@@ -8459,7 +10005,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "ECbhh8dymhCFXgFjrHhcP5EGMSsNg839228DpUaXAZEF": {
         "account_type": "User",
@@ -8478,7 +10028,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EDyFfsRup8cruW8dNRKm7ETX2vjDQyxcxvs5JiXHxnMJ": {
         "account_type": "User",
@@ -8497,7 +10051,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EF5t2y54LwhFMFoQFKvv3hKP5NWPig3cDNrjcPAZXVsM": {
         "account_type": "User",
@@ -8516,7 +10074,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "Fx8ATrRvjMnmUCjjDaUFcyjhbLVPzZJicj32bDcraqBz",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EFM3WnyQ7EhJwKCu2LiywCZtvJtps9fs5LaKmwwietGZ": {
         "account_type": "User",
@@ -8535,7 +10097,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "AB821LfpFBwedJEfoNFZRsiPvcSxXPBNMgjyGC7RuNfS",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EFx6HSfe3dzuFSQtYsyGa4Nv585tinGGzMVovtXj2pBC": {
         "account_type": "User",
@@ -8554,7 +10120,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EJNkfaDPvFKaYYX79Tsk89vbhT32LHB1Mqg47aJbdSUm": {
         "account_type": "User",
@@ -8573,7 +10143,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "BDMzcU37JaQGHkkZkdQZU45o8zJWLjmX8DXVxnGtLXfd",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EJz44sV7zdcL3qpo95oVt24XCZuwYijCGC4EByPpWCaw": {
         "account_type": "User",
@@ -8592,7 +10166,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "7Nu9ckgtjobZ3MkbadGFKEvRymYuah9HmcxiUJKMM9NB",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EMQ7JzVEgN92ydryk4JGcNy2GDRWFFXYBRFs7U7CfCWB": {
         "account_type": "User",
@@ -8611,7 +10189,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "ENL9g12sBZSKX7h9AYny1WChnH8Ac6VjSBkVYRfrUpsh": {
         "account_type": "User",
@@ -8630,7 +10212,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "2Ue9zGmDnvYRrJNEjuAdNkbbickw6fKWtbeNM7T2rakg",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EPt4d6fjHLTAV3efShC3FkpQ1xZyyy9siJbJ6CmeApkP": {
         "account_type": "User",
@@ -8649,7 +10235,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EQtLnW1JXoioSQ6vAzy6cj1Tj2CTqmHBb3seiD8jf19b": {
         "account_type": "User",
@@ -8668,7 +10258,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "ERotm7GH5oaR4dk4SxYJVAjuwozBWpx54urMVWhEg5vv": {
         "account_type": "User",
@@ -8687,7 +10281,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "ESYDErt99sqpjN5s7LnjaABz8huCJwSrSHdFThW2bVZF": {
         "account_type": "User",
@@ -8706,7 +10304,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EW5Mujb5zzAXtRjwysh5hPeCmJgTHM16HFFgp1xUv1LT": {
         "account_type": "User",
@@ -8725,7 +10327,11 @@
         "publishers": "AR8DvEn77GRQ19drMhPCjvFx2StcRJ8XbLVKS6yrgQAV",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Eayr68WJHskFjXjXmsapwyueU74kbKd1QmaRPMJfX5CD": {
         "account_type": "User",
@@ -8744,7 +10350,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Ec6ZZrfQDeVFBJ8EtydY7BKJ4Jdmw3ZWmjvwZjrWq291": {
         "account_type": "User",
@@ -8763,7 +10373,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EcxArW1LnwaUhjVBsKCy55N1cigjsTPhh6NYTB8YDNWs": {
         "account_type": "User",
@@ -8782,7 +10396,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "8Q7K2irCbYfEG5ZWyBceiytbL1u977gXqw7UaHZ55Awo",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Ed98PzWbgEid7rRuSrfphGoP49tEFqfj8gBkbZiEB8bv": {
         "account_type": "User",
@@ -8801,7 +10419,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "F3tdN8SoakjEPb743VY18YyKJWYHo6rojV3nkas5YJh8",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EfEpvyfXxE9qkc7efBYwANSzpeuzPA9UbVuZg61sqXKt": {
         "account_type": "User",
@@ -8820,7 +10442,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "451X5rboJpJtXK2gj4dLsXv8yCGfujqus2HsYjMkkSpE",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EhYPtideUiJQwdTBHBDJG8qvhSpr4KZ6Ze9oDSqJtWi": {
         "account_type": "User",
@@ -8839,7 +10465,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EjLCPqxzDERVyYvis5cuwzVuwSN9GAziWXJEk5erjT8e": {
         "account_type": "User",
@@ -8858,7 +10488,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EjYtKcpnNA4jCdxfojvt2uUWApznp3BWecwErE3JvtgD": {
         "account_type": "User",
@@ -8877,7 +10511,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Eku8XjoxF5rw6m7nYJG5E6nXYWnDsXwfKsXJbCjzpmEc": {
         "account_type": "User",
@@ -8896,7 +10534,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "8Z7QvPn2w9ERGPYDY4DQh42oSxdXWcX4eZoiHLe3dHcu",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EmWtQiDcqPkDH7dMYJZKrtY9Wk79BDKZJVjtRVGkectW": {
         "account_type": "User",
@@ -8915,7 +10557,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EpFGcx5Ge7YJ9BrMAUC9ACE9G9NAyfVJHACgcBchtDPA": {
         "account_type": "User",
@@ -8934,7 +10580,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "NATsUSZGohWw8xtLdxG4yus21UCkaes4FLfM2eqKbRk",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EpS8xH8xFuMpicy33FMfgq6kF11DvccF9z4BSgKFX4mz": {
         "account_type": "User",
@@ -8953,7 +10603,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EuxKuiCdSEk5mTHCaT7yJ7Rvd8B2JNNG1xuicdujjG4G": {
         "account_type": "User",
@@ -8972,7 +10626,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "zeroT6PTAEjipvZuACTh1mbGCqTHgA6i1ped9DcuidX",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Ev2KACv1EHqPetZVpFvy15sKNsGVaGDpDyHrhh5ye4hK": {
         "account_type": "User",
@@ -8991,7 +10649,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "EvfGJ22veyLBZReevctXm2NDfHofxTrg1P3jYQohybyY": {
         "account_type": "User",
@@ -9010,7 +10672,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "F39gcK1J1eBKnES6hz1riXpxQCmXAX2X3bG5Bsj3URhc": {
         "account_type": "User",
@@ -9029,7 +10695,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "EWARp8Syq8cTWGWHtP5LT9fKAn5GvXfSCH8LfAwpgQ6m",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "F55WVRpoChLMmuPKCioMSnTirraAiAmDkESrpToJx6RV": {
         "account_type": "User",
@@ -9048,7 +10718,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "F7FeEdo2SCAZ4LQaqiddjDkYjgbkW7ECbpWaG4SQipM9": {
         "account_type": "User",
@@ -9067,7 +10741,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "8vhc44Xia6we1vNdgZp3r8PpPLj5pqntpssnS27iHiVi",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "F9MiwPYesFfHydV8jp69Ud4QrUKMg2JNasTqyRX9K62C": {
         "account_type": "User",
@@ -9086,7 +10764,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "FDbsmrKxQWTWTHFF85GGWtsb6mfzKip2uSkx326MqJDv": {
         "account_type": "User",
@@ -9105,7 +10787,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "kRUJJGpMGU8geCdogsjknkZuFcJpD6UQxUUgCCWfnAH",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "FDc4BYtKJ6c17woMGamVikuhYcKLQyHLYcyxePAGEc1m": {
         "account_type": "User",
@@ -9124,7 +10810,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "2AKKnirWVZMhnzuwqpizw9SwfZjGpRFLx2zCCNtPWpbc",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "FJtosrMJj82zvE7yxoeumz8QowNrucufsaVYBNdg8kEJ": {
         "account_type": "User",
@@ -9143,7 +10833,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "FMyHAPn5br1daSTakxPiPSPrjpwp89riKFCvTZCWtJ18": {
         "account_type": "User",
@@ -9162,7 +10856,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "FSVkUcuqkDEbyR78jshP2qVmwMKKS93gcmvBst9KoLgP": {
         "account_type": "User",
@@ -9181,7 +10879,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "b1ueZK9bWTywN2587zsScyLTaH18wfRfN5W15XnkiqF",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "FUPHBs7VYQ6p6kBRAxLzK17Qbut5b9YriTi2j6Tzrf4V": {
         "account_type": "User",
@@ -9200,7 +10902,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "FVRCYQtCrvuPX3YS3E9WycY2Mn4P18AA6SiLHKy1etbH": {
         "account_type": "User",
@@ -9219,7 +10925,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "GzK6vbP3fejCMqja1veNtN3kF3s8KubDCwApnkVeyGt4",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "FhmURy15L36gH5fhDGbfMiEBWwmjfnDhZbABLxbBGZtE": {
         "account_type": "User",
@@ -9238,7 +10948,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "FkyLjDkMjJZyjo7h1BJG3twYZLhvU5PYV4LJACQZaJ8k": {
         "account_type": "User",
@@ -9257,7 +10971,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "xkN8xAw8kQAvUjcpqnxBM5hYdrXRUJtHotK8WuK649M",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Fn3mMWaC2nAZuQxye77S4mkYabgUMaueEXwsjy6dAkbo": {
         "account_type": "User",
@@ -9276,7 +10994,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "D6uUDTEgXDf1yzLuQfFFCEKF9a2Ri5trFAWwaUpKB2ji",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "FnPeigx89jHEGGmcqvEL3nbbJvnbyc4KNz71H7o3U2qo": {
         "account_type": "User",
@@ -9295,7 +11017,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "sf1G9ySUNSWRsiEdc8vuXcBgSeQw93kjr9sgnH3XAik",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Fs9eTGAooNfsQJ914uJDco7k7xvdCGtdaQNuMEXmueH5": {
         "account_type": "User",
@@ -9314,7 +11040,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "FsoHPm3MxpjDBSpqXJANnZ5iHUX58KLCKfXMt2gUXQsk": {
         "account_type": "User",
@@ -9333,7 +11063,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "FtjdrqSFBTv2P8dv3F8C4n5BVAU6moqR3fW2QU7ApSRk": {
         "account_type": "User",
@@ -9352,7 +11086,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "FuF88sYU7Z5k3prGMp92Jes9Rgme9Q54N3rdkWTXDwaH": {
         "account_type": "User",
@@ -9371,7 +11109,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "FwuUKhTwu7ZyShrWR9txorKJDENbcETVFy8mDgbHom8v": {
         "account_type": "User",
@@ -9390,7 +11132,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Fy5aVzz8snsaHFshRWwKZWVEswDmwdNzuVfa2GRCs7HP": {
         "account_type": "User",
@@ -9409,7 +11155,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "G3Pa4L1snEbuGy67KiUgDPrsKQFKNDBkBUjRhT4S41hQ": {
         "account_type": "User",
@@ -9428,7 +11178,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "G4TJWzkuDmbJJcsgftf97DoD6eMwQpLjR39L3hmV4poK": {
         "account_type": "User",
@@ -9447,7 +11201,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "G5d6QsZithMGbXdpquLeS7tRLSqZXAn85zXwm7ZP62AU": {
         "account_type": "User",
@@ -9466,7 +11224,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "G9aZN6bsgQCjhqNA69hgADRjf7tn9BJqSgVYBJQsLYtb": {
         "account_type": "User",
@@ -9485,7 +11247,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "GBZVdYv5eEftQxp3UzK3q8LVSGDoawDo49DnRRVDDV29": {
         "account_type": "User",
@@ -9504,7 +11270,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "GC4cjZEkg5FBkksjtQVFayKJrKcGFjPRoPCZZ3h66LwH": {
         "account_type": "User",
@@ -9523,7 +11293,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "7VZM7YHcX73TpGoXDeBu61g4QKC86GwAEnew8dA7Y2xn",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "GFFyCszTdWoFoqsCi4tUfdNAxQYaa4SmyV9AgtB5hFWE": {
         "account_type": "User",
@@ -9542,7 +11316,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "GFv1VyQ3Zow2ry3pbrMJ6Wzs8S46auA5CQqt1VSghx4z": {
         "account_type": "User",
@@ -9561,7 +11339,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "GPPVGRZC8XcUhEk8wgioDWU26Uh87S2DakkYv4WFx4XQ": {
         "account_type": "User",
@@ -9580,7 +11362,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "GPwumVi6xddR5WhSXKMNYxyrzk6X3ktTasQZ3Hw4r4qT": {
         "account_type": "User",
@@ -9599,7 +11385,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "BNtHBLo1L2vAG7PBQ6mJvWz7GqVPxBnioXsY2Gjtubrg",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "GSZSoCALVXD516a2fpDRYqXCrSeD5S8Sqcrtiqkf2HXu": {
         "account_type": "User",
@@ -9618,7 +11408,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "7MTjmteQHhthwwTZhUzsc2dP4NBvGNRqj8jzdqNxHFGE",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "GVE6ch3eG989RVw4st19sssvfCrgHUHqtbbcNaJVyhAr": {
         "account_type": "User",
@@ -9637,7 +11431,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "GVtCj5wFGcLV2GPbP2M1H8jqK1VTe88tbdrD4YCJmUWA": {
         "account_type": "User",
@@ -9656,7 +11454,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "TrUtH9WTw1jBVuuExpm3MnC5XF7mW6J3x6oXXA9yX4U",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "GXaJaUQ3zYZb9pAF9MpFH5U29DVo2XMZsaPe67qvmYmM": {
         "account_type": "User",
@@ -9675,7 +11477,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "GbVi8ePjsuVQVM6d4jUt6HxDAJUHWR3fn2r3SV2sbvHF": {
         "account_type": "User",
@@ -9694,7 +11500,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Gc3Xs8uPq835Y6ziGFWAmh6s4tdNqErbdeBkF5KdARD": {
         "account_type": "User",
@@ -9713,7 +11523,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Ge1TLCkojydtkyWgFxd6M4r816nzerT36zs2APyEskYa": {
         "account_type": "User",
@@ -9732,7 +11546,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "chdvWr6T14nqGRFD37KY36dsvhkCtDaufW5rpu3AfHe",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "GgNkf17VYAoBM3qt6DAfqUpAcPpnjAcSDctyukfaEvXK": {
         "account_type": "User",
@@ -9751,7 +11569,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Ghj5X57VvsG78SZsTRZrpa1wuNoadjgco3k8MgCZH1wu": {
         "account_type": "User",
@@ -9770,7 +11592,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "GiMGw9KrikUj4RgfyauhhDAeyvWLiNqn7kJjj3mYLPDf": {
         "account_type": "User",
@@ -9789,7 +11615,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "GjYXh58zsPfh6jyu1muLs5DNjmZEgT1V473AwhULqiyQ": {
         "account_type": "User",
@@ -9808,7 +11638,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "GkgyJu34ZAEN84MuCsQgnma9vMXmDs2zwnxY2KiwB3y3": {
         "account_type": "User",
@@ -9827,7 +11661,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "CtzN7ysR5rX69qd168Aosbuc83mPozhi81bEHbG7ecNP",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "GmZJWCnHALh1oD2MCRFAdD67A7v96MXLRP7pxCSf3caD": {
         "account_type": "User",
@@ -9846,7 +11684,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "5tGM5Ri56WdzhpdPrWpCQPRjM3rp3xQQGn4bpT6acH9V",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Gqfzisqkgw6Dz8JqsMY2KKaJRzTGY5ZhVHLBcSTUn8Nu": {
         "account_type": "User",
@@ -9865,7 +11707,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Gu5qNRonEr32C4bHMXZ6yQpZHVViTcTRsrZJmmbe6LTR": {
         "account_type": "User",
@@ -9884,7 +11730,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "GuE9kvFh2xkoArcFZhkGfidVFGyo6hSovsJcQYK5eNL1": {
         "account_type": "User",
@@ -9903,7 +11753,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "adre1Xia7ekGsEqNgHeFc7MYwkfzTQNeJgQmZ2agAKZ",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Gy7QiYVgcspkQuVz5tzBssYcLkKBNeazDuNprSEadHRi": {
         "account_type": "User",
@@ -9922,7 +11776,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "GyH2mEVwk8kSF5zndJW1FxDNUiYY2khR8rwRHX8tgzd2": {
         "account_type": "User",
@@ -9941,7 +11799,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "Hhn4usDjnktbPURJHbi4YrPdKudBD5Qq35mTcaQ3Uu6",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "GzgSbh9a1gcECmJziawzJ7MaKwMn5PSdq4qqEHY2KqxV": {
         "account_type": "User",
@@ -9960,7 +11822,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "H1uEJA3GChED7akvT6F6FmZAo4QYZqP1T2KsTGyJfMLv": {
         "account_type": "User",
@@ -9979,7 +11845,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "H4SFxqRfDCbL5jggUaUeFuU8a1UuAGvsVCGwsS789e3x": {
         "account_type": "User",
@@ -9998,7 +11868,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "H6aKUkTvKtKGt9SRY8UFESG1RarnTrz8CzZB1n8Xm73n": {
         "account_type": "User",
@@ -10017,7 +11891,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "6xUK9Nbonr4eoJNtHGoUEMmYKoPz5mipKzyDBv6deX4d",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HABixeCgQue8xuaiuQPBgJbfCsZ7xZzrehE9EUYr5qE1": {
         "account_type": "User",
@@ -10036,7 +11914,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HB5jpt7UFap22JFk8r9YK1Su5Tq3Y57RbtU17CVPQu5w": {
         "account_type": "User",
@@ -10055,7 +11937,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HDnY5x6DQGxvaFbi9Qq1CdbT1LzCAaQpotnAYWMEtazL": {
         "account_type": "User",
@@ -10074,7 +11960,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HGStSViv3LzcBawEC3dgRVSjno1cth4HfMQ7rj88F914": {
         "account_type": "User",
@@ -10093,7 +11983,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "4JTfCRjd6SzZdoKqdvStHvaKHBYCe9iENAnG4iDTrGW2",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HJnLnipV8RJSuFvjeiMhnQGpiHGVL6PntecHvSTATtLE": {
         "account_type": "User",
@@ -10112,7 +12006,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "6xFDLX751L7H9d5fQT9sf2SM5RWWE9LDgqz25pPDbWoJ",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HNyni8E4Af1epoEiMjKRVaCjTHc2S4NHBCxiZmqxxXvK": {
         "account_type": "User",
@@ -10131,7 +12029,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "7Nn8qBJey7vXtVFMNBbbuN8UkujU8Y6nWzbHVGuf49yV",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HPqvor8z8DwuBVXheLM2t8Ab3BJ2xaZSLsMDZ67589vh": {
         "account_type": "User",
@@ -10150,7 +12052,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "DWGupvBwXjUudG1fPqtcuw4qe6ByDzzLhnbr5z7RGWsL",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HSDR76enLUDKug3RbnTB54WnppZRt8umvA94oqfqTiiz": {
         "account_type": "User",
@@ -10169,7 +12075,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HT7FrupdBEM1iBzjgfpSXc6NPgoayyuj9n1jUTkksNVz": {
         "account_type": "User",
@@ -10188,7 +12098,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "pitch9cMruwjDtAnisNS4mwZUPhMsBztNEGu2weMg55",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HZZJXiRHaw63hccbkjsQj21J38sHmZc2W6LLQyfBqhbz": {
         "account_type": "User",
@@ -10207,7 +12121,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "DEgenZMznWXvg5YHaZM75arVTauV453SeXX1UrxcGNup",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HaFarP1T6Nn4R3L4cB9BkZZHzuSZ4t3f4K4peMWbZN61": {
         "account_type": "User",
@@ -10226,7 +12144,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HaThCyQ5LZjNdt4ieWme1HNjPoFMUMxenFPXUnyzugir": {
         "account_type": "User",
@@ -10245,7 +12167,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HcChBAj3m1q2TZJaREhRg2RAxtp6RDmRnrKZUtn5xPYc": {
         "account_type": "User",
@@ -10264,7 +12190,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "He2E6CfYixcwuKWjPuwPmH47Ffbxtp58SmHJJ9Eqd6wx": {
         "account_type": "User",
@@ -10283,7 +12213,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HipKYESgP1tozPA7yWjEVn4cr3ZTftBLgcX2co8Gf3DL": {
         "account_type": "User",
@@ -10302,7 +12236,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "wetkjRRRDrSPAzHqfVHtFDbhNnejKm5UPfkHeccFCpo",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HmyT3k82a5FDTuMPAx6GV1bzB4Pmwd64V8uSDEV13V4L": {
         "account_type": "User",
@@ -10321,7 +12259,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "2iXZmNQmmgE5ZeTQ1GMhhYGDqDr2BiqdEu3DbGJDo8MA",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HoYNCtjtd5XYjtXodjHxwdqXq8Y8vvXcgDqU4DHykrWv": {
         "account_type": "User",
@@ -10340,7 +12282,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Hp4GXwuyBmV6BJemAfwaPggkZSFGuagt9ce1PEkh3dzG": {
         "account_type": "User",
@@ -10359,7 +12305,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "AsMpvJ3DZ2Ydu1WTRMAyMH4QjSLiUG39rKzfzvtE1bWr",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HpFkt8EKASUcMS4WUy2985xBWte55tR7adr6WP4b33RP": {
         "account_type": "User",
@@ -10378,7 +12328,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Hpjj2oqW5Ho1k72Z51XggyvmT4aYbemsZQvW5BaD5M4P": {
         "account_type": "User",
@@ -10397,7 +12351,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HqMv1iMnATznh2mKZ5wfBmRwsxVn7rHL9TA1ohLUrBzn": {
         "account_type": "User",
@@ -10416,7 +12374,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Hqrd3L18C2peJWtT2kcwmDRni4sXWcHGUh8FUWH8jvpE": {
         "account_type": "User",
@@ -10435,7 +12397,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "9q16BB7WGmBxf1nJTdxH5zPnBUhtHqdqXqRFjSjuM4k7",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Hrmg9mk35Dcfae7FGomzhU6vzeyjyerx7QZesanmnvBb": {
         "account_type": "User",
@@ -10454,7 +12420,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "F5CRSKK34yQ1G43WnnP5vy9sj4YxthBWM4ct3wGzaB6n",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HstLTG31MfWWKkPd4tY4xRgug6SYCFiLbpF2L5wbcv3r": {
         "account_type": "User",
@@ -10473,7 +12443,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HvvkL8qzkp51oqQMHs7ADUWdWnEoCJsJyced2P6s1MyC": {
         "account_type": "User",
@@ -10492,7 +12466,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "G8PRbhRgmsfVycBjSmzswifnZRd4ZEWBiREQSymbKUY9",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HwCf5jZ98iJ6RJAdouvAUSJ4ZVbtanUs3xfmCvMTDZXB": {
         "account_type": "User",
@@ -10511,7 +12489,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Hwr7JBiUT92KgKUNvDXf5Qth8FN1NV2Qz3jhqQxhgy8r": {
         "account_type": "User",
@@ -10530,7 +12512,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "7Hp1e6BrTBkbBN4wFiNmycPVPsjvyUUBL2tGhYEMT6gt",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HxdA3vGBxGTY9vYCkvdp6mJFrEpQLkMmJKdEF2Vu4SZS": {
         "account_type": "User",
@@ -10549,7 +12535,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "4SgoyAwN26iu9Gpf12Bk1rnzp4G4yDUM3XVv4w7VQcAf",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "HzsJA9LokNsn74uDDRqfDMEFcAQYeEEkPhdwPYqDtmpC": {
         "account_type": "User",
@@ -10568,7 +12558,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "J2TzQM4mGEp62GjWPa8pq1iAVESVEyYCdGL8unA4HUc4": {
         "account_type": "User",
@@ -10587,7 +12581,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "J4yagS5s41tDwF1CbUUSfLagj6jqjGNqTcCCtpRsPuDi": {
         "account_type": "User",
@@ -10606,7 +12604,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "J6CxQAhPNn2pWic4XeR52Zwmf7UdzB2fSNeGR7mtj3JL": {
         "account_type": "User",
@@ -10625,7 +12627,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "J77KZsSXzK11AA3uLHxZRpodyLNG1ykmZkC986eFgUWY": {
         "account_type": "User",
@@ -10644,7 +12650,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "SLAY6uN1zZpXBTfbuDDCesNmM5D288xrz8uYvfS3n41",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "J8mqm4F5NM63PCGskoSDyWi1xesvC8CwnSaxpdMaqRpS": {
         "account_type": "User",
@@ -10663,7 +12673,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "J9mci6bntpAA5DGf8DktR22VvQQpsxDj3TJ9fpZB3E4C": {
         "account_type": "User",
@@ -10682,7 +12696,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "JALjgjwuaAALGoSGBX1CmW6P7WiJXxEoxQB4wzDQmrPu": {
         "account_type": "User",
@@ -10701,7 +12719,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "JCKChHjPd2mm9doH6kF9UPE3g41GJijZSrEQfiFeJcfJ": {
         "account_type": "User",
@@ -10720,7 +12742,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "JE5PJ8DLq4oXH7iqyzUGVvXwRj9czmFYHXhA3tiZdoyU": {
         "account_type": "User",
@@ -10739,7 +12765,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "LLTPYpkezF39ghUpG2gdrRJ92yTfrymDj7UktGaaUrX": {
         "account_type": "User",
@@ -10758,7 +12788,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "N3T66SpnQTeTuFGkqhPk31r3Dmevmk8rAGYJqXfgdZu": {
         "account_type": "User",
@@ -10777,7 +12811,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "BeRtYZnaaZLFwYQRPaZcxuuHBmyFBSGP32C8Ls5xnrZP",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "SAcRTNiKLF7V7Lh6S5yXR21uYPVweW2YkbPmBnuBAJH": {
         "account_type": "User",
@@ -10796,7 +12834,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "BoNKmNCGvoHS4CkKvYRnF21iEpUP827pZjhFGdA4t5as",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "VXoKVBcjkQBKwgxpz5Wu9b84gC9uUyD3Bj5uP4hgcyh": {
         "account_type": "User",
@@ -10815,7 +12857,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "VjkytjCDXh2MEG8y2xa9S68ghhDgZJw4tT44jy473sQ": {
         "account_type": "User",
@@ -10834,7 +12880,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "Y1Uyvq2CUuTy2pCeDsovGBF2ReSpbEegZks3dqLCn4a": {
         "account_type": "User",
@@ -10853,7 +12903,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "YStjoWyFCVWbFeRUViHaVnqHDoqA2x2wsUKsjQxeiY4": {
         "account_type": "User",
@@ -10872,7 +12926,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "7VZM7YHcX73TpGoXDeBu61g4QKC86GwAEnew8dA7Y2xn",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "YVYW6K4oHSEcvd1VyKFWFy78iQktNVegPNH4aPDPZ7U": {
         "account_type": "User",
@@ -10891,7 +12949,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "bCohjxaUkXq5G7TdSGztLnCcusbyEtJB1btS91gqJVy": {
         "account_type": "User",
@@ -10910,7 +12972,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "c2N18veCkMoSsJ4ozzRf1NjNCH85wsjjRY7mfw6M7JS": {
         "account_type": "User",
@@ -10929,7 +12995,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "et1BU84izg3x5c2UvLJbjhkiKWC9xJofNyQGSigKt4P": {
         "account_type": "User",
@@ -10948,7 +13018,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "DwGEK1ZSC5SM9e7Tkts5hLpkUffAsFUcqeLr2zifaXZi",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "gJbF866smjL4HZqc8nan5FgrvZ7Nf4sNkwSMh9gzBbP": {
         "account_type": "User",
@@ -10967,7 +13041,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "DWwZGTzddxgZ9qCQiGzydcdEbjBNkfSL7Y6c6oYBYk8v",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "jhsaYa875hTeWZUYE9LJWS117szm8x5cvnqKddJtpzt": {
         "account_type": "User",
@@ -10986,7 +13064,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "SP9K2c8Z1aaQaqdQgC6hZMJ5UCTTnE76XNYVse7H94b",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "kQwtrVocVcJ9AFLDKChi81Jd6zLu8Z3pzdmd4mYJz8a": {
         "account_type": "User",
@@ -11005,7 +13087,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "m3ePtcQJiTCi8cM9bSqnJ459BJ9B2zWxhbQyRjenjUR": {
         "account_type": "User",
@@ -11024,7 +13110,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "vALigXFg9wnnhVHN16vNxHxXtAXiBv5QjAE6udoniBY",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "mowi28JfbopAkgUcuutTAyCU7gTjFXtauybyKUJkr9Y": {
         "account_type": "User",
@@ -11043,7 +13133,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "naYZQdL57WF4PdAa7ctKKrzeFVgtFhQUDGCZgqF6Y98": {
         "account_type": "User",
@@ -11062,7 +13156,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "4YGgmwyqztpJeAi3pzHQ4Gf9cWrMHCjZaWeWoCK6zz6X",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "q2AEcvhg5ZGMtiuuHfjPG95PqnnMdJ8UyvVRakyRFJE": {
         "account_type": "User",
@@ -11081,7 +13179,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "CZ2xJQHwiojrAgrR2BUNheuWxXGjSVSZrkcxFcAGoSUH",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "rDzzH1Y9ajh9crytVMBR5ifYNt3VRKTazqzjJuw4f3y": {
         "account_type": "User",
@@ -11100,7 +13202,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "YE11a5nVJtUNqsojkphYuWc7StqBzbCeFH6BjhAAUEV",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "rEUqVFUFmyJkhaXNNMcMWoT92cPDR9BmHKMiqt6tcJv": {
         "account_type": "User",
@@ -11119,7 +13225,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "6pVZhUW9AZMMFuNVMUds8useZHB7VFT4vvxuA3B9JgW4",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "v2k88RzCLGvtCGoa3w1nbxTbAuTcGLL8GmryfJnzcVB": {
         "account_type": "User",
@@ -11138,7 +13248,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "11111111111111111111111111111111",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       },
       "v866oGLAM8mhhLch4Qxub2fgmQm1rYrjQorMfGe1Lh9": {
         "account_type": "User",
@@ -11157,7 +13271,11 @@
         "publishers": "",
         "subscribers": "",
         "validator_pubkey": "8SZcsqGPxv5Y2YQfjH2A5XMqvcFSfYgxTKZLNwKhs2sN",
-        "tunnel_endpoint": "0.0.0.0"
+        "tunnel_endpoint": "0.0.0.0",
+        "tunnel_flags": 0,
+        "bgp_status": "Unknown",
+        "last_bgp_up_at": 0,
+        "last_bgp_reported_at": 0
       }
     },
     "multicast_groups": {

--- a/crates/sentinel/CHANGELOG.md
+++ b/crates/sentinel/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- feat(sentinel): run multicast publisher sentinel, gated by `--multicast-autoconnect-enabled` with `JitoLabs`/`AgaveBam` client filter ([#349](https://github.com/doublezerofoundation/doublezero-offchain/pull/349))
 - fix(sentinel): adapt to SetAccessPassArgs API change after doublezero dep bump
 - refactor(sentinel): replace `multicast_group_codes` setting with `multicast_group_pubkeys` ([#315](https://github.com/doublezerofoundation/doublezero-offchain/pull/315))
 - fix(sentinel): associate access passes with solana tenant PDA ([#283](https://github.com/doublezerofoundation/doublezero-offchain/pull/283))

--- a/crates/sentinel/Cargo.toml
+++ b/crates/sentinel/Cargo.toml
@@ -17,6 +17,7 @@ borsh.workspace = true
 clap.workspace = true
 config.workspace = true
 doublezero-passport.workspace = true
+doublezero-sentinel.workspace = true
 doublezero-program-common.workspace = true
 doublezero-program-tools.workspace = true
 doublezero-record.workspace = true

--- a/crates/sentinel/src/main.rs
+++ b/crates/sentinel/src/main.rs
@@ -6,6 +6,7 @@ use doublezero_ledger_sentinel::{
     settings::{AppArgs, Settings},
 };
 use doublezero_revenue_distribution::state::Journal;
+use doublezero_sentinel::multicast_publisher::MulticastPublisherSentinel;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use solana_sdk::signer::Signer;
 use spl_associated_token_account_interface::address::get_associated_token_address;
@@ -55,6 +56,23 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
+    let multicast_publisher_sentinel = if args.multicast_autoconnect_enabled {
+        info!("multicast autoconnect enabled");
+        Some(MulticastPublisherSentinel::new(
+            dz_rpc_url.clone(),
+            sol_rpc_url.clone(),
+            keypair.clone(),
+            serviceability_id,
+            multicast_group_pubkeys.clone(),
+            settings.multicast_client_filter.clone(),
+            settings.multicast_validator_metadata_url.clone(),
+            args.multicast_publisher_poll_interval,
+        ))
+    } else {
+        info!("multicast autoconnect disabled");
+        None
+    };
+
     let mut polling_sentinel = PollingSentinel::new(
         dz_rpc_url.clone(),
         sol_rpc_url.clone(),
@@ -99,6 +117,16 @@ async fn main() -> anyhow::Result<()> {
         result = billing_sentinel.run(shutdown_listener.clone()) => {
             if let Err(err) = result {
                 error!(?err, "billing sentinel exited with error");
+            }
+        },
+        result = async {
+            match multicast_publisher_sentinel {
+                Some(s) => s.run(shutdown_listener.clone()).await,
+                None => std::future::pending().await,
+            }
+        } => {
+            if let Err(err) = result {
+                error!(?err, "multicast publisher sentinel exited with error");
             }
         }
     }

--- a/crates/sentinel/src/settings.rs
+++ b/crates/sentinel/src/settings.rs
@@ -41,6 +41,15 @@ pub struct AppArgs {
     /// Default: 1 (any nonzero balance = paid).
     #[arg(long)]
     pub minimum_balance: Option<u64>,
+
+    /// Polling interval in seconds for the multicast publisher sentinel.
+    #[arg(long, default_value = "300")]
+    pub multicast_publisher_poll_interval: u64,
+
+    /// Enable automatic subscription of validators to multicast publisher groups.
+    /// Disabled by default.
+    #[arg(long, default_value = "false")]
+    pub multicast_autoconnect_enabled: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -70,6 +79,17 @@ pub struct Settings {
     /// validator onboarding. When empty (default), allowlisting is disabled.
     #[serde(default)]
     multicast_group_pubkeys: Option<String>,
+
+    /// Only create multicast publishers for validators whose software client
+    /// name matches any of these substrings (case-insensitive). Requires
+    /// `multicast_validator_metadata_url` to be set. Empty disables filtering.
+    #[serde(default = "default_multicast_client_filter")]
+    pub multicast_client_filter: Vec<String>,
+
+    /// URL of the validator metadata service used to look up software client
+    /// names for multicast publisher filtering.
+    #[serde(default)]
+    pub multicast_validator_metadata_url: Option<String>,
 }
 
 impl Settings {
@@ -177,6 +197,8 @@ fn settings_with_mcast_pubkeys(pubkeys: Option<&str>) -> Settings {
         keypair: "/dev/null".into(),
         metrics_addr: default_metrics_addr(),
         multicast_group_pubkeys: pubkeys.map(String::from),
+        multicast_client_filter: default_multicast_client_filter(),
+        multicast_validator_metadata_url: None,
     }
 }
 
@@ -186,6 +208,10 @@ fn default_log() -> String {
 
 fn default_metrics_addr() -> String {
     "127.0.0.1:2112".to_string()
+}
+
+fn default_multicast_client_filter() -> Vec<String> {
+    vec!["JitoLabs".to_string(), "AgaveBam".to_string()]
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Runs the multicast publisher sentinel alongside the existing polling and billing sentinels
- Adds `multicast_client_filter` (list of case-insensitive substrings, defaults to `["JitoLabs", "AgaveBam"]`) and `multicast_validator_metadata_url` settings to restrict publisher creation to matching validators
- Adds `--multicast-publisher-poll-interval` CLI flag (default 300s)