### PR TITLE
solana-cli: shreds pay integrates prorated instant seat allocation

### DIFF
--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `shreds pay`: integrate prorated instant seat allocation — when the onchain `is_prorated_service_enabled` flag is set, skip the client-side min-price check and suppress the late-epoch warning; legacy behavior preserved when the flag is unset
+
 ## [0.5.3](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.3)
 
 - uptick crate to v0.5.3 (#348)

--- a/crates/solana-cli/src/command/shreds/pay.rs
+++ b/crates/solana-cli/src/command/shreds/pay.rs
@@ -43,6 +43,7 @@ struct EpochWarningInput {
     accept_partial_epoch: bool,
     dry_run: bool,
     seat_active_this_epoch: bool,
+    prorated_service_enabled: bool,
     slot_index: u64,
     slots_in_epoch: u64,
 }
@@ -66,7 +67,11 @@ fn is_seat_already_active(seat_data: Option<&[u8]>) -> bool {
 /// Returns `Some(prompt_message)` if the user should be warned about paying late
 /// in the epoch, or `None` if no warning is needed.
 fn epoch_warning_prompt(input: &EpochWarningInput) -> Option<String> {
-    if input.accept_partial_epoch || input.dry_run || input.seat_active_this_epoch {
+    if input.accept_partial_epoch
+        || input.dry_run
+        || input.seat_active_this_epoch
+        || input.prorated_service_enabled
+    {
         return None;
     }
 
@@ -224,14 +229,18 @@ impl PayCommand {
         let (client_seat_key, seat_bump) = state::find_client_seat_address(&device, client_ip_bits);
         let (escrow_key, escrow_bump) =
             state::find_payment_escrow_address(&client_seat_key, &wallet_key);
+        let (program_config_key, _) = state::find_program_config_address();
 
         // Check which accounts already exist on-chain.
         let accounts = wallet
             .connection
-            .get_multiple_accounts(&[client_seat_key, escrow_key])
+            .get_multiple_accounts(&[client_seat_key, escrow_key, program_config_key])
             .await?;
         let seat_exists = accounts[0].is_some();
         let escrow_exists = accounts[1].is_some();
+        let prorated_service_enabled = accounts[2]
+            .as_ref()
+            .is_some_and(|a| state::is_prorated_service_enabled(&a.data));
 
         // Block if this client IP already has a seat on a DIFFERENT device.
         // The serviceability User PDA is keyed by (IP, user_type) with no
@@ -303,6 +312,7 @@ impl PayCommand {
                     accept_partial_epoch: self.accept_partial_epoch,
                     dry_run: wallet.dry_run,
                     seat_active_this_epoch,
+                    prorated_service_enabled,
                     slot_index: epoch_info.slot_index,
                     slots_in_epoch: epoch_info.slots_in_epoch,
                 };
@@ -337,27 +347,30 @@ impl PayCommand {
         let exchange_key = device_info.exchange_key;
 
         // Check the current price so the user gets a friendly error instead of
-        // an opaque on-chain revert.  If the seat has a per-seat price
+        // an opaque on-chain revert. If the seat has a per-seat price
         // override, use that instead of the metro base + device premium.
-        let seat_price_override = accounts[0]
-            .as_ref()
-            .and_then(|a| state::parse_client_seat_price_override(&a.data));
+        // Skipped when prorated service is enabled.
+        if !prorated_service_enabled {
+            let seat_price_override = accounts[0]
+                .as_ref()
+                .and_then(|a| state::parse_client_seat_price_override(&a.data));
 
-        let metro_history_key = state::find_metro_history_address(&exchange_key).0;
-        let metro_history_account = wallet.connection.get_account(&metro_history_key).await?;
-        if let Some(metro_info) = state::parse_metro_history(&metro_history_account.data) {
-            let min_price = seat_price_override.unwrap_or_else(|| {
-                (metro_info.current_usdc_price as i32 + device_info.current_premium as i32).max(0)
-                    as u64
-                    * 1_000_000
-            });
-            if amount_micro < min_price {
-                let min_usdc = min_price as f64 / 1_000_000.0;
-                bail!(
-                    "Amount ({:.6} USDC) is below the current price ({:.6} USDC)",
-                    self.amount,
-                    min_usdc,
-                );
+            let metro_history_key = state::find_metro_history_address(&exchange_key).0;
+            let metro_history_account = wallet.connection.get_account(&metro_history_key).await?;
+            if let Some(metro_info) = state::parse_metro_history(&metro_history_account.data) {
+                let min_price = seat_price_override.unwrap_or_else(|| {
+                    (metro_info.current_usdc_price as i32 + device_info.current_premium as i32)
+                        .max(0) as u64
+                        * 1_000_000
+                });
+                if amount_micro < min_price {
+                    let min_usdc = min_price as f64 / 1_000_000.0;
+                    bail!(
+                        "Amount ({:.6} USDC) is below the current price ({:.6} USDC)",
+                        self.amount,
+                        min_usdc,
+                    );
+                }
             }
         }
 
@@ -510,6 +523,7 @@ mod tests {
             accept_partial_epoch: false,
             dry_run: false,
             seat_active_this_epoch: false,
+            prorated_service_enabled: false,
             slot_index,
             slots_in_epoch,
         }
@@ -558,11 +572,21 @@ mod tests {
     }
 
     #[test]
+    fn no_warning_when_prorated_service_enabled() {
+        // Late in epoch + prorated on → warning is moot because the user
+        // only pays for the remaining slots.
+        let mut input = make_input(0.02);
+        input.prorated_service_enabled = true;
+        assert!(epoch_warning_prompt(&input).is_none());
+    }
+
+    #[test]
     fn no_warning_when_slots_in_epoch_zero() {
         let input = EpochWarningInput {
             accept_partial_epoch: false,
             dry_run: false,
             seat_active_this_epoch: false,
+            prorated_service_enabled: false,
             slot_index: 0,
             slots_in_epoch: 0,
         };
@@ -628,6 +652,7 @@ mod tests {
             accept_partial_epoch: false,
             dry_run: false,
             seat_active_this_epoch: false,
+            prorated_service_enabled: false,
             slot_index,
             slots_in_epoch,
         };
@@ -645,6 +670,7 @@ mod tests {
             accept_partial_epoch: false,
             dry_run: false,
             seat_active_this_epoch: false,
+            prorated_service_enabled: false,
             slot_index,
             slots_in_epoch,
         };
@@ -660,6 +686,7 @@ mod tests {
             accept_partial_epoch: false,
             dry_run: false,
             seat_active_this_epoch: false,
+            prorated_service_enabled: false,
             slot_index: slots_in_epoch,
             slots_in_epoch,
         };
@@ -674,6 +701,7 @@ mod tests {
             accept_partial_epoch: false,
             dry_run: false,
             seat_active_this_epoch: false,
+            prorated_service_enabled: false,
             slot_index: 432_001,
             slots_in_epoch: 432_000,
         };
@@ -689,6 +717,7 @@ mod tests {
             accept_partial_epoch: false,
             dry_run: false,
             seat_active_this_epoch: false,
+            prorated_service_enabled: false,
             slot_index: slots_in_epoch - 1, // 1 slot = 0.4 s remaining
             slots_in_epoch,
         };
@@ -795,6 +824,7 @@ mod tests {
             accept_partial_epoch: false,
             dry_run: false,
             seat_active_this_epoch: false,
+            prorated_service_enabled: false,
             slot_index: 7,
             slots_in_epoch,
         };
@@ -805,6 +835,7 @@ mod tests {
             accept_partial_epoch: false,
             dry_run: false,
             seat_active_this_epoch: false,
+            prorated_service_enabled: false,
             slot_index: 8,
             slots_in_epoch,
         };
@@ -819,6 +850,7 @@ mod tests {
             accept_partial_epoch: false,
             dry_run: false,
             seat_active_this_epoch: false,
+            prorated_service_enabled: false,
             slot_index: 0,
             slots_in_epoch: 1,
         };

--- a/crates/solana-sdk/CHANGELOG.md
+++ b/crates/solana-sdk/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- add `is_prorated_service_enabled` helper and `ProgramConfig` flag/offset constants for raw-byte parsing
 - add `RequestInstantSeatWithdrawal` instruction builder and `withdraw_seat_request` PDA helper
 - add reservation module: PDA helpers, instruction builders, and account parsers for the seat reservation program
 - add more revenue-distribution fetch methods ([#243](https://github.com/doublezerofoundation/doublezero-offchain/pull/243))

--- a/crates/solana-sdk/src/shred_subscription/state.rs
+++ b/crates/solana-sdk/src/shred_subscription/state.rs
@@ -110,6 +110,40 @@ pub fn find_payment_escrow_address(
 }
 
 // ---------------------------------------------------------------------------
+// ProgramConfig raw-byte parsing.
+//
+// Layout (ZeroCopy with 8-byte discriminator prefix):
+//   [0..8)   discriminator
+//   [8..16)  flags: Flags (u64, LE) -- first field, stable since account
+//            was introduced. Bit 2 gates prorated instant service.
+//   ...      (remaining fields irrelevant for the CLI today)
+// ---------------------------------------------------------------------------
+
+pub const PROGRAM_CONFIG_DISCRIMINATOR: Discriminator<DISCRIMINATOR_LEN> =
+    Discriminator::new_sha2(b"dz::account::program_config");
+
+pub const PROGRAM_CONFIG_FLAGS_OFFSET: usize = DISCRIMINATOR_LEN;
+
+const PROGRAM_CONFIG_FLAG_IS_PRORATED_SERVICE_ENABLED_BIT: u64 = 1 << 2;
+
+/// Returns `true` if the `is_prorated_service_enabled` bit is set on the
+/// raw `ProgramConfig` account data. Returns `false` for accounts that are
+/// too short to contain the flags word (e.g. a pre-prorated program
+/// deployment), which is the same behavior as the flag being unset.
+pub fn is_prorated_service_enabled(data: &[u8]) -> bool {
+    if data.len() < PROGRAM_CONFIG_FLAGS_OFFSET + 8 {
+        return false;
+    }
+    let Ok(flags_bytes) =
+        <[u8; 8]>::try_from(&data[PROGRAM_CONFIG_FLAGS_OFFSET..PROGRAM_CONFIG_FLAGS_OFFSET + 8])
+    else {
+        return false;
+    };
+    let flags = u64::from_le_bytes(flags_bytes);
+    flags & PROGRAM_CONFIG_FLAG_IS_PRORATED_SERVICE_ENABLED_BIT != 0
+}
+
+// ---------------------------------------------------------------------------
 // ClientSeat raw-byte parsing (for the `list` command).
 //
 // Layout (ZeroCopy with 8-byte discriminator prefix):
@@ -436,4 +470,49 @@ pub fn parse_metro_history(data: &[u8]) -> Option<MetroHistoryInfo> {
         current_epoch,
         current_usdc_price,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn program_config_data_with_flags(flags: u64) -> Vec<u8> {
+        let mut data = vec![0u8; PROGRAM_CONFIG_FLAGS_OFFSET + 8];
+        data[PROGRAM_CONFIG_FLAGS_OFFSET..PROGRAM_CONFIG_FLAGS_OFFSET + 8]
+            .copy_from_slice(&flags.to_le_bytes());
+        data
+    }
+
+    #[test]
+    fn prorated_enabled_bit_set() {
+        let data =
+            program_config_data_with_flags(PROGRAM_CONFIG_FLAG_IS_PRORATED_SERVICE_ENABLED_BIT);
+        assert!(is_prorated_service_enabled(&data));
+    }
+
+    #[test]
+    fn prorated_enabled_bit_unset() {
+        let data = program_config_data_with_flags(0);
+        assert!(!is_prorated_service_enabled(&data));
+    }
+
+    #[test]
+    fn prorated_enabled_other_bits_ignored() {
+        // is_paused (bit 0) + is_migrated (bit 1) set, but not bit 2.
+        let data = program_config_data_with_flags(0b011);
+        assert!(!is_prorated_service_enabled(&data));
+    }
+
+    #[test]
+    fn prorated_enabled_short_buffer_returns_false() {
+        // Pre-prorated program deployment: account data too short for the
+        // flags word. Treat as flag unset rather than panicking.
+        let data = vec![0u8; PROGRAM_CONFIG_FLAGS_OFFSET + 4];
+        assert!(!is_prorated_service_enabled(&data));
+    }
+
+    #[test]
+    fn prorated_enabled_empty_buffer_returns_false() {
+        assert!(!is_prorated_service_enabled(&[]));
+    }
 }


### PR DESCRIPTION
Resolves: malbeclabs/infra#1062

## Summary
- Teaches `shreds pay` about `ProgramConfig.is_prorated_service_enabled` (bit 2 of the flags word, see malbeclabs/doublezero-shreds#258) so users can pay late in the epoch without being blocked.
- When the bit is set: skip the client-side min-price check and suppress the late-epoch warning — the onchain program charges the prorated amount and enforces its own floor.
- When the bit is unset: preserve legacy full-epoch behavior. Pre-prorated programs naturally read `false` because the bit sits at a stable offset right after the discriminator.
- Folds the `ProgramConfig` fetch into the existing `get_multiple_accounts` call so there is no extra RPC.

## Lines of Code
| Section | Added | Removed |
|---------|-------|---------|
| Core logic | +30 | -18 |
| SDKs | +38 | -0 |
| Tests | +67 | -3 |

## Testing Verification
- New `no_warning_when_prorated_service_enabled` test in `pay.rs` covers the warning-suppression branch.
- New SDK test module in `crates/solana-sdk/src/shred_subscription/state.rs` covers `is_prorated_service_enabled` against bit set, bit unset, unrelated bits, short buffers, and empty buffers.