### PR TITLE
solana-cli: shreds withdraw uses prorated instruction when onchain flag is set

### DIFF
--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `shreds pay`: integrate prorated instant seat allocation — when the onchain `is_prorated_service_enabled` flag is set, skip the client-side min-price check and suppress the late-epoch warning; legacy behavior preserved when the flag is unset
+- `shreds withdraw`: use `RequestProratedInstantSeatWithdrawal` to receive a prorated USDC refund when the onchain flag is set and the seat has a recorded `last_usdc_price_dollars`; falls back to the legacy instruction when the flag is unset or the seat pre-dates the prorated rollout
 
 ## [0.5.3](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.3)
 

--- a/crates/solana-cli/src/command/shreds/payments.rs
+++ b/crates/solana-cli/src/command/shreds/payments.rs
@@ -212,6 +212,7 @@ impl PaymentsCommand {
                             | ShredSubscriptionInstructionData::InitializeClientSeat { .. }
                             | ShredSubscriptionInstructionData::RequestInstantSeatAllocation
                             | ShredSubscriptionInstructionData::RequestInstantSeatWithdrawal
+                            | ShredSubscriptionInstructionData::RequestProratedInstantSeatWithdrawal
                             | ShredSubscriptionInstructionData::SetValidatorClientRewardsProportion(
                                 _,
                             )

--- a/crates/solana-cli/src/command/shreds/withdraw.rs
+++ b/crates/solana-cli/src/command/shreds/withdraw.rs
@@ -9,7 +9,10 @@ use doublezero_solana_sdk::{
         ID,
         instruction::{
             ShredSubscriptionInstructionData,
-            account::{ClosePaymentEscrowAccounts, RequestInstantSeatWithdrawalAccounts},
+            account::{
+                ClosePaymentEscrowAccounts, RequestInstantSeatWithdrawalAccounts,
+                RequestProratedInstantSeatWithdrawalAccounts,
+            },
         },
         state,
     },
@@ -76,14 +79,19 @@ impl WithdrawCommand {
         let client_ip_bits = u32::from(self.client_ip);
         let (client_seat_key, _) = state::find_client_seat_address(&device, client_ip_bits);
         let (escrow_key, _) = state::find_payment_escrow_address(&client_seat_key, &wallet_key);
+        let (program_config_key, _) = state::find_program_config_address();
 
-        // Fetch client seat and payment escrow.
+        // Fetch client seat, payment escrow, and program config in a single RPC.
         let mut accounts = wallet
             .connection
-            .get_multiple_accounts(&[client_seat_key, escrow_key])
+            .get_multiple_accounts(&[client_seat_key, escrow_key, program_config_key])
             .await?;
 
-        // Pop in reverse order: escrow (index 1) first, then seat (index 0).
+        // Pop in reverse order: program_config (2), escrow (1), seat (0).
+        let prorated_service_enabled = accounts
+            .pop()
+            .flatten()
+            .is_some_and(|a| state::is_prorated_service_enabled(&a.data));
         let escrow_exists = accounts.pop().flatten().is_some();
 
         let seat_data = accounts
@@ -92,6 +100,12 @@ impl WithdrawCommand {
             .with_context(|| format!("Client seat {client_seat_key} does not exist"))?;
         let (_, _, _, _, active_epoch) = state::parse_client_seat(&seat_data.data)
             .with_context(|| format!("Failed to parse client seat {client_seat_key}"))?;
+        // Pre-upgrade seats carry `last_usdc_price_dollars == 0` and the
+        // prorated instruction reverts for them. Fall back to the legacy
+        // instruction until the next settlement cycle repopulates the field.
+        let seat_has_recorded_price =
+            state::parse_client_seat_last_usdc_price_dollars(&seat_data.data)
+                .is_some_and(|price| price > 0);
         let current_epoch = wallet.connection.get_epoch_info().await?.epoch;
         let has_active_service = active_epoch >= current_epoch;
 
@@ -109,11 +123,26 @@ impl WithdrawCommand {
         let mut compute_unit_limit = 5_000 + 30_000;
 
         if request_instant_withdrawal {
-            instructions.push(try_build_instruction(
-                &ID,
-                RequestInstantSeatWithdrawalAccounts::new(&device, client_ip_bits, &wallet_key),
-                &ShredSubscriptionInstructionData::RequestInstantSeatWithdrawal,
-            )?);
+            if prorated_service_enabled && seat_has_recorded_price {
+                instructions.push(try_build_instruction(
+                    &ID,
+                    RequestProratedInstantSeatWithdrawalAccounts::new(
+                        &device,
+                        client_ip_bits,
+                        &wallet_key,
+                        active_epoch,
+                        &usdc_mint_key,
+                        &wallet_key,
+                    ),
+                    &ShredSubscriptionInstructionData::RequestProratedInstantSeatWithdrawal,
+                )?);
+            } else {
+                instructions.push(try_build_instruction(
+                    &ID,
+                    RequestInstantSeatWithdrawalAccounts::new(&device, client_ip_bits, &wallet_key),
+                    &ShredSubscriptionInstructionData::RequestInstantSeatWithdrawal,
+                )?);
+            }
             compute_unit_limit += 50_000;
         }
 

--- a/crates/solana-sdk/CHANGELOG.md
+++ b/crates/solana-sdk/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- add `RequestProratedInstantSeatWithdrawal` instruction variant and accounts builder
+- add `find_shred_distribution_address` PDA helper and `parse_client_seat_last_usdc_price_dollars` parser for prorated withdrawal integration
 - add `is_prorated_service_enabled` helper and `ProgramConfig` flag/offset constants for raw-byte parsing
 - add `RequestInstantSeatWithdrawal` instruction builder and `withdraw_seat_request` PDA helper
 - add reservation module: PDA helpers, instruction builders, and account parsers for the seat reservation program

--- a/crates/solana-sdk/src/shred_subscription/instruction/account.rs
+++ b/crates/solana-sdk/src/shred_subscription/instruction/account.rs
@@ -236,6 +236,79 @@ impl From<RequestInstantSeatWithdrawalAccounts> for Vec<AccountMeta> {
     }
 }
 
+/// Accounts for the `RequestProratedInstantSeatWithdrawal` instruction (12 accounts).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequestProratedInstantSeatWithdrawalAccounts {
+    pub program_config_key: Pubkey,
+    pub execution_controller_key: Pubkey,
+    pub client_seat_key: Pubkey,
+    pub device_history_key: Pubkey,
+    pub payment_escrow_key: Pubkey,
+    pub shred_distribution_key: Pubkey,
+    pub device_history_usdc_token_account_key: Pubkey,
+    pub shred_distribution_usdc_ata_key: Pubkey,
+    pub payer_key: Pubkey,
+    pub withdraw_seat_request_key: Pubkey,
+}
+
+impl RequestProratedInstantSeatWithdrawalAccounts {
+    pub fn new(
+        device_key: &Pubkey,
+        client_ip_bits: u32,
+        funding_authority_key: &Pubkey,
+        subscription_epoch: u64,
+        usdc_mint_key: &Pubkey,
+        payer_key: &Pubkey,
+    ) -> Self {
+        let client_seat_key = state::find_client_seat_address(device_key, client_ip_bits).0;
+        let device_history_key = state::find_device_history_address(device_key).0;
+        let shred_distribution_key = state::find_shred_distribution_address(subscription_epoch).0;
+        Self {
+            program_config_key: state::find_program_config_address().0,
+            execution_controller_key: state::find_execution_controller_address().0,
+            client_seat_key,
+            device_history_key,
+            payment_escrow_key: state::find_payment_escrow_address(
+                &client_seat_key,
+                funding_authority_key,
+            )
+            .0,
+            shred_distribution_key,
+            device_history_usdc_token_account_key: state::find_token_pda_address(
+                &device_history_key,
+                usdc_mint_key,
+            )
+            .0,
+            shred_distribution_usdc_ata_key: get_associated_token_address(
+                &shred_distribution_key,
+                usdc_mint_key,
+            ),
+            payer_key: *payer_key,
+            withdraw_seat_request_key: state::find_withdraw_seat_request_address(&client_seat_key)
+                .0,
+        }
+    }
+}
+
+impl From<RequestProratedInstantSeatWithdrawalAccounts> for Vec<AccountMeta> {
+    fn from(accounts: RequestProratedInstantSeatWithdrawalAccounts) -> Self {
+        vec![
+            AccountMeta::new_readonly(accounts.program_config_key, false),
+            AccountMeta::new(accounts.execution_controller_key, false),
+            AccountMeta::new(accounts.client_seat_key, false),
+            AccountMeta::new(accounts.device_history_key, false),
+            AccountMeta::new(accounts.payment_escrow_key, false),
+            AccountMeta::new(accounts.shred_distribution_key, false),
+            AccountMeta::new(accounts.device_history_usdc_token_account_key, false),
+            AccountMeta::new(accounts.shred_distribution_usdc_ata_key, false),
+            AccountMeta::new_readonly(spl_token_interface::ID, false),
+            AccountMeta::new(accounts.payer_key, true),
+            AccountMeta::new(accounts.withdraw_seat_request_key, false),
+            AccountMeta::new_readonly(solana_sdk::system_program::ID, false),
+        ]
+    }
+}
+
 /// Accounts for the `SetValidatorClientRewardsProportion` instruction (3 accounts).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetValidatorClientRewardsProportionAccounts {

--- a/crates/solana-sdk/src/shred_subscription/instruction/mod.rs
+++ b/crates/solana-sdk/src/shred_subscription/instruction/mod.rs
@@ -19,6 +19,10 @@ pub enum ShredSubscriptionInstructionData {
     RequestInstantSeatAllocation,
     /// Request instant seat withdrawal.
     RequestInstantSeatWithdrawal,
+    /// Request instant seat withdrawal with a prorated USDC refund based on
+    /// the remaining slots in the epoch. Superset of
+    /// `RequestInstantSeatWithdrawal` (more accounts).
+    RequestProratedInstantSeatWithdrawal,
     /// Set the rewards proportion for a validator client.
     SetValidatorClientRewardsProportion(u16),
     /// Validates the provided CLI version against the onchain minimum.
@@ -38,6 +42,8 @@ impl ShredSubscriptionInstructionData {
         Discriminator::new_sha2(b"dz::ix::request_instant_seat_allocation");
     pub const REQUEST_INSTANT_SEAT_WITHDRAWAL: Discriminator<DISCRIMINATOR_LEN> =
         Discriminator::new_sha2(b"dz::ix::request_instant_seat_withdrawal");
+    pub const REQUEST_PRORATED_INSTANT_SEAT_WITHDRAWAL: Discriminator<DISCRIMINATOR_LEN> =
+        Discriminator::new_sha2(b"dz::ix::request_prorated_instant_seat_withdrawal");
     pub const SET_VALIDATOR_CLIENT_REWARDS_PROPORTION: Discriminator<DISCRIMINATOR_LEN> =
         Discriminator::new_sha2(b"dz::ix::set_validator_client_rewards_proportion");
     pub const CHECK_CLI_VERSION: Discriminator<DISCRIMINATOR_LEN> =
@@ -62,6 +68,9 @@ impl BorshSerialize for ShredSubscriptionInstructionData {
             }
             Self::RequestInstantSeatWithdrawal => {
                 Self::REQUEST_INSTANT_SEAT_WITHDRAWAL.serialize(writer)
+            }
+            Self::RequestProratedInstantSeatWithdrawal => {
+                Self::REQUEST_PRORATED_INSTANT_SEAT_WITHDRAWAL.serialize(writer)
             }
             Self::SetValidatorClientRewardsProportion(proportion) => {
                 Self::SET_VALIDATOR_CLIENT_REWARDS_PROPORTION.serialize(writer)?;
@@ -96,6 +105,9 @@ impl BorshDeserialize for ShredSubscriptionInstructionData {
             }
             Self::REQUEST_INSTANT_SEAT_ALLOCATION => Ok(Self::RequestInstantSeatAllocation),
             Self::REQUEST_INSTANT_SEAT_WITHDRAWAL => Ok(Self::RequestInstantSeatWithdrawal),
+            Self::REQUEST_PRORATED_INSTANT_SEAT_WITHDRAWAL => {
+                Ok(Self::RequestProratedInstantSeatWithdrawal)
+            }
             Self::SET_VALIDATOR_CLIENT_REWARDS_PROPORTION => {
                 let proportion = u16::deserialize_reader(reader)?;
                 Ok(Self::SetValidatorClientRewardsProportion(proportion))

--- a/crates/solana-sdk/src/shred_subscription/state.rs
+++ b/crates/solana-sdk/src/shred_subscription/state.rs
@@ -13,6 +13,7 @@ pub const PAYMENT_ESCROW_SEED_PREFIX: &[u8] = b"payment_escrow";
 pub const VALIDATOR_CLIENT_REWARDS_SEED_PREFIX: &[u8] = b"validator_client_rewards";
 pub const INSTANT_ALLOCATION_REQUEST_SEED_PREFIX: &[u8] = b"instant_seat_allocation_request";
 pub const WITHDRAW_SEAT_REQUEST_SEED_PREFIX: &[u8] = b"withdraw_seat_request";
+pub const SHRED_DISTRIBUTION_SEED_PREFIX: &[u8] = b"shred_distribution";
 
 pub fn find_program_config_address() -> (Pubkey, u8) {
     Pubkey::find_program_address(
@@ -109,6 +110,16 @@ pub fn find_payment_escrow_address(
     )
 }
 
+pub fn find_shred_distribution_address(subscription_epoch: u64) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[
+            SHRED_DISTRIBUTION_SEED_PREFIX,
+            &subscription_epoch.to_le_bytes(),
+        ],
+        &crate::shred_subscription::ID,
+    )
+}
+
 // ---------------------------------------------------------------------------
 // ProgramConfig raw-byte parsing.
 //
@@ -160,6 +171,8 @@ pub fn is_prorated_service_enabled(data: &[u8]) -> bool {
 //   [112..144) funding_authority_key: Pubkey
 //   [144..148) escrow_count: u32
 //   [148..150) override_usdc_price_dollars: u16
+//   [152..160) subscription_start_slot: u64
+//   [160..162) last_usdc_price_dollars: u16
 // ---------------------------------------------------------------------------
 
 pub const CLIENT_SEAT_DISCRIMINATOR: Discriminator<DISCRIMINATOR_LEN> =
@@ -173,6 +186,7 @@ pub const CLIENT_SEAT_ACTIVE_EPOCH_OFFSET: usize = DISCRIMINATOR_LEN + 56;
 pub const CLIENT_SEAT_FLAGS_OFFSET: usize = DISCRIMINATOR_LEN + 40;
 pub const CLIENT_SEAT_FUNDING_INDEX_OFFSET: usize = DISCRIMINATOR_LEN + 64;
 pub const CLIENT_SEAT_OVERRIDE_USDC_PRICE_OFFSET: usize = DISCRIMINATOR_LEN + 140;
+pub const CLIENT_SEAT_LAST_USDC_PRICE_OFFSET: usize = DISCRIMINATOR_LEN + 152;
 
 /// Parse a `ClientSeat` from raw account data. Returns
 /// `(device_key, client_ip, tenure_epochs, funded_epoch, active_epoch)`.
@@ -212,6 +226,22 @@ pub fn parse_client_seat(data: &[u8]) -> Option<(Pubkey, Ipv4Addr, u16, u64, u64
         funded_epoch,
         active_epoch,
     ))
+}
+
+/// Returns the seat's `last_usdc_price_dollars` (whole USDC dollars charged
+/// at the most recent allocation). Returns `None` when the account data is
+/// too short (e.g. a program predating prorated-service fields). A returned
+/// value of `Some(0)` means the field exists but is zero — a "pre-upgrade"
+/// seat that has not yet been repopulated by a settlement cycle.
+pub fn parse_client_seat_last_usdc_price_dollars(data: &[u8]) -> Option<u16> {
+    if data.len() < CLIENT_SEAT_LAST_USDC_PRICE_OFFSET + 2 {
+        return None;
+    }
+    let bytes = <[u8; 2]>::try_from(
+        &data[CLIENT_SEAT_LAST_USDC_PRICE_OFFSET..CLIENT_SEAT_LAST_USDC_PRICE_OFFSET + 2],
+    )
+    .ok()?;
+    Some(u16::from_le_bytes(bytes))
 }
 
 const CLIENT_SEAT_FLAG_HAS_PRICE_OVERRIDE_BIT: u64 = 1 << 0;
@@ -514,5 +544,30 @@ mod tests {
     #[test]
     fn prorated_enabled_empty_buffer_returns_false() {
         assert!(!is_prorated_service_enabled(&[]));
+    }
+
+    fn client_seat_data_with_last_price(price_dollars: u16) -> Vec<u8> {
+        let mut data = vec![0u8; CLIENT_SEAT_LAST_USDC_PRICE_OFFSET + 2];
+        data[CLIENT_SEAT_LAST_USDC_PRICE_OFFSET..CLIENT_SEAT_LAST_USDC_PRICE_OFFSET + 2]
+            .copy_from_slice(&price_dollars.to_le_bytes());
+        data
+    }
+
+    #[test]
+    fn last_usdc_price_zero() {
+        let data = client_seat_data_with_last_price(0);
+        assert_eq!(parse_client_seat_last_usdc_price_dollars(&data), Some(0));
+    }
+
+    #[test]
+    fn last_usdc_price_nonzero() {
+        let data = client_seat_data_with_last_price(42);
+        assert_eq!(parse_client_seat_last_usdc_price_dollars(&data), Some(42));
+    }
+
+    #[test]
+    fn last_usdc_price_short_buffer_returns_none() {
+        let data = vec![0u8; CLIENT_SEAT_LAST_USDC_PRICE_OFFSET];
+        assert_eq!(parse_client_seat_last_usdc_price_dollars(&data), None);
     }
 }


### PR DESCRIPTION
Resolves: malbeclabs/infra#1063

Stacked on #350. Reviewers please merge that first (or squash-review both together).

## Summary
- Teaches `shreds withdraw` about `ProgramConfig.is_prorated_service_enabled` and swaps in the new `RequestProratedInstantSeatWithdrawal` instruction so users get a prorated USDC refund when the onchain flag is on.
- Falls back to the legacy `RequestInstantSeatWithdrawal` when the flag is off, or when the seat pre-dates the prorated rollout (`last_usdc_price_dollars == 0`, which would otherwise cause the prorated instruction to revert — the field gets repopulated on the next settlement cycle).
- `--funds-only` and the stale-seat path are unchanged; only the active-seat branch picks between instructions.
- `ProgramConfig` is folded into the existing `get_multiple_accounts` call so there is no extra RPC.
- Extends the SDK with the new instruction variant, accounts builder, `find_shred_distribution_address` PDA helper, and `parse_client_seat_last_usdc_price_dollars` parser.

## Lines of Code
| Section | Added | Removed |
|---------|-------|---------|
| Core logic | +48 | -9 |
| SDKs | +123 | -0 |
| Tests | +11 | -0 |

## Testing Verification
- New SDK tests cover `parse_client_seat_last_usdc_price_dollars` at nonzero, zero, and short-buffer inputs — the byte-offset math is the thing most likely to silently drift against the onchain layout.