### PR TITLE
solana-admin-cli/revenue-distribution: add initialize-rewards-integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,7 +1371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.4",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -2474,7 +2474,7 @@ dependencies = [
 [[package]]
 name = "doublezero-passport"
 version = "0.2.0"
-source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.6#199479840c911720ae5507d8cb9d5f43e51f6199"
+source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.7#4368da2c446b799f354aecb6156fc0e77343634b"
 dependencies = [
  "borsh 1.5.7",
  "bytemuck",
@@ -2519,7 +2519,7 @@ dependencies = [
 [[package]]
 name = "doublezero-program-tools"
 version = "0.0.0"
-source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.6#199479840c911720ae5507d8cb9d5f43e51f6199"
+source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.7#4368da2c446b799f354aecb6156fc0e77343634b"
 dependencies = [
  "bincode 1.3.3",
  "borsh 1.5.7",
@@ -2552,8 +2552,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-revenue-distribution"
-version = "0.3.6"
-source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.6#199479840c911720ae5507d8cb9d5f43e51f6199"
+version = "0.3.7"
+source = "git+https://github.com/doublezerofoundation/doublezero-solana?tag=revenue-distribution%2Fv0.3.7#4368da2c446b799f354aecb6156fc0e77343634b"
 dependencies = [
  "borsh 1.5.7",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,15 +95,15 @@ url = "2"
 [workspace.dependencies.doublezero-passport]
 features = ["offchain"]
 git = "https://github.com/doublezerofoundation/doublezero-solana"
-tag = "revenue-distribution/v0.3.6"
+tag = "revenue-distribution/v0.3.7"
 
 [workspace.dependencies.doublezero-program-tools]
 git = "https://github.com/doublezerofoundation/doublezero-solana"
-tag = "revenue-distribution/v0.3.6"
+tag = "revenue-distribution/v0.3.7"
 
 [workspace.dependencies.doublezero-revenue-distribution]
 git = "https://github.com/doublezerofoundation/doublezero-solana"
-tag = "revenue-distribution/v0.3.6"
+tag = "revenue-distribution/v0.3.7"
 
 ### Dependencies found in github.com/malbeclabs/doublezero
 

--- a/crates/solana-admin-cli/revenue-distribution/CHANGELOG.md
+++ b/crates/solana-admin-cli/revenue-distribution/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- add `initialize-rewards-integration` command (#361)
+
 ## [0.0.1](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-revenue-distribution-admin-cli%2Fv0.0.1) - 2025-10-21
 
 - add `--solana_validator_debt_write_off_feature_activation_epoch` ([#237](https://github.com/doublezerofoundation/doublezero-offchain/pull/237))

--- a/crates/solana-admin-cli/revenue-distribution/src/command.rs
+++ b/crates/solana-admin-cli/revenue-distribution/src/command.rs
@@ -122,9 +122,7 @@ impl RevenueDistributionAdminSubcommand {
             Self::InitializeRewardsIntegration {
                 program_id,
                 solana_payer_options,
-            } => {
-                try_execute_initialize_rewards_integration(program_id, solana_payer_options).await
-            }
+            } => try_execute_initialize_rewards_integration(program_id, solana_payer_options).await,
             Self::MigrateProgramAccounts {
                 solana_payer_options,
             } => try_execute_migrate_program_accounts(solana_payer_options).await,

--- a/crates/solana-admin-cli/revenue-distribution/src/command.rs
+++ b/crates/solana-admin-cli/revenue-distribution/src/command.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow, bail, ensure};
 use clap::{Args, Subcommand};
 use doublezero_solana_client_tools::{
     payer::{SolanaPayerOptions, TransactionOutcome, Wallet},
@@ -15,10 +15,11 @@ use doublezero_solana_sdk::{
             account::{
                 ConfigureProgramAccounts, InitializeContributorRewardsAccounts,
                 InitializeJournalAccounts, InitializeProgramAccounts,
-                InitializeSwapDestinationAccounts, SetAdminAccounts, SetRewardsManagerAccounts,
+                InitializeRewardsIntegrationAccounts, InitializeSwapDestinationAccounts,
+                SetAdminAccounts, SetRewardsManagerAccounts,
             },
         },
-        state::{self, ContributorRewards, Journal, ProgramConfig},
+        state::{self, ContributorRewards, Journal, ProgramConfig, RewardsIntegration},
         types::DoubleZeroEpoch,
     },
     try_build_instruction,
@@ -68,6 +69,16 @@ pub enum RevenueDistributionAdminSubcommand {
         solana_payer_options: SolanaPayerOptions,
     },
 
+    /// Register an external program as a rewards integration.
+    InitializeRewardsIntegration {
+        /// Program ID of the integration to register. Must be an executable account.
+        #[arg(long)]
+        program_id: Pubkey,
+
+        #[command(flatten)]
+        solana_payer_options: SolanaPayerOptions,
+    },
+
     /// Migrate program accounts.
     MigrateProgramAccounts {
         #[command(flatten)]
@@ -107,6 +118,12 @@ impl RevenueDistributionAdminSubcommand {
                     solana_payer_options,
                 )
                 .await
+            }
+            Self::InitializeRewardsIntegration {
+                program_id,
+                solana_payer_options,
+            } => {
+                try_execute_initialize_rewards_integration(program_id, solana_payer_options).await
             }
             Self::MigrateProgramAccounts {
                 solana_payer_options,
@@ -686,6 +703,60 @@ pub async fn try_execute_set_rewards_manager(
 
     if let TransactionOutcome::Executed(tx_sig) = tx_outcome {
         println!("Set rewards manager: {tx_sig}");
+
+        wallet.print_verbose_output(&[tx_sig]).await?;
+    }
+
+    Ok(())
+}
+
+//
+// RevenueDistributionAdminSubcommand::InitializeRewardsIntegration.
+//
+
+pub async fn try_execute_initialize_rewards_integration(
+    program_id: Pubkey,
+    solana_payer_options: SolanaPayerOptions,
+) -> Result<()> {
+    let wallet = Wallet::try_from(solana_payer_options)?;
+    let wallet_key = wallet.pubkey();
+
+    // Pre-flight: ensure the supplied account exists and is executable so the
+    // operator gets a clear error before we send the transaction.
+    let program_account = wallet
+        .connection
+        .get_account(&program_id)
+        .await
+        .with_context(|| format!("Failed to fetch program account {program_id}"))?;
+    ensure!(
+        program_account.executable,
+        "Account {program_id} is not executable",
+    );
+
+    let initialize_rewards_integration_ix = try_build_instruction(
+        &ID,
+        InitializeRewardsIntegrationAccounts::new(&wallet_key, &wallet_key, &program_id),
+        &RevenueDistributionInstructionData::InitializeRewardsIntegration,
+    )?;
+
+    let mut compute_unit_limit = 10_000;
+    let (_, bump) = RewardsIntegration::find_address(&program_id);
+    compute_unit_limit += Wallet::compute_units_for_bump_seed(bump);
+
+    let mut instructions = vec![
+        initialize_rewards_integration_ix,
+        ComputeBudgetInstruction::set_compute_unit_limit(compute_unit_limit),
+    ];
+
+    if let Some(ref compute_unit_price_ix) = wallet.compute_unit_price_ix {
+        instructions.push(compute_unit_price_ix.clone());
+    }
+
+    let transaction = wallet.new_transaction(&instructions).await?;
+    let tx_outcome = wallet.send_or_simulate_transaction(&transaction).await?;
+
+    if let TransactionOutcome::Executed(tx_sig) = tx_outcome {
+        println!("Initialized rewards integration for {program_id}: {tx_sig}");
 
         wallet.print_verbose_output(&[tx_sig]).await?;
     }


### PR DESCRIPTION
## Summary

- Bumps the `doublezero-solana` workspace dependencies to `revenue-distribution/v0.3.7`, which switches `InitializeRewardsIntegration` to a unit variant (program ID is now sourced from the integration program account).
- Adds an `initialize-rewards-integration` admin CLI subcommand that takes `--program-id`, fetches the supplied account, asserts it is executable, and submits the registration transaction.

## Testing

Ran the new subcommand locally with `--dry-run`.