### PR TITLE
solana-cli: shreds withdraw bails when instant seat allocation request is in flight

### DIFF
--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `shreds pay`: integrate prorated instant seat allocation — when the onchain `is_prorated_service_enabled` flag is set, skip the client-side min-price check and suppress the late-epoch warning; legacy behavior preserved when the flag is unset
 - `shreds withdraw`: use `RequestProratedInstantSeatWithdrawal` to receive a prorated USDC refund when the onchain flag is set and the seat has a recorded `last_usdc_price_dollars`; falls back to the legacy instruction when the flag is unset or the seat pre-dates the prorated rollout
+- `shreds withdraw`: bail with a clear error when an instant seat allocation request is in flight for the seat, rather than submitting a transaction that would be rejected onchain
 
 ## [0.5.3](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.3)
 

--- a/crates/solana-cli/src/command/shreds/withdraw.rs
+++ b/crates/solana-cli/src/command/shreds/withdraw.rs
@@ -80,19 +80,36 @@ impl WithdrawCommand {
         let (client_seat_key, _) = state::find_client_seat_address(&device, client_ip_bits);
         let (escrow_key, _) = state::find_payment_escrow_address(&client_seat_key, &wallet_key);
         let (program_config_key, _) = state::find_program_config_address();
+        let (allocation_request_key, _) =
+            state::find_instant_allocation_request_address(&device, client_ip_bits);
 
-        // Fetch client seat, payment escrow, and program config in a single RPC.
+        // Fetch client seat, payment escrow, program config, and any in-flight
+        // instant seat allocation request in a single RPC.
         let mut accounts = wallet
             .connection
-            .get_multiple_accounts(&[client_seat_key, escrow_key, program_config_key])
+            .get_multiple_accounts(&[
+                client_seat_key,
+                escrow_key,
+                program_config_key,
+                allocation_request_key,
+            ])
             .await?;
 
-        // Pop in reverse order: program_config (2), escrow (1), seat (0).
+        // Pop in reverse order: allocation_request (3), program_config (2), escrow (1), seat (0).
+        let allocation_request_in_flight = accounts.pop().flatten().is_some();
         let prorated_service_enabled = accounts
             .pop()
             .flatten()
             .is_some_and(|a| state::is_prorated_service_enabled(&a.data));
         let escrow_exists = accounts.pop().flatten().is_some();
+
+        if allocation_request_in_flight {
+            bail!(
+                "Instant seat allocation request {allocation_request_key} is in flight for \
+                 client seat {client_seat_key}. Wait for the oracle to ack or reject it before \
+                 withdrawing."
+            );
+        }
 
         let seat_data = accounts
             .pop()


### PR DESCRIPTION
Resolves: malbeclabs/infra#1225
Resolves: malbeclabs/infra#1226

## Summary
- `shreds withdraw` would submit a transaction even when an `InstantSeatAllocationRequest` PDA exists for the seat, only to be rejected onchain with a cryptic program error after paying the tx fee.
- Add a client-side preflight: fetch the allocation-request PDA alongside the seat / escrow / program-config in the existing `get_multiple_accounts` call, and bail with a clear message if it exists.

## Lines of Code
| Section    | Added | Removed |
|------------|-------|---------|
| Core logic | +21   | -3      |
| SDKs       | +0    | -0      |
| Tests      | +0    | -0      |

## Testing Verification
- Will write e2e tests in the shreds repo