### PR TITLE
workspace: bump revenue-distribution pin to v0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,7 +1371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.4",
- "hashbrown 0.13.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2474,7 +2474,7 @@ dependencies = [
 [[package]]
 name = "doublezero-passport"
 version = "0.2.0"
-source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.4#9823d799635e19ddbdec6d09e03c104f21839516"
+source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.5#3cf089c94ed789d318af1f1e8c779799395fab42"
 dependencies = [
  "borsh 1.5.7",
  "bytemuck",
@@ -2519,7 +2519,7 @@ dependencies = [
 [[package]]
 name = "doublezero-program-tools"
 version = "0.0.0"
-source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.4#9823d799635e19ddbdec6d09e03c104f21839516"
+source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.5#3cf089c94ed789d318af1f1e8c779799395fab42"
 dependencies = [
  "bincode 1.3.3",
  "borsh 1.5.7",
@@ -2552,8 +2552,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-revenue-distribution"
-version = "0.3.4"
-source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.4#9823d799635e19ddbdec6d09e03c104f21839516"
+version = "0.3.5"
+source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.5#3cf089c94ed789d318af1f1e8c779799395fab42"
 dependencies = [
  "borsh 1.5.7",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,15 +95,15 @@ url = "2"
 [workspace.dependencies.doublezero-passport]
 features = ["offchain"]
 git = "https://github.com/doublezerofoundation/doublezero-solana"
-tag = "revenue-distribution/v0.3.4"
+tag = "revenue-distribution/v0.3.5"
 
 [workspace.dependencies.doublezero-program-tools]
 git = "https://github.com/doublezerofoundation/doublezero-solana"
-tag = "revenue-distribution/v0.3.4"
+tag = "revenue-distribution/v0.3.5"
 
 [workspace.dependencies.doublezero-revenue-distribution]
 git = "https://github.com/doublezerofoundation/doublezero-solana"
-tag = "revenue-distribution/v0.3.4"
+tag = "revenue-distribution/v0.3.5"
 
 ### Dependencies found in github.com/malbeclabs/doublezero
 


### PR DESCRIPTION
## Summary
- Bumps the `doublezero-solana` tag for `doublezero-passport`, `doublezero-program-tools`, and `doublezero-revenue-distribution` from `revenue-distribution/v0.3.4` to `revenue-distribution/v0.3.5`
- No breaking interface changes; workspace builds and clippies clean

## Lines of Code
| Section | Added | Removed |
|---------|-------|---------|
| Core logic | +0 | -0 |
| SDKs | +8 | -8 |
| Tests | +0 | -0 |