### PR TITLE
feat(contributor-rewards): make demand parameters configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-contributor-rewards"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/contributor-rewards/CHANGELOG.md
+++ b/crates/contributor-rewards/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- feat(contributor-rewards): make demand parameters configurable ([#358](https://github.com/doublezerofoundation/doublezero-offchain/pull/358))
+
+## [0.5.1](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/contributor-rewards%2Fv0.5.1) - 2026-05-04
+
 - chore(contributor-rewards): bump to v0.5.1 ([#356](https://github.com/doublezerofoundation/doublezero-offchain/pull/356))
 - fix(contributor-rewards): subscriber decoding ([#353](https://github.com/doublezerofoundation/doublezero-offchain/pull/353))
 

--- a/crates/contributor-rewards/Cargo.toml
+++ b/crates/contributor-rewards/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "doublezero-contributor-rewards"
 readme = "README.md"
-version = "0.5.1"
+version = "0.5.2"
 
 # Workspace inherited keys
 edition.workspace = true

--- a/crates/contributor-rewards/README.md
+++ b/crates/contributor-rewards/README.md
@@ -99,6 +99,23 @@ contiguity_bonus = 5.0
 # Increases rewards in high-demand areas
 demand_multiplier = 1.2
 
+# ========== Demand Generation Parameters ==========
+[demand]
+# Traffic per receiver in Gbps, used for both IBRL and shred demands
+traffic = 0.15
+
+# Priority for IBRL validator-to-validator demands
+# Shred demand priority remains derived from metro price
+priority = 0.0
+
+# Demand kind/type values written into Shapley demand rows
+kind = 1
+shred_kind = 2
+
+# Multicast flags for IBRL and shred demands
+multicast_enabled = false
+shred_multicast_enabled = true
+
 # ========== Program IDs ==========
 [programs]
 # DZ Serviceability program ID

--- a/crates/contributor-rewards/example.config.toml
+++ b/crates/contributor-rewards/example.config.toml
@@ -49,6 +49,30 @@ contiguity_bonus = 5.0
 # Increases rewards in high-demand areas
 demand_multiplier = 1.2
 
+# ========== Demand Generation Parameters ==========
+# All fields can be overridden via environment variables:
+#   DZ__DEMAND__TRAFFIC
+#   DZ__DEMAND__PRIORITY
+#   DZ__DEMAND__KIND
+#   DZ__DEMAND__SHRED_KIND
+#   DZ__DEMAND__MULTICAST_ENABLED
+#   DZ__DEMAND__SHRED_MULTICAST_ENABLED
+[demand]
+# Traffic per receiver in Gbps, used for both IBRL and shred demands
+traffic = 0.15
+
+# Priority for IBRL validator-to-validator demands
+# Shred demand priority remains derived from metro price
+priority = 0.0
+
+# Demand kind/type values written into Shapley demand rows
+kind = 1
+shred_kind = 2
+
+# Multicast flags for IBRL and shred demands
+multicast_enabled = false
+shred_multicast_enabled = true
+
 # ========== Program IDs ==========
 [programs]
 # DZ Serviceability program ID

--- a/crates/contributor-rewards/src/calculator/constants.rs
+++ b/crates/contributor-rewards/src/calculator/constants.rs
@@ -18,18 +18,3 @@ pub const SEC_TO_US: f64 = 1_000_000.0;
 
 // max unit share
 pub const MAX_UNIT_SHARE: f64 = 1_000_000_000.0;
-
-// default traffic per receiver in Gbps
-pub const DEMAND_TRAFFIC: f64 = 0.15;
-
-// default demand type
-pub const DEMAND_TYPE: u32 = 1;
-
-// default multicast enabled?
-pub const DEMAND_MULTICAST_ENABLED: bool = false;
-
-// shred demand type
-pub const DEMAND_TYPE_SHRED: u32 = 2;
-
-// shred multicast enabled
-pub const DEMAND_MULTICAST_SHRED: bool = true;

--- a/crates/contributor-rewards/src/calculator/ledger_operations.rs
+++ b/crates/contributor-rewards/src/calculator/ledger_operations.rs
@@ -626,6 +626,16 @@ pub struct AllRewardsOutput {
     pub rewards: Vec<RewardEntry>,
 }
 
+fn format_unit_share_proportion(unit_share: u32, total_units: u32) -> String {
+    let proportion = if total_units == 0 {
+        0.0
+    } else {
+        unit_share as f64 / total_units as f64 * 100.0
+    };
+
+    format!("{proportion:.4}%")
+}
+
 /// Print a rewards summary table (epoch, merkle root, contributors, unit shares)
 pub fn print_rewards_summary(
     shapley_storage: &ShapleyOutputStorage,
@@ -672,6 +682,8 @@ pub fn print_rewards_summary(
         pubkey: String,
         #[tabled(rename = "Unit Share")]
         unit_share: u32,
+        #[tabled(rename = "Proportion")]
+        proportion: String,
     }
 
     let reward_rows: Vec<RewardRow> = shapley_storage
@@ -686,6 +698,10 @@ pub fn print_rewards_summary(
                 contributor,
                 pubkey: r.contributor_key.to_string(),
                 unit_share: r.unit_share,
+                proportion: format_unit_share_proportion(
+                    r.unit_share,
+                    shapley_storage.total_unit_shares,
+                ),
             }
         })
         .collect();
@@ -1143,4 +1159,20 @@ pub async fn try_fetch_contributor_labels(
             Ok((contributor.owner, contributor.code))
         })
         .collect::<Result<HashMap<_, _>>>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_unit_share_proportion;
+
+    #[test]
+    fn formats_unit_share_proportion() {
+        assert_eq!(format_unit_share_proportion(250, 1000), "25.0000%");
+        assert_eq!(format_unit_share_proportion(1, 3), "33.3333%");
+    }
+
+    #[test]
+    fn formats_zero_total_units_as_zero_percent() {
+        assert_eq!(format_unit_share_proportion(1, 0), "0.0000%");
+    }
 }

--- a/crates/contributor-rewards/src/ingestor/demand.rs
+++ b/crates/contributor-rewards/src/ingestor/demand.rs
@@ -7,16 +7,12 @@ use rayon::prelude::*;
 use tracing::info;
 
 use crate::{
-    calculator::constants::{
-        DEMAND_MULTICAST_ENABLED, DEMAND_MULTICAST_SHRED, DEMAND_TRAFFIC, DEMAND_TYPE,
-        DEMAND_TYPE_SHRED,
-    },
     ingestor::{
         epoch::{EpochFinder, LeaderSchedule},
         fetcher::Fetcher,
         types::FetchData,
     },
-    settings::{Settings, network::Network},
+    settings::{DemandSettings, Settings, network::Network},
 };
 
 // key: location code, val: city stat
@@ -108,7 +104,7 @@ pub fn build_with_schedule(
     }
 
     // Generate demands
-    let demands = generate(&city_stats);
+    let demands = generate(&city_stats, &settings.demand);
     if demands.is_empty() {
         bail!("Could not build any demands!")
     }
@@ -287,7 +283,7 @@ pub fn build_city_stats(
 }
 
 /// Generates demand entries for cities (IBRL + shred rows)
-pub fn generate(city_stats: &CityStats) -> Demands {
+pub fn generate(city_stats: &CityStats, demand_settings: &DemandSettings) -> Demands {
     // Source cities: cities with validators (used for both IBRL and shred)
     let cities_with_validators: Vec<(&String, &CityStat)> = city_stats
         .iter()
@@ -318,10 +314,10 @@ pub fn generate(city_stats: &CityStats) -> Demands {
                         start: start_city_upper.clone(),
                         end: end_city_upper,
                         receivers: end_stats.validator_count as u32,
-                        traffic: DEMAND_TRAFFIC,
-                        priority: 0.0,
-                        kind: DEMAND_TYPE,
-                        multicast: DEMAND_MULTICAST_ENABLED,
+                        traffic: demand_settings.traffic,
+                        priority: demand_settings.priority,
+                        kind: demand_settings.kind,
+                        multicast: demand_settings.multicast_enabled,
                     })
                 })
                 .collect::<Vec<_>>()
@@ -341,10 +337,10 @@ pub fn generate(city_stats: &CityStats) -> Demands {
                     start: start_city_upper.clone(),
                     end: end_city.to_uppercase(),
                     receivers: end_stats.subscriber_count as u32,
-                    traffic: DEMAND_TRAFFIC,
+                    traffic: demand_settings.traffic,
                     priority: end_stats.city_price as f64,
-                    kind: DEMAND_TYPE_SHRED,
-                    multicast: DEMAND_MULTICAST_SHRED,
+                    kind: demand_settings.shred_kind,
+                    multicast: demand_settings.shred_multicast_enabled,
                 })
                 .collect::<Vec<_>>()
         })

--- a/crates/contributor-rewards/src/settings/mod.rs
+++ b/crates/contributor-rewards/src/settings/mod.rs
@@ -21,6 +21,9 @@ pub struct Settings {
     pub network: Network,
     /// Shapley value calculation parameters
     pub shapley: ShapleySettings,
+    /// Demand generation parameters
+    #[serde(default)]
+    pub demand: DemandSettings,
     /// RPC endpoint configuration
     pub rpc: RpcSettings,
     /// Solana program IDs
@@ -54,6 +57,37 @@ pub struct ShapleySettings {
     /// Multiplier for demand-based rewards
     /// Increases rewards in high-demand areas
     pub demand_multiplier: f64,
+}
+
+/// Demand generation parameters for Shapley inputs
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DemandSettings {
+    /// Traffic per receiver in Gbps, used for both IBRL and shred demands
+    pub traffic: f64,
+    /// Priority for IBRL validator-to-validator demands
+    pub priority: f64,
+    /// Demand kind/type for IBRL demands
+    pub kind: u32,
+    /// Multicast flag for IBRL demands
+    pub multicast_enabled: bool,
+    /// Demand kind/type for shred demands
+    pub shred_kind: u32,
+    /// Multicast flag for shred demands
+    pub shred_multicast_enabled: bool,
+}
+
+impl Default for DemandSettings {
+    fn default() -> Self {
+        Self {
+            traffic: 0.15,
+            priority: 0.0,
+            kind: 1,
+            multicast_enabled: false,
+            shred_kind: 2,
+            shred_multicast_enabled: true,
+        }
+    }
 }
 
 /// RPC endpoint configuration for blockchain interactions
@@ -249,6 +283,12 @@ impl fmt::Display for Settings {
              \tShapley Operator Uptime: {}\n\
              \tShapley Contiguity Bonus: {}\n\
              \tShapley Demand Multiplier: {}\n\
+             \tDemand Traffic: {}\n\
+             \tDemand Priority: {}\n\
+             \tDemand Kind: {}\n\
+             \tDemand Multicast Enabled: {}\n\
+             \tDemand Shred Kind: {}\n\
+             \tDemand Shred Multicast Enabled: {}\n\
              }}",
             self.network,
             self.log_level,
@@ -259,6 +299,163 @@ impl fmt::Display for Settings {
             self.shapley.operator_uptime,
             self.shapley.contiguity_bonus,
             self.shapley.demand_multiplier,
+            self.demand.traffic,
+            self.demand.priority,
+            self.demand.kind,
+            self.demand.multicast_enabled,
+            self.demand.shred_kind,
+            self.demand.shred_multicast_enabled,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{io::Write, sync::Mutex};
+
+    use super::*;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    const DEMAND_ENV_KEYS: &[&str] = &[
+        "DZ__DEMAND__TRAFFIC",
+        "DZ__DEMAND__PRIORITY",
+        "DZ__DEMAND__KIND",
+        "DZ__DEMAND__SHRED_KIND",
+        "DZ__DEMAND__MULTICAST_ENABLED",
+        "DZ__DEMAND__SHRED_MULTICAST_ENABLED",
+    ];
+
+    struct DemandEnvCleanup;
+
+    impl Drop for DemandEnvCleanup {
+        fn drop(&mut self) {
+            clear_demand_env();
+        }
+    }
+
+    fn clear_demand_env() {
+        for key in DEMAND_ENV_KEYS {
+            unsafe {
+                std::env::remove_var(key);
+            }
+        }
+    }
+
+    fn base_config(extra: &str) -> String {
+        format!(
+            r#"
+network = "testnet"
+log_level = "info"
+
+[shapley]
+operator_uptime = 0.98
+contiguity_bonus = 5.0
+demand_multiplier = 1.2
+
+[rpc]
+dz_url = "https://test.com"
+solana_read_url = "https://test.com"
+solana_write_url = "https://test.com"
+commitment = "confirmed"
+rps_limit = 10
+
+[programs]
+serviceability_program_id = "test"
+telemetry_program_id = "test"
+
+[prefixes]
+device_telemetry = "device"
+internet_telemetry = "internet"
+contributor_rewards = "rewards"
+reward_input = "input"
+
+[inet_lookback]
+min_coverage_threshold = 0.8
+max_epochs_lookback = 5
+min_samples_per_link = 20
+enable_accumulator = true
+dedup_window_us = 10000000
+
+[telemetry_defaults]
+missing_data_threshold = 0.7
+private_default_latency_ms = 1000.0
+enable_previous_epoch_lookup = true
+
+[scheduler]
+interval_seconds = 300
+state_file = "/tmp/test.state"
+snapshot_dir = "/tmp/snapshots"
+enable_dry_run = false
+storage_backend = "local-file"
+{extra}
+"#
+        )
+    }
+
+    fn write_config(contents: &str) -> tempfile::TempPath {
+        let mut file = tempfile::Builder::new().suffix(".toml").tempfile().unwrap();
+        file.write_all(contents.as_bytes()).unwrap();
+        file.flush().unwrap();
+        file.into_temp_path()
+    }
+
+    #[test]
+    fn demand_settings_default_when_section_missing() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_demand_env();
+        let _cleanup = DemandEnvCleanup;
+        let path = write_config(&base_config(""));
+
+        let settings = Settings::from_path(&path).unwrap();
+
+        assert_eq!(settings.demand, DemandSettings::default());
+    }
+
+    #[test]
+    fn demand_settings_partial_section_uses_defaults() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_demand_env();
+        let _cleanup = DemandEnvCleanup;
+        let path = write_config(&base_config(
+            r#"
+[demand]
+traffic = 0.2
+kind = 7
+shred_multicast_enabled = false
+"#,
+        ));
+
+        let settings = Settings::from_path(&path).unwrap();
+
+        assert_eq!(settings.demand.traffic, 0.2);
+        assert_eq!(settings.demand.priority, 0.0);
+        assert_eq!(settings.demand.kind, 7);
+        assert!(!settings.demand.multicast_enabled);
+        assert_eq!(settings.demand.shred_kind, 2);
+        assert!(!settings.demand.shred_multicast_enabled);
+    }
+
+    #[test]
+    fn demand_settings_env_overrides_toml() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_demand_env();
+        let _cleanup = DemandEnvCleanup;
+        unsafe {
+            std::env::set_var("DZ__DEMAND__PRIORITY", "4.25");
+            std::env::set_var("DZ__DEMAND__KIND", "9");
+        }
+        let path = write_config(&base_config(
+            r#"
+[demand]
+priority = 1.0
+kind = 3
+"#,
+        ));
+
+        let settings = Settings::from_path(&path).unwrap();
+
+        assert_eq!(settings.demand.priority, 4.25);
+        assert_eq!(settings.demand.kind, 9);
     }
 }

--- a/crates/contributor-rewards/src/settings/validation.rs
+++ b/crates/contributor-rewards/src/settings/validation.rs
@@ -28,6 +28,29 @@ pub fn validate_config(settings: &Settings) -> Result<()> {
         );
     }
 
+    // Validate demand settings
+    if settings.demand.traffic <= 0.0 {
+        bail!(
+            "Demand traffic must be positive, got {}",
+            settings.demand.traffic
+        );
+    }
+
+    if settings.demand.priority < 0.0 {
+        bail!(
+            "Demand priority must be non-negative, got {}",
+            settings.demand.priority
+        );
+    }
+
+    if settings.demand.kind == 0 {
+        bail!("Demand kind must be non-zero");
+    }
+
+    if settings.demand.shred_kind == 0 {
+        bail!("Demand shred_kind must be non-zero");
+    }
+
     // Validate RPC settings
     if settings.rpc.dz_url.is_empty() {
         bail!("DZ RPC URL cannot be empty");
@@ -176,8 +199,8 @@ mod tests {
 
     use super::*;
     use crate::settings::{
-        InetLookbackSettings, MetricsSettings, PrefixSettings, ProgramSettings, RpcSettings,
-        SchedulerSettings, ShapleySettings, TelemetryDefaultSettings,
+        DemandSettings, InetLookbackSettings, MetricsSettings, PrefixSettings, ProgramSettings,
+        RpcSettings, SchedulerSettings, ShapleySettings, TelemetryDefaultSettings,
         aws::{AwsSettings, StorageBackend},
         network::Network,
     };
@@ -191,6 +214,7 @@ mod tests {
                 contiguity_bonus: 5.0,
                 demand_multiplier: 1.2,
             },
+            demand: DemandSettings::default(),
             rpc: RpcSettings {
                 dz_url: "https://api.mainnet-beta.solana.com".to_string(),
                 solana_read_url: "https://api.mainnet-beta.solana.com".to_string(),
@@ -255,6 +279,29 @@ mod tests {
         assert!(validate_config(&config).is_err());
 
         config.shapley.operator_uptime = -0.1;
+        assert!(validate_config(&config).is_err());
+    }
+
+    #[test]
+    fn test_invalid_demand_settings() {
+        let mut config = create_valid_config();
+        config.demand.traffic = 0.0;
+        assert!(validate_config(&config).is_err());
+
+        config = create_valid_config();
+        config.demand.traffic = -0.1;
+        assert!(validate_config(&config).is_err());
+
+        config = create_valid_config();
+        config.demand.priority = -0.1;
+        assert!(validate_config(&config).is_err());
+
+        config = create_valid_config();
+        config.demand.kind = 0;
+        assert!(validate_config(&config).is_err());
+
+        config = create_valid_config();
+        config.demand.shred_kind = 0;
         assert!(validate_config(&config).is_err());
     }
 

--- a/crates/contributor-rewards/test.config.toml
+++ b/crates/contributor-rewards/test.config.toml
@@ -23,6 +23,15 @@ operator_uptime = 0.98
 contiguity_bonus = 5.0
 demand_multiplier = 1.2
 
+# ========== Demand Generation Parameters ==========
+[demand]
+traffic = 0.15
+priority = 0.0
+kind = 1
+shred_kind = 2
+multicast_enabled = false
+shred_multicast_enabled = true
+
 # ========== Program IDs ==========
 [programs]
 serviceability_program_id = "DZServ1111111111111111111111111111111111111"

--- a/crates/contributor-rewards/tests/common/mod.rs
+++ b/crates/contributor-rewards/tests/common/mod.rs
@@ -14,6 +14,7 @@ pub fn create_test_settings(
             contiguity_bonus: 5.0,
             demand_multiplier: 1.2,
         },
+        demand: settings::DemandSettings::default(),
         rpc: settings::RpcSettings {
             dz_url: "https://test.com".to_string(),
             solana_read_url: "https://test.com".to_string(),

--- a/crates/contributor-rewards/tests/test_demand.rs
+++ b/crates/contributor-rewards/tests/test_demand.rs
@@ -4,10 +4,13 @@ use std::{collections::BTreeMap, fs, path::Path};
 
 use anyhow::Result;
 use common::create_test_settings;
-use doublezero_contributor_rewards::ingestor::{
-    demand,
-    epoch::LeaderSchedule,
-    types::{FetchData, apply_json_compat_migrations},
+use doublezero_contributor_rewards::{
+    ingestor::{
+        demand::{self, CityStat},
+        epoch::LeaderSchedule,
+        types::{FetchData, apply_json_compat_migrations},
+    },
+    settings::DemandSettings,
 };
 use doublezero_serviceability::state::user::{UserStatus, UserType};
 use serde_json::Value;
@@ -108,6 +111,55 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn test_demand_generation_uses_configured_settings() {
+        let mut city_stats = BTreeMap::new();
+        city_stats.insert(
+            "AAA".to_string(),
+            CityStat {
+                validator_count: 1,
+                total_stake_proxy: 1,
+                subscriber_count: 0,
+                city_price: 0,
+            },
+        );
+        city_stats.insert(
+            "BBB".to_string(),
+            CityStat {
+                validator_count: 2,
+                total_stake_proxy: 2,
+                subscriber_count: 3,
+                city_price: 42,
+            },
+        );
+        let demand_settings = DemandSettings {
+            traffic: 0.42,
+            priority: 7.0,
+            kind: 11,
+            multicast_enabled: true,
+            shred_kind: 22,
+            shred_multicast_enabled: false,
+        };
+
+        let demands = demand::generate(&city_stats, &demand_settings);
+
+        let ibrl = demands
+            .iter()
+            .find(|d| d.kind == demand_settings.kind)
+            .expect("expected IBRL demand");
+        assert_eq!(ibrl.traffic, demand_settings.traffic);
+        assert_eq!(ibrl.priority, demand_settings.priority);
+        assert_eq!(ibrl.multicast, demand_settings.multicast_enabled);
+
+        let shred = demands
+            .iter()
+            .find(|d| d.kind == demand_settings.shred_kind)
+            .expect("expected shred demand");
+        assert_eq!(shred.traffic, demand_settings.traffic);
+        assert_eq!(shred.priority, 42.0);
+        assert_eq!(shred.multicast, demand_settings.shred_multicast_enabled);
     }
 
     #[test]

--- a/crates/contributor-rewards/tests/test_pub_links.rs
+++ b/crates/contributor-rewards/tests/test_pub_links.rs
@@ -30,6 +30,7 @@ fn test_settings() -> settings::Settings {
             contiguity_bonus: 5.0,
             demand_multiplier: 1.2,
         },
+        demand: settings::DemandSettings::default(),
         rpc: settings::RpcSettings {
             dz_url: "https://test.com".to_string(),
             solana_read_url: "https://test.com".to_string(),

--- a/crates/contributor-rewards/tests/test_pvt_links.rs
+++ b/crates/contributor-rewards/tests/test_pvt_links.rs
@@ -104,6 +104,7 @@ fn test_settings() -> settings::Settings {
             contiguity_bonus: 5.0,
             demand_multiplier: 1.2,
         },
+        demand: settings::DemandSettings::default(),
         rpc: settings::RpcSettings {
             dz_url: "https://test.com".to_string(),
             solana_read_url: "https://test.com".to_string(),

--- a/crates/contributor-rewards/tests/test_s3_storage.rs
+++ b/crates/contributor-rewards/tests/test_s3_storage.rs
@@ -5,7 +5,7 @@ use doublezero_contributor_rewards::{
     cli::snapshot::{CompleteSnapshot, SnapshotMetadata},
     ingestor::types::FetchData,
     settings::{
-        Settings,
+        DemandSettings, Settings,
         aws::{AwsSettings, StorageBackend},
         network::Network,
     },
@@ -46,6 +46,7 @@ fn create_test_settings(
             contiguity_bonus: 5.0,
             demand_multiplier: 1.2,
         },
+        demand: DemandSettings::default(),
         rpc: doublezero_contributor_rewards::settings::RpcSettings {
             dz_url: "https://test.com".to_string(),
             solana_read_url: "https://test.com".to_string(),


### PR DESCRIPTION
# Summary

Fix https://github.com/malbeclabs/doublezero/issues/3668

Makes contributor-rewards demand generation parameters configurable via TOML/env settings, with defaults preserving existing behavior.

## Changes

- Add DemandSettings under Settings.demand
- Support `[demand]` TOML config and `DZ**DEMAND**...` env overrides
- Remove demand defaults from calculator/constants.rs
- Thread demand settings into demand generation
- Add configurable IBRL demand priority, defaulting to 0.0
- Keep shred demand priority derived from metro price
- Add validation for demand settings
- Update config examples and README docs
- Add tests for defaults, partial config, env overrides, validation, and generation behavior