### PR TITLE
fix(contributor-rewards): subscriber decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,8 +2350,8 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "doublezero-config"
-version = "0.10.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787#f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+version = "0.20.0"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
 dependencies = [
  "eyre",
  "serde",
@@ -2414,8 +2414,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-geolocation"
-version = "0.10.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787#f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+version = "0.20.0"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
 dependencies = [
  "borsh 1.5.7",
  "borsh-incremental",
@@ -2505,8 +2505,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-program-common"
-version = "0.10.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787#f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+version = "0.20.0"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
 dependencies = [
  "borsh 1.5.7",
  "byteorder",
@@ -2541,8 +2541,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-record"
-version = "0.10.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787#f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+version = "0.20.0"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -2601,8 +2601,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-serviceability"
-version = "0.10.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787#f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+version = "0.20.0"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
 dependencies = [
  "bitflags",
  "borsh 1.5.7",
@@ -2807,8 +2807,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-telemetry"
-version = "0.10.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787#f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+version = "0.20.0"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
 dependencies = [
  "borsh 1.5.7",
  "borsh-incremental",
@@ -2822,8 +2822,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero_sdk"
-version = "0.10.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787#f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+version = "0.20.0"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
 dependencies = [
  "async-trait",
  "backon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,26 +109,26 @@ tag = "revenue-distribution/v0.3.5"
 
 [workspace.dependencies.doublezero-program-common]
 git = "https://github.com/malbeclabs/doublezero"
-rev="f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+tag = "client/v0.20.0"
 
 [workspace.dependencies.doublezero-record]
 features = ["no-entrypoint"]
 git = "https://github.com/malbeclabs/doublezero"
-rev="f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+tag = "client/v0.20.0"
 
 [workspace.dependencies.doublezero_sdk]
 git = "https://github.com/malbeclabs/doublezero"
-rev="f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+tag = "client/v0.20.0"
 
 [workspace.dependencies.doublezero-serviceability]
 features = ["no-entrypoint", "serde"]
 git = "https://github.com/malbeclabs/doublezero"
-rev="f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+tag = "client/v0.20.0"
 
 [workspace.dependencies.doublezero-telemetry]
 features = ["no-entrypoint", "serde"]
 git = "https://github.com/malbeclabs/doublezero"
-rev="f6698ab6bd7f7ed24878eb3af5d2a22bae2c8787"
+tag = "client/v0.20.0"
 
 ### Other git dependencies
 

--- a/crates/contributor-rewards/CHANGELOG.md
+++ b/crates/contributor-rewards/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fix(contributor-rewards): subscriber decoding ([#353](https://github.com/doublezerofoundation/doublezero-offchain/pull/353))
+
+## [0.5.0](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/contributor-rewards%2Fv0.5.0) - 2026-04-24
+
 - feat(contributor-rewards): add shred subscription metro price fetching for demand inputs
 - feat(contributor-rewards): add support for distribution slack notifications and other minor cleanups ([#285](https://github.com/doublezerofoundation/doublezero-offchain/pull/285))
 

--- a/crates/contributor-rewards/src/cli/snapshot.rs
+++ b/crates/contributor-rewards/src/cli/snapshot.rs
@@ -13,7 +13,7 @@ use crate::{
     ingestor::{
         epoch::{EpochFinder, LeaderSchedule},
         fetcher::Fetcher,
-        types::FetchData,
+        types::{FetchData, apply_json_compat_migrations},
     },
     settings::network::Network,
     storage,
@@ -74,11 +74,25 @@ impl CompleteSnapshot {
         Ok(())
     }
 
+    /// Deserialize a snapshot, applying compatibility migrations for older JSON snapshots.
+    pub fn from_json_str(contents: &str) -> Result<Self> {
+        let mut value: serde_json::Value = serde_json::from_str(contents)?;
+        apply_json_compat_migrations(&mut value);
+        Ok(serde_json::from_value(value)?)
+    }
+
+    /// Deserialize a snapshot, applying compatibility migrations for older JSON snapshots.
+    pub fn from_json_slice(contents: &[u8]) -> Result<Self> {
+        let mut value: serde_json::Value = serde_json::from_slice(contents)?;
+        apply_json_compat_migrations(&mut value);
+        Ok(serde_json::from_value(value)?)
+    }
+
     /// Load and validate snapshot from file
     pub fn load_from_file(path: &std::path::Path) -> Result<Self> {
         info!("Loading snapshot from: {:?}", path);
         let contents = std::fs::read_to_string(path)?;
-        let snapshot: Self = serde_json::from_str(&contents)?;
+        let snapshot = Self::from_json_str(&contents)?;
         snapshot.validate()?;
         info!("Snapshot loaded and validated successfully");
         Ok(snapshot)

--- a/crates/contributor-rewards/src/ingestor/demand.rs
+++ b/crates/contributor-rewards/src/ingestor/demand.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use anyhow::{Result, anyhow, bail};
-use doublezero_serviceability::state::user::User as DZUser;
+use doublezero_serviceability::state::user::{User as DZUser, UserStatus, UserType};
 use network_shapley::types::{Demand, Demands};
 use rayon::prelude::*;
 use tracing::info;
@@ -29,7 +29,7 @@ pub struct CityStat {
     pub validator_count: usize,
     /// Sum of all validator stake proxies (leader schedule lengths) in this city
     pub total_stake_proxy: usize,
-    /// Sum of max_multicast_subscribers across devices in this city
+    /// Live multicast subscriber count for this city, derived from User accounts
     pub subscriber_count: u16,
     /// Metro price (whole USDC dollars) for this city
     pub city_price: u16,
@@ -200,8 +200,23 @@ pub fn build_city_stats(
     info!("Pairs without device: {}", pairs_without_device);
     info!("R expects: 422 user-validator pairs, 97548 slots");
 
-    // Populate subscriber counts by iterating over devices
-    for (_device_pk, device) in fetch_data.dz_serviceability.devices.iter() {
+    // Populate subscriber counts from live User accounts, not from denormalized
+    // Device counters. Device counters can be stale and, more importantly, can be
+    // misread by older serviceability decoders when the live account contains a
+    // newer interface variant before the counter fields. User accounts are the
+    // source of truth and match the serviceability migration command's tallying.
+    for user in fetch_data.dz_serviceability.users.values() {
+        let is_live = !matches!(
+            user.status,
+            UserStatus::Rejected | UserStatus::Banned | UserStatus::PendingBan
+        );
+        if user.user_type != UserType::Multicast || !is_live || user.is_publisher() {
+            continue;
+        }
+
+        let Some(device) = fetch_data.dz_serviceability.devices.get(&user.device_pk) else {
+            continue;
+        };
         // Need valid contributor and exchange
         let Some(_contributor) = fetch_data
             .dz_serviceability
@@ -233,9 +248,7 @@ pub fn build_city_stats(
             subscriber_count: 0,
             city_price: 0,
         });
-        stats.subscriber_count = stats
-            .subscriber_count
-            .saturating_add(device.multicast_subscribers_count);
+        stats.subscriber_count = stats.subscriber_count.saturating_add(1);
     }
 
     // Populate city prices from metro_prices

--- a/crates/contributor-rewards/src/ingestor/types.rs
+++ b/crates/contributor-rewards/src/ingestor/types.rs
@@ -17,6 +17,7 @@ use doublezero_telemetry::state::{
 };
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use solana_sdk::{account::Account, pubkey::Pubkey};
 
 pub type KeyedAccounts = Vec<(Pubkey, Account)>;
@@ -86,6 +87,59 @@ impl FetchData {
         let from_device = self.dz_serviceability.devices.get(&link.side_a_pk);
         let to_device = self.dz_serviceability.devices.get(&link.side_z_pk);
         (from_device, to_device)
+    }
+}
+
+/// Apply compatibility migrations to snapshot/fetch-data JSON before deserializing.
+///
+/// This keeps snapshots produced by older binaries readable after bumping
+/// `doublezero-serviceability` to account layouts with newly serialized fields.
+pub fn apply_json_compat_migrations(value: &mut Value) {
+    if let Some(serviceability) = value.get_mut("dz_serviceability") {
+        apply_serviceability_json_compat_migrations(serviceability);
+    }
+
+    if let Some(serviceability) = value
+        .get_mut("fetch_data")
+        .and_then(|fetch_data| fetch_data.get_mut("dz_serviceability"))
+    {
+        apply_serviceability_json_compat_migrations(serviceability);
+    }
+}
+
+fn apply_serviceability_json_compat_migrations(serviceability: &mut Value) {
+    // doublezero-serviceability v0.19 added these Link fields. Historical
+    // snapshots serialized before that bump do not contain them; default them to
+    // the same values used by onchain/Borsh deserialization for absent tails.
+    if let Some(links) = serviceability
+        .get_mut("links")
+        .and_then(|links| links.as_object_mut())
+    {
+        for link in links.values_mut().filter_map(|link| link.as_object_mut()) {
+            link.entry("link_topologies")
+                .or_insert_with(|| Value::Array(Vec::new()));
+            link.entry("link_flags")
+                .or_insert_with(|| Value::Number(0.into()));
+        }
+    }
+
+    // doublezero-serviceability v0.20 added durable tunnel/BGP state to User.
+    if let Some(users) = serviceability
+        .get_mut("users")
+        .and_then(|users| users.as_object_mut())
+    {
+        for user in users.values_mut().filter_map(|user| user.as_object_mut()) {
+            user.entry("tunnel_endpoint")
+                .or_insert_with(|| Value::String("0.0.0.0".to_string()));
+            user.entry("tunnel_flags")
+                .or_insert_with(|| Value::Number(0.into()));
+            user.entry("bgp_status")
+                .or_insert_with(|| Value::String("Unknown".to_string()));
+            user.entry("last_bgp_up_at")
+                .or_insert_with(|| Value::Number(0.into()));
+            user.entry("last_bgp_reported_at")
+                .or_insert_with(|| Value::Number(0.into()));
+        }
     }
 }
 

--- a/crates/contributor-rewards/src/storage/local.rs
+++ b/crates/contributor-rewards/src/storage/local.rs
@@ -61,8 +61,8 @@ impl SnapshotStorage for LocalFileStorage {
             .await
             .context("Failed to read snapshot file")?;
 
-        let snapshot: CompleteSnapshot =
-            serde_json::from_str(&contents).context("Failed to deserialize snapshot")?;
+        let snapshot =
+            CompleteSnapshot::from_json_str(&contents).context("Failed to deserialize snapshot")?;
 
         Ok(snapshot)
     }

--- a/crates/contributor-rewards/src/storage/s3.rs
+++ b/crates/contributor-rewards/src/storage/s3.rs
@@ -160,8 +160,8 @@ impl SnapshotStorage for S3Storage {
             .context("Failed to read snapshot data")?
             .into_bytes();
 
-        let snapshot: CompleteSnapshot =
-            serde_json::from_slice(&data).context("Failed to deserialize snapshot from S3")?;
+        let snapshot = CompleteSnapshot::from_json_slice(&data)
+            .context("Failed to deserialize snapshot from S3")?;
 
         info!("Snapshot loaded successfully from S3");
         Ok(snapshot)

--- a/crates/contributor-rewards/tests/test_demand.rs
+++ b/crates/contributor-rewards/tests/test_demand.rs
@@ -1,16 +1,22 @@
 mod common;
 
-use std::{fs, path::Path};
+use std::{collections::BTreeMap, fs, path::Path};
 
 use anyhow::Result;
 use common::create_test_settings;
-use doublezero_contributor_rewards::ingestor::{demand, epoch::LeaderSchedule, types::FetchData};
+use doublezero_contributor_rewards::ingestor::{
+    demand,
+    epoch::LeaderSchedule,
+    types::{FetchData, apply_json_compat_migrations},
+};
+use doublezero_serviceability::state::user::{UserStatus, UserType};
 use serde_json::Value;
 
 fn load_test_data() -> Result<FetchData> {
     let data_path = Path::new("tests/testnet_snapshot.json");
     let json = fs::read_to_string(data_path)?;
-    let data: Value = serde_json::from_str(&json)?;
+    let mut data: Value = serde_json::from_str(&json)?;
+    apply_json_compat_migrations(&mut data);
 
     // Parse the JSON into FetchData
     let fetch_data: FetchData = serde_json::from_value(data)?;
@@ -98,6 +104,69 @@ mod tests {
                 demand.end,
                 demand.receivers,
                 demand.priority
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_subscriber_counts_come_from_users_not_device_counters() -> Result<()> {
+        let settings = create_test_settings(0.7, 1000.0, false);
+        let mut fetch_data = load_test_data()?;
+        let leader_schedule = load_leader_schedule()?;
+
+        let mut expected_by_city = BTreeMap::<String, u16>::new();
+        for user in fetch_data.dz_serviceability.users.values() {
+            let is_live = !matches!(
+                user.status,
+                UserStatus::Rejected | UserStatus::Banned | UserStatus::PendingBan
+            );
+            if user.user_type != UserType::Multicast || !is_live || user.is_publisher() {
+                continue;
+            }
+
+            let Some(device) = fetch_data.dz_serviceability.devices.get(&user.device_pk) else {
+                continue;
+            };
+            let Some(exchange) = fetch_data
+                .dz_serviceability
+                .exchanges
+                .get(&device.exchange_pk)
+            else {
+                continue;
+            };
+            let city = exchange
+                .code
+                .strip_prefix('x')
+                .unwrap_or(&exchange.code)
+                .to_uppercase();
+            *expected_by_city.entry(city).or_default() += 1;
+        }
+
+        assert!(
+            expected_by_city.values().any(|count| *count > 0),
+            "fixture should contain multicast subscribers"
+        );
+
+        // Poison the denormalized Device counters with an impossible value. The
+        // demand builder must ignore these counters and derive subscriber demand
+        // from live multicast User accounts instead.
+        for device in fetch_data.dz_serviceability.devices.values_mut() {
+            device.multicast_subscribers_count = 12_916;
+        }
+
+        let result = demand::build_with_schedule(&settings, &fetch_data, &leader_schedule)?;
+
+        for (city, expected) in expected_by_city {
+            let actual = result
+                .city_stats
+                .get(&city)
+                .map(|stats| stats.subscriber_count)
+                .unwrap_or(0);
+            assert_eq!(
+                actual, expected,
+                "subscriber count for {city} should be derived from users"
             );
         }
 

--- a/crates/contributor-rewards/tests/test_pub_links.rs
+++ b/crates/contributor-rewards/tests/test_pub_links.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fs, path::Path};
 use anyhow::Result;
 use doublezero_contributor_rewards::{
     calculator::shapley::handler::{PreviousEpochCache, build_public_links},
-    ingestor::types::FetchData,
+    ingestor::types::{FetchData, apply_json_compat_migrations},
     processor::internet::InternetTelemetryProcessor,
     settings,
 };
@@ -12,7 +12,8 @@ use serde_json::Value;
 fn load_test_data() -> Result<FetchData> {
     let data_path = Path::new("tests/testnet_snapshot.json");
     let json = fs::read_to_string(data_path)?;
-    let data: Value = serde_json::from_str(&json)?;
+    let mut data: Value = serde_json::from_str(&json)?;
+    apply_json_compat_migrations(&mut data);
 
     // Parse the JSON into FetchData manually
     let fetch_data: FetchData = serde_json::from_value(data)?;

--- a/crates/contributor-rewards/tests/test_pvt_links.rs
+++ b/crates/contributor-rewards/tests/test_pvt_links.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fs, path::Path};
 use anyhow::Result;
 use doublezero_contributor_rewards::{
     calculator::shapley::handler::{build_devices, build_private_links},
-    ingestor::types::FetchData,
+    ingestor::types::{FetchData, apply_json_compat_migrations},
     processor::telemetry::DZDTelemetryProcessor,
     settings,
 };
@@ -12,7 +12,8 @@ use serde_json::Value;
 fn load_test_data() -> Result<FetchData> {
     let data_path = Path::new("tests/testnet_snapshot.json");
     let json = fs::read_to_string(data_path)?;
-    let data: Value = serde_json::from_str(&json)?;
+    let mut data: Value = serde_json::from_str(&json)?;
+    apply_json_compat_migrations(&mut data);
 
     // Parse the JSON into FetchData
     let fetch_data: FetchData = serde_json::from_value(data)?;


### PR DESCRIPTION
# Summary

- Bumps `malbeclabs/doublezero` dependencies to `client/v0.20.0` so serviceability `InterfaceV3` device accounts decode with the correct layout.
- Derives shred multicast subscriber demand from live multicast `User` accounts instead of `Device.multicast_subscribers_count`.
- Adds JSON compatibility migrations for older snapshots missing newer `Link`/`User` fields.
- Adds/updates tests for poisoned device counters and legacy snapshot fixture loading.

# Testing

- `just fmt-check`
- `cargo check -p doublezero-contributor-rewards`
- `cargo clippy -p doublezero-contributor-rewards --all-targets -- -Dwarnings`
- `cargo test -p doublezero-contributor-rewards --test test_demand -- --nocapture`
- `cargo test -p doublezero-contributor-rewards --test test_pvt_links -- --nocapture`
- `cargo test -p doublezero-contributor-rewards --test test_pub_links -- --nocapture`
- `just test`