### PR TITLE
feat(solana-cli): add shreds configure-validator-publisher-rewards

### DIFF
--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `shreds pay`: integrate prorated instant seat allocation — when the onchain `is_prorated_service_enabled` flag is set, skip the client-side min-price check and suppress the late-epoch warning; legacy behavior preserved when the flag is unset
 - `shreds withdraw`: use `RequestProratedInstantSeatWithdrawal` to receive a prorated USDC refund when the onchain flag is set and the seat has a recorded `last_usdc_price_dollars`; falls back to the legacy instruction when the flag is unset or the seat pre-dates the prorated rollout
+- `shreds configure-validator-publisher-rewards`: add command to set the validator's preferred reward token mint and destination owner
 
 ## [0.5.3](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.3)
 

--- a/crates/solana-cli/src/command/shreds/configure_validator_publisher_rewards.rs
+++ b/crates/solana-cli/src/command/shreds/configure_validator_publisher_rewards.rs
@@ -1,0 +1,133 @@
+use anyhow::{Result, bail};
+use clap::Args;
+use doublezero_solana_client_tools::payer::{SolanaPayerOptions, TransactionOutcome, Wallet};
+use doublezero_solana_sdk::{
+    shred_subscription::{
+        ID,
+        instruction::{
+            ShredSubscriptionInstructionData,
+            account::{
+                ConfigureValidatorPublisherRewardsAccounts,
+                InitializeValidatorPublisherRewardsAccounts,
+            },
+        },
+        state,
+    },
+    try_build_instruction,
+};
+use solana_sdk::{compute_budget::ComputeBudgetInstruction, pubkey::Pubkey};
+
+/*
+   doublezero-solana shreds configure-validator-publisher-rewards \
+       --rewards-token-mint <MINT> \
+       [--rewards-token-owner <OWNER>] \
+       [--node-id <NODE_ID>]
+*/
+
+#[derive(Debug, Args)]
+pub struct ConfigureValidatorPublisherRewardsCommand {
+    /// Mint of the protocol-registered shred reward token to receive rewards
+    /// in. The mint must already be initialized via `InitializeShredRewardToken`
+    /// (admin-only); validators cannot point at arbitrary mints.
+    #[arg(long)]
+    rewards_token_mint: Pubkey,
+    /// Owner of the destination token account that will receive rewards.
+    /// Defaults to the payer.
+    #[arg(long)]
+    rewards_token_owner: Option<Pubkey>,
+    /// Validator node identity. Defaults to the payer. The current implementation
+    /// requires the node identity to sign the transaction (direct-signer auth),
+    /// so this flag must either be omitted or equal the payer.
+    #[arg(long)]
+    node_id: Option<Pubkey>,
+
+    #[command(flatten)]
+    solana_payer_options: SolanaPayerOptions,
+}
+
+impl ConfigureValidatorPublisherRewardsCommand {
+    pub async fn try_into_execute(self) -> Result<()> {
+        let dz_connection = self
+            .solana_payer_options
+            .connection_options
+            .clone()
+            .into_shred_subscription_connection();
+        let mut wallet = Wallet::try_from(self.solana_payer_options)?;
+        wallet.connection = dz_connection;
+        let wallet_key = wallet.pubkey();
+
+        let node_id = self.node_id.unwrap_or(wallet_key);
+        if node_id != wallet_key {
+            bail!(
+                "--node-id must equal the payer ({wallet_key}); offchain authorization \
+                 (e.g. for Ledger or cold-keyed validator identities) is not yet \
+                 supported in this CLI",
+            );
+        }
+
+        let rewards_token_owner_key = self.rewards_token_owner.unwrap_or(wallet_key);
+
+        println!("Shred subscription - Configure Validator Publisher Rewards");
+        println!("  Node ID:           {node_id}");
+        println!("  Reward token mint: {}", self.rewards_token_mint);
+        println!("  Reward token owner: {rewards_token_owner_key}");
+
+        let validator_publisher_rewards_key =
+            state::find_validator_publisher_rewards_address(&node_id).0;
+
+        let publisher_rewards_account = wallet
+            .connection
+            .get_account_with_commitment(
+                &validator_publisher_rewards_key,
+                solana_commitment_config::CommitmentConfig::confirmed(),
+            )
+            .await?
+            .value;
+
+        let mut instructions = vec![super::build_check_cli_version_instruction()?];
+        let mut compute_unit_limit = 5_000u32;
+
+        if publisher_rewards_account.is_none() {
+            println!("Initializing validator publisher rewards account...");
+            let init_ix = try_build_instruction(
+                &ID,
+                InitializeValidatorPublisherRewardsAccounts::new(&wallet_key, &node_id),
+                &ShredSubscriptionInstructionData::InitializeValidatorPublisherRewards { node_id },
+            )?;
+            instructions.push(init_ix);
+            compute_unit_limit += 50_000;
+        }
+
+        let configure_ix = try_build_instruction(
+            &ID,
+            ConfigureValidatorPublisherRewardsAccounts::new(
+                &node_id,
+                &self.rewards_token_mint,
+                true,
+            ),
+            &ShredSubscriptionInstructionData::ConfigureValidatorPublisherRewards {
+                rewards_token_owner_key,
+                offchain_authorization: None,
+            },
+        )?;
+        instructions.push(configure_ix);
+        compute_unit_limit += 35_000;
+
+        instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(
+            compute_unit_limit,
+        ));
+        if let Some(ref compute_unit_price_ix) = wallet.compute_unit_price_ix {
+            instructions.push(compute_unit_price_ix.clone());
+        }
+
+        let transaction = wallet.new_transaction(&instructions).await?;
+        let tx_outcome = wallet.send_or_simulate_transaction(&transaction).await?;
+
+        if let TransactionOutcome::Executed(tx_sig) = tx_outcome {
+            println!("Configured validator publisher rewards: {tx_sig}");
+            wallet.print_verbose_output(&[tx_sig]).await?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/solana-cli/src/command/shreds/mod.rs
+++ b/crates/solana-cli/src/command/shreds/mod.rs
@@ -1,3 +1,4 @@
+pub mod configure_validator_publisher_rewards;
 pub mod list;
 pub mod pay;
 pub mod payments;
@@ -53,6 +54,11 @@ pub enum ShredsSubcommand {
     /// Set the rewards proportion for a validator client.
     #[command(hide = true)]
     ValidatorClientRewards(validator_client_rewards::ValidatorClientRewardsCommand),
+    /// Configure the rewards-token destination owner and preferred mint for a
+    /// validator publisher (auto-initializes the account if needed).
+    ConfigureValidatorPublisherRewards(
+        configure_validator_publisher_rewards::ConfigureValidatorPublisherRewardsCommand,
+    ),
 }
 
 impl ShredsSubcommand {
@@ -64,6 +70,7 @@ impl ShredsSubcommand {
             Self::Payments(command) => command.try_into_execute(dz_ledger_url).await,
             Self::Price(command) => command.try_into_execute(dz_ledger_url).await,
             Self::ValidatorClientRewards(command) => command.try_into_execute().await,
+            Self::ConfigureValidatorPublisherRewards(command) => command.try_into_execute().await,
         }
     }
 }

--- a/crates/solana-cli/src/command/shreds/payments.rs
+++ b/crates/solana-cli/src/command/shreds/payments.rs
@@ -216,6 +216,12 @@ impl PaymentsCommand {
                             | ShredSubscriptionInstructionData::SetValidatorClientRewardsProportion(
                                 _,
                             )
+                            | ShredSubscriptionInstructionData::InitializeValidatorPublisherRewards {
+                                ..
+                            }
+                            | ShredSubscriptionInstructionData::ConfigureValidatorPublisherRewards {
+                                ..
+                            }
                             | ShredSubscriptionInstructionData::CheckCliVersion { .. },
                         ) => {}
                         // TODO: oracle instructions (BatchAllocateSeats,

--- a/crates/solana-sdk/src/shred_subscription/instruction/account.rs
+++ b/crates/solana-sdk/src/shred_subscription/instruction/account.rs
@@ -337,6 +337,76 @@ impl From<SetValidatorClientRewardsProportionAccounts> for Vec<AccountMeta> {
     }
 }
 
+/// Accounts for the `InitializeValidatorPublisherRewards` instruction (3 accounts).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InitializeValidatorPublisherRewardsAccounts {
+    pub payer_key: Pubkey,
+    pub new_validator_publisher_rewards_key: Pubkey,
+}
+
+impl InitializeValidatorPublisherRewardsAccounts {
+    pub fn new(payer_key: &Pubkey, node_id: &Pubkey) -> Self {
+        Self {
+            payer_key: *payer_key,
+            new_validator_publisher_rewards_key: state::find_validator_publisher_rewards_address(
+                node_id,
+            )
+            .0,
+        }
+    }
+}
+
+impl From<InitializeValidatorPublisherRewardsAccounts> for Vec<AccountMeta> {
+    fn from(accounts: InitializeValidatorPublisherRewardsAccounts) -> Self {
+        vec![
+            AccountMeta::new(accounts.payer_key, true),
+            AccountMeta::new(accounts.new_validator_publisher_rewards_key, false),
+            AccountMeta::new_readonly(solana_sdk::system_program::ID, false),
+        ]
+    }
+}
+
+/// Accounts for the `ConfigureValidatorPublisherRewards` instruction (4 accounts).
+///
+/// `is_node_signer` controls whether the validator node identity signs the
+/// Solana transaction directly. Set `true` for the direct-signer path; set
+/// `false` when the instruction data carries a `ValidatorOffchainAuthorization`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigureValidatorPublisherRewardsAccounts {
+    pub program_config_key: Pubkey,
+    pub shred_reward_token_key: Pubkey,
+    pub validator_node_key: Pubkey,
+    pub validator_publisher_rewards_key: Pubkey,
+    pub is_node_signer: bool,
+}
+
+impl ConfigureValidatorPublisherRewardsAccounts {
+    pub fn new(node_id: &Pubkey, rewards_token_mint_key: &Pubkey, is_node_signer: bool) -> Self {
+        Self {
+            program_config_key: state::find_program_config_address().0,
+            shred_reward_token_key: state::find_shred_reward_token_address(rewards_token_mint_key)
+                .0,
+            validator_node_key: *node_id,
+            validator_publisher_rewards_key: state::find_validator_publisher_rewards_address(
+                node_id,
+            )
+            .0,
+            is_node_signer,
+        }
+    }
+}
+
+impl From<ConfigureValidatorPublisherRewardsAccounts> for Vec<AccountMeta> {
+    fn from(accounts: ConfigureValidatorPublisherRewardsAccounts) -> Self {
+        vec![
+            AccountMeta::new_readonly(accounts.program_config_key, false),
+            AccountMeta::new_readonly(accounts.shred_reward_token_key, false),
+            AccountMeta::new_readonly(accounts.validator_node_key, accounts.is_node_signer),
+            AccountMeta::new(accounts.validator_publisher_rewards_key, false),
+        ]
+    }
+}
+
 /// Accounts for the `CheckCliVersion` instruction (1 account).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CheckCliVersionAccounts {

--- a/crates/solana-sdk/src/shred_subscription/instruction/mod.rs
+++ b/crates/solana-sdk/src/shred_subscription/instruction/mod.rs
@@ -4,6 +4,19 @@ use std::io;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use doublezero_program_tools::{DISCRIMINATOR_LEN, Discriminator};
+use solana_sdk::pubkey::Pubkey;
+
+/// Envelope for an offchain authorization produced by a validator operator
+/// via `solana sign-offchain-message`. Carries the ed25519 signature plus
+/// the cluster slot after which the authorization is no longer valid.
+///
+/// Wire-compatible with `ValidatorOffchainAuthorization` in the onchain
+/// program — Borsh-serialized in the same field order.
+#[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+pub struct ValidatorOffchainAuthorization {
+    pub deadline_slot: u64,
+    pub signature: [u8; 64],
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ShredSubscriptionInstructionData {
@@ -25,6 +38,27 @@ pub enum ShredSubscriptionInstructionData {
     RequestProratedInstantSeatWithdrawal,
     /// Set the rewards proportion for a validator client.
     SetValidatorClientRewardsProportion(u16),
+    /// Initialize the validator publisher rewards account for a node. Anyone
+    /// can call this; the account is created with the canonical 2Z mint as
+    /// the default reward token. Use `ConfigureValidatorPublisherRewards` to
+    /// set the destination owner and (optionally) switch the mint.
+    InitializeValidatorPublisherRewards { node_id: Pubkey },
+    /// Set the reward token destination owner and mint on a previously
+    /// initialized validator publisher rewards account. The mint is read
+    /// from the `ShredRewardToken` account passed in, not from this struct;
+    /// only protocol-registered mints are accepted.
+    ///
+    /// Authorization takes one of two forms:
+    /// - `offchain_authorization = Some(_)`: the validator identity signed
+    ///   the canonical authorization message via
+    ///   `solana sign-offchain-message`. The transaction does not need the
+    ///   node identity as a Solana signer.
+    /// - `offchain_authorization = None`: the validator identity must be a
+    ///   Solana signer on the transaction.
+    ConfigureValidatorPublisherRewards {
+        rewards_token_owner_key: Pubkey,
+        offchain_authorization: Option<ValidatorOffchainAuthorization>,
+    },
     /// Validates the provided CLI version against the onchain minimum.
     CheckCliVersion { major: u32, minor: u32, patch: u32 },
 }
@@ -46,6 +80,10 @@ impl ShredSubscriptionInstructionData {
         Discriminator::new_sha2(b"dz::ix::request_prorated_instant_seat_withdrawal");
     pub const SET_VALIDATOR_CLIENT_REWARDS_PROPORTION: Discriminator<DISCRIMINATOR_LEN> =
         Discriminator::new_sha2(b"dz::ix::set_validator_client_rewards_proportion");
+    pub const INITIALIZE_VALIDATOR_PUBLISHER_REWARDS: Discriminator<DISCRIMINATOR_LEN> =
+        Discriminator::new_sha2(b"dz::ix::initialize_validator_publisher_rewards");
+    pub const CONFIGURE_VALIDATOR_PUBLISHER_REWARDS: Discriminator<DISCRIMINATOR_LEN> =
+        Discriminator::new_sha2(b"dz::ix::configure_validator_publisher_rewards");
     pub const CHECK_CLI_VERSION: Discriminator<DISCRIMINATOR_LEN> =
         Discriminator::new_sha2(b"dz::ix::check_cli_version");
 }
@@ -75,6 +113,18 @@ impl BorshSerialize for ShredSubscriptionInstructionData {
             Self::SetValidatorClientRewardsProportion(proportion) => {
                 Self::SET_VALIDATOR_CLIENT_REWARDS_PROPORTION.serialize(writer)?;
                 proportion.serialize(writer)
+            }
+            Self::InitializeValidatorPublisherRewards { node_id } => {
+                Self::INITIALIZE_VALIDATOR_PUBLISHER_REWARDS.serialize(writer)?;
+                node_id.serialize(writer)
+            }
+            Self::ConfigureValidatorPublisherRewards {
+                rewards_token_owner_key,
+                offchain_authorization,
+            } => {
+                Self::CONFIGURE_VALIDATOR_PUBLISHER_REWARDS.serialize(writer)?;
+                rewards_token_owner_key.serialize(writer)?;
+                offchain_authorization.serialize(writer)
             }
             Self::CheckCliVersion {
                 major,
@@ -111,6 +161,19 @@ impl BorshDeserialize for ShredSubscriptionInstructionData {
             Self::SET_VALIDATOR_CLIENT_REWARDS_PROPORTION => {
                 let proportion = u16::deserialize_reader(reader)?;
                 Ok(Self::SetValidatorClientRewardsProportion(proportion))
+            }
+            Self::INITIALIZE_VALIDATOR_PUBLISHER_REWARDS => {
+                let node_id = Pubkey::deserialize_reader(reader)?;
+                Ok(Self::InitializeValidatorPublisherRewards { node_id })
+            }
+            Self::CONFIGURE_VALIDATOR_PUBLISHER_REWARDS => {
+                let rewards_token_owner_key = Pubkey::deserialize_reader(reader)?;
+                let offchain_authorization =
+                    Option::<ValidatorOffchainAuthorization>::deserialize_reader(reader)?;
+                Ok(Self::ConfigureValidatorPublisherRewards {
+                    rewards_token_owner_key,
+                    offchain_authorization,
+                })
             }
             Self::CHECK_CLI_VERSION => {
                 let major = u32::deserialize_reader(reader)?;

--- a/crates/solana-sdk/src/shred_subscription/state.rs
+++ b/crates/solana-sdk/src/shred_subscription/state.rs
@@ -14,6 +14,8 @@ pub const VALIDATOR_CLIENT_REWARDS_SEED_PREFIX: &[u8] = b"validator_client_rewar
 pub const INSTANT_ALLOCATION_REQUEST_SEED_PREFIX: &[u8] = b"instant_seat_allocation_request";
 pub const WITHDRAW_SEAT_REQUEST_SEED_PREFIX: &[u8] = b"withdraw_seat_request";
 pub const SHRED_DISTRIBUTION_SEED_PREFIX: &[u8] = b"shred_distribution";
+pub const VALIDATOR_PUBLISHER_REWARDS_SEED_PREFIX: &[u8] = b"validator_publisher_rewards";
+pub const SHRED_REWARD_TOKEN_SEED_PREFIX: &[u8] = b"shred_reward_token";
 
 pub fn find_program_config_address() -> (Pubkey, u8) {
     Pubkey::find_program_address(
@@ -116,6 +118,20 @@ pub fn find_shred_distribution_address(subscription_epoch: u64) -> (Pubkey, u8) 
             SHRED_DISTRIBUTION_SEED_PREFIX,
             &subscription_epoch.to_le_bytes(),
         ],
+        &crate::shred_subscription::ID,
+    )
+}
+
+pub fn find_validator_publisher_rewards_address(node_id: &Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[VALIDATOR_PUBLISHER_REWARDS_SEED_PREFIX, node_id.as_ref()],
+        &crate::shred_subscription::ID,
+    )
+}
+
+pub fn find_shred_reward_token_address(mint_key: &Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[SHRED_REWARD_TOKEN_SEED_PREFIX, mint_key.as_ref()],
         &crate::shred_subscription::ID,
     )
 }


### PR DESCRIPTION
## Summary
- Adds a `doublezero-solana shreds configure-validator-publisher-rewards` subcommand so validators can set their preferred reward token mint and destination owner via the CLI. Auto-initializes the `ValidatorPublisherRewards` PDA when missing and configures it in the same tx.
- Direct-signer auth only (the payer's keypair must be the validator identity). Offchain (`solana sign-offchain-message` / Ledger / cold-key) auth is not wired up yet, but the SDK side already takes `is_node_signer` and a Borsh-compatible `ValidatorOffchainAuthorization` so the path can be added later without churn.
- SDK additions: `validator_publisher_rewards` and `shred_reward_token` PDAs in state, plus `InitializeValidatorPublisherRewards` / `ConfigureValidatorPublisherRewards` instruction data + account structs.
- Relates to malbeclabs/infra#1200

## Testing
- `cargo build`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` for `doublezero-solana-sdk` and `doublezero-solana-cli` all pass.
- Manually inspected `--help` output for the new subcommand.
- No e2e / mainnet run yet — would appreciate a reviewer pass on the account ordering against the onchain processor before we soak this on testnet.