### PR TITLE
workspace: uptick tag to revenue-distribution/v0.3.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,7 +2474,7 @@ dependencies = [
 [[package]]
 name = "doublezero-passport"
 version = "0.2.0"
-source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.5#3cf089c94ed789d318af1f1e8c779799395fab42"
+source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.6#199479840c911720ae5507d8cb9d5f43e51f6199"
 dependencies = [
  "borsh 1.5.7",
  "bytemuck",
@@ -2519,7 +2519,7 @@ dependencies = [
 [[package]]
 name = "doublezero-program-tools"
 version = "0.0.0"
-source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.5#3cf089c94ed789d318af1f1e8c779799395fab42"
+source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.6#199479840c911720ae5507d8cb9d5f43e51f6199"
 dependencies = [
  "bincode 1.3.3",
  "borsh 1.5.7",
@@ -2552,8 +2552,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-revenue-distribution"
-version = "0.3.5"
-source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.5#3cf089c94ed789d318af1f1e8c779799395fab42"
+version = "0.3.6"
+source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.6#199479840c911720ae5507d8cb9d5f43e51f6199"
 dependencies = [
  "borsh 1.5.7",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,15 +95,15 @@ url = "2"
 [workspace.dependencies.doublezero-passport]
 features = ["offchain"]
 git = "https://github.com/doublezerofoundation/doublezero-solana"
-tag = "revenue-distribution/v0.3.5"
+tag = "revenue-distribution/v0.3.6"
 
 [workspace.dependencies.doublezero-program-tools]
 git = "https://github.com/doublezerofoundation/doublezero-solana"
-tag = "revenue-distribution/v0.3.5"
+tag = "revenue-distribution/v0.3.6"
 
 [workspace.dependencies.doublezero-revenue-distribution]
 git = "https://github.com/doublezerofoundation/doublezero-solana"
-tag = "revenue-distribution/v0.3.5"
+tag = "revenue-distribution/v0.3.6"
 
 ### Dependencies found in github.com/malbeclabs/doublezero
 


### PR DESCRIPTION
## Summary of Changes
Update `doublezero-solana` repo tag to `revenue-distribution/v0.3.6`.

## Testing Verification
N/A
