### PR TITLE
fix(contributor-rewards): update shapley input defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-contributor-rewards"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/contributor-rewards/CHANGELOG.md
+++ b/crates/contributor-rewards/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fix(contributor-rewards): update shapley input defaults ([#359](https://github.com/doublezerofoundation/doublezero-offchain/pull/359))
+
+## [0.5.2](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/contributor-rewards%2Fv0.5.2) - 2026-05-05
+
 - feat(contributor-rewards): make demand parameters configurable ([#358](https://github.com/doublezerofoundation/doublezero-offchain/pull/358))
 
 ## [0.5.1](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/contributor-rewards%2Fv0.5.1) - 2026-05-04

--- a/crates/contributor-rewards/Cargo.toml
+++ b/crates/contributor-rewards/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "doublezero-contributor-rewards"
 readme = "README.md"
-version = "0.5.2"
+version = "0.5.3"
 
 # Workspace inherited keys
 edition.workspace = true

--- a/crates/contributor-rewards/src/calculator/shapley/handler.rs
+++ b/crates/contributor-rewards/src/calculator/shapley/handler.rs
@@ -406,7 +406,14 @@ pub fn build_private_links(fetch_data: &FetchData, device_ids: &DeviceIdMap) -> 
         // Compute P95 from combined samples using R type 7 quantile (linear interpolation)
         // Matches R line 40: quantile(samples, 0.95) which defaults to type=7
         combined_samples.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-        let latency_us = quantile_r_type7(&combined_samples, 0.95);
+        // Enforce delay_override_ns as a P95 latency floor: convert the configured
+        // nanosecond RTT override to microseconds and apply 95% of it when it exceeds
+        // the telemetry-derived P95.
+        let mut latency_us = quantile_r_type7(&combined_samples, 0.95);
+        let override_us = 0.95 * (link.delay_override_ns as f64) / 1000.0;
+        if override_us > latency_us {
+            latency_us = override_us;
+        }
 
         // Convert latency from microseconds to milliseconds (R divides by 1e3 on line 40)
         let latency_ms = latency_us / 1000.0;

--- a/crates/contributor-rewards/src/settings/mod.rs
+++ b/crates/contributor-rewards/src/settings/mod.rs
@@ -81,7 +81,7 @@ impl Default for DemandSettings {
     fn default() -> Self {
         Self {
             traffic: 0.15,
-            priority: 20.0,
+            priority: 0.0,
             kind: 1,
             multicast_enabled: false,
             shred_kind: 2,
@@ -429,7 +429,7 @@ shred_multicast_enabled = false
         let settings = Settings::from_path(&path).unwrap();
 
         assert_eq!(settings.demand.traffic, 0.2);
-        assert_eq!(settings.demand.priority, 20.0);
+        assert_eq!(settings.demand.priority, 0.0);
         assert_eq!(settings.demand.kind, 7);
         assert!(!settings.demand.multicast_enabled);
         assert_eq!(settings.demand.shred_kind, 2);

--- a/crates/contributor-rewards/src/settings/mod.rs
+++ b/crates/contributor-rewards/src/settings/mod.rs
@@ -81,7 +81,7 @@ impl Default for DemandSettings {
     fn default() -> Self {
         Self {
             traffic: 0.15,
-            priority: 0.0,
+            priority: 20.0,
             kind: 1,
             multicast_enabled: false,
             shred_kind: 2,
@@ -429,7 +429,7 @@ shred_multicast_enabled = false
         let settings = Settings::from_path(&path).unwrap();
 
         assert_eq!(settings.demand.traffic, 0.2);
-        assert_eq!(settings.demand.priority, 0.0);
+        assert_eq!(settings.demand.priority, 20.0);
         assert_eq!(settings.demand.kind, 7);
         assert!(!settings.demand.multicast_enabled);
         assert_eq!(settings.demand.shred_kind, 2);


### PR DESCRIPTION
# Summary

- Apply delay_override_ns as a floor on private-link P95 latency
- Default demand priority to 20.0 and update the settings test
