### PR TITLE
feat(solana-cli): allow validator client teams to claim rewards (#1201)

### DIFF
--- a/.github/workflows/local-validator.yml
+++ b/.github/workflows/local-validator.yml
@@ -34,8 +34,12 @@ jobs:
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       - name: Generate ~/.config/solana/id.json
         run: solana-keygen new --silent --no-bip39-passphrase
+      - name: Generate manager keypair for synthetic VCR
+        run: solana-keygen new --silent --no-bip39-passphrase -o manager_keypair.json
       - name: Start Solana mainnet-beta fork in background
-        run: cargo run --bin doublezero-solana-fork -- -um --reset > /dev/null 2>&1 &
+        run: |
+          MANAGER_PUBKEY=$(solana address -k manager_keypair.json)
+          cargo run --bin doublezero-solana-fork -- -um --reset --synthetic-vcr-manager "$MANAGER_PUBKEY" > /dev/null 2>&1 &
       - name: Build `doublezero-solana`
         run: cargo build --bin doublezero-solana
       - name: Run `doublezero-solana` tests

--- a/.github/workflows/local-validator.yml
+++ b/.github/workflows/local-validator.yml
@@ -34,7 +34,7 @@ jobs:
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       - name: Generate ~/.config/solana/id.json
         run: solana-keygen new --silent --no-bip39-passphrase
-      - name: Generate manager keypair for synthetic VCR
+      - name: Generate manager keypair for synthetic ValidatorClientRewards
         run: solana-keygen new --silent --no-bip39-passphrase -o manager_keypair.json
       - name: Start Solana mainnet-beta fork in background
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,6 @@ test-ledger/
 .tool-versions
 crates/contributor-rewards/dry-run-output/
 crates/contributor-rewards/mainnet-beta.config.toml
+crates/solana-client-tools/target/
 docs/plans
 docs/superpowers

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ test-ledger/
 .tool-versions
 crates/contributor-rewards/dry-run-output/
 crates/contributor-rewards/mainnet-beta.config.toml
+docs/plans
+docs/superpowers

--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `shreds validator-client-rewards`: relocate existing `set-proportion` behavior into a subcommand group (hidden); preparation for `claim`, `init-holding`, `show`
+- `shreds validator-client-rewards init-holding`: new permissionless command to initialize claim holding accounts for one or more `(subscription_epoch, mint)` pairs under a `ValidatorClientRewards` PDA
+- `shreds validator-client-rewards claim`: new manager-signed command to drain claim holdings into a destination token account. Defaults destination to ATA(manager, mint); override with `--destination-token-account`. Reads `program_config.shred_oracle_key` to set the on-chain rent beneficiary
+- `shreds validator-client-rewards show`: new read-only command. With just `--client-id`, prints the VCR PDA, manager, description, and claim holding count. With `--rewards-token-mint --subscription-epoch <e>...`, also lists per-epoch holding balances (or `(not initialized)`)
 - `shreds pay`: integrate prorated instant seat allocation — when the onchain `is_prorated_service_enabled` flag is set, skip the client-side min-price check and suppress the late-epoch warning; legacy behavior preserved when the flag is unset
 - `shreds withdraw`: use `RequestProratedInstantSeatWithdrawal` to receive a prorated USDC refund when the onchain flag is set and the seat has a recorded `last_usdc_price_dollars`; falls back to the legacy instruction when the flag is unset or the seat pre-dates the prorated rollout
 - `shreds withdraw`: bail with a clear error when an instant seat allocation request is in flight for the seat, rather than submitting a transaction that would be rejected onchain
+- `shreds validator-client-rewards show`: when `--rewards-token-mint` is supplied without `--subscription-epoch`, print the manager's ATA address and balance (previously silently no-op)
+- `shreds validator-client-rewards claim`: print per-holding drained breakdown and re-fetch the VCR to report the remaining `claim_holding_count` after the claim transaction lands
+- `shreds validator-client-rewards claim`: split "wrong owner" and "wrong mint" pre-flight checks into distinct error messages so a non-SPL holding is no longer mislabeled as a wrong-mint holding
 
 ## [0.5.3](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.3)
 

--- a/crates/solana-cli/src/command/shreds/mod.rs
+++ b/crates/solana-cli/src/command/shreds/mod.rs
@@ -50,8 +50,7 @@ pub enum ShredsSubcommand {
     Payments(payments::PaymentsCommand),
     /// Show current device pricing.
     Price(price::PriceCommand),
-    /// Set the rewards proportion for a validator client.
-    #[command(hide = true)]
+    /// Validator client rewards: claim accumulated rewards and manage proportions.
     ValidatorClientRewards(validator_client_rewards::ValidatorClientRewardsCommand),
 }
 
@@ -105,7 +104,7 @@ impl DeviceArgs {
 
 /// Construct a DZ Ledger connection, using the explicit URL if provided or
 /// falling back to the environment-derived URL.
-pub(super) fn make_dz_connection(
+pub(in crate::command::shreds) fn make_dz_connection(
     dz_ledger_url: &Option<String>,
     network_env: NetworkEnvironment,
 ) -> DoubleZeroLedgerConnection {
@@ -118,7 +117,7 @@ pub(super) fn make_dz_connection(
 /// Known shred oracle pubkey per environment. Returns `None` on localnet
 /// (the multicast-user guard is already skipped there because
 /// `serviceability_program_id` returns `Err`).
-pub(super) fn shred_oracle_key(env: NetworkEnvironment) -> Option<Pubkey> {
+pub(in crate::command::shreds) fn shred_oracle_key(env: NetworkEnvironment) -> Option<Pubkey> {
     match env {
         NetworkEnvironment::MainnetBeta => Some(solana_sdk::pubkey!(
             "3b2Ze7VYUvhwQBfx5oCMCmsc2xvyZ74s2Lata5vmQeeN"
@@ -151,8 +150,8 @@ fn cli_version() -> (u32, u32, u32) {
 }
 
 /// Build a `CheckCliVersion` instruction to prepend to write transactions.
-pub(super) fn build_check_cli_version_instruction() -> Result<solana_sdk::instruction::Instruction>
-{
+pub(in crate::command::shreds) fn build_check_cli_version_instruction()
+-> Result<solana_sdk::instruction::Instruction> {
     let (major, minor, patch) = cli_version();
     let ix = doublezero_solana_sdk::try_build_instruction(
         &SHRED_SUBSCRIPTION_PROGRAM_ID,
@@ -166,7 +165,9 @@ pub(super) fn build_check_cli_version_instruction() -> Result<solana_sdk::instru
     Ok(ix)
 }
 
-pub(super) fn serviceability_program_id(env: NetworkEnvironment) -> Result<Pubkey> {
+pub(in crate::command::shreds) fn serviceability_program_id(
+    env: NetworkEnvironment,
+) -> Result<Pubkey> {
     match env {
         NetworkEnvironment::MainnetBeta => {
             Ok(doublezero_serviceability::addresses::mainnet::program_id::id())

--- a/crates/solana-cli/src/command/shreds/payments.rs
+++ b/crates/solana-cli/src/command/shreds/payments.rs
@@ -216,6 +216,8 @@ impl PaymentsCommand {
                             | ShredSubscriptionInstructionData::SetValidatorClientRewardsProportion(
                                 _,
                             )
+                            | ShredSubscriptionInstructionData::InitializeClaimHoldingAccount(_)
+                            | ShredSubscriptionInstructionData::ClaimValidatorClientRewards(_)
                             | ShredSubscriptionInstructionData::CheckCliVersion { .. },
                         ) => {}
                         // TODO: oracle instructions (BatchAllocateSeats,

--- a/crates/solana-cli/src/command/shreds/validator_client_rewards/claim.rs
+++ b/crates/solana-cli/src/command/shreds/validator_client_rewards/claim.rs
@@ -64,8 +64,23 @@ pub(crate) fn validate_manager(wallet: &Pubkey, vcr_manager: &Pubkey) -> Result<
     Ok(())
 }
 
+/// Upper bound on epochs per claim tx. Each `ClaimHoldingId` adds 9 bytes of
+/// instruction data and the holding account adds 32 bytes to the account list,
+/// so beyond ~20 the tx blows past the 1232-byte packet limit. 16 is a
+/// conservative cap that leaves room for the destination/rent/program-config
+/// accounts and the CheckCliVersion ix.
+pub(crate) const MAX_CLAIM_EPOCHS_PER_TX: usize = 16;
+
 impl ClaimCommand {
     pub async fn try_into_execute(self) -> Result<()> {
+        if self.subscription_epochs.len() > MAX_CLAIM_EPOCHS_PER_TX {
+            bail!(
+                "too many --subscription-epoch values ({}); max {} per tx. Split into multiple `claim` calls.",
+                self.subscription_epochs.len(),
+                MAX_CLAIM_EPOCHS_PER_TX
+            );
+        }
+
         let dz_connection = self
             .solana_payer_options
             .connection_options
@@ -150,24 +165,25 @@ impl ClaimCommand {
                 }
             }
         }
-        if !missing.is_empty() {
-            bail!(
-                "claim holdings not initialized for epochs: {:?}. Run `shreds validator-client-rewards init-holding ...` first.",
-                missing
-            );
-        }
-        if !wrong_owner.is_empty() {
-            bail!(
-                "claim holdings for epochs {:?} are not SPL token accounts (owners: {:?})",
-                wrong_owner.iter().map(|(e, _)| *e).collect::<Vec<_>>(),
-                wrong_owner
-            );
-        }
-        if !wrong_mint.is_empty() {
-            bail!(
-                "claim holdings for the following epochs are for the wrong mint: {:?}",
-                wrong_mint
-            );
+        if !missing.is_empty() || !wrong_owner.is_empty() || !wrong_mint.is_empty() {
+            let mut issues: Vec<String> = Vec::new();
+            if !missing.is_empty() {
+                issues.push(format!(
+                    "  - holdings not initialized for epochs: {missing:?}. Run `shreds validator-client-rewards init-holding ...` first."
+                ));
+            }
+            if !wrong_owner.is_empty() {
+                let epochs: Vec<u64> = wrong_owner.iter().map(|(e, _)| *e).collect();
+                issues.push(format!(
+                    "  - holdings for epochs {epochs:?} are not SPL token accounts (epoch, owner): {wrong_owner:?}"
+                ));
+            }
+            if !wrong_mint.is_empty() {
+                issues.push(format!(
+                    "  - holdings for the following epochs are for the wrong mint (epoch, found_mint): {wrong_mint:?}"
+                ));
+            }
+            bail!("claim holdings have issues:\n{}", issues.join("\n"));
         }
         for epoch in &zero_balance {
             eprintln!(
@@ -257,7 +273,7 @@ impl ClaimCommand {
         let mut instructions = vec![super::super::build_check_cli_version_instruction()?, ix];
 
         // ~30k CU per holding (token transfer + close + state decrement), plus
-        // the check-cli-version ix.
+        // the check-cli-version ix. Bounded by MAX_CLAIM_EPOCHS_PER_TX.
         let cu_limit: u32 = 30_000u32.saturating_mul(self.subscription_epochs.len() as u32 + 1);
         instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(cu_limit));
         if let Some(ref compute_unit_price_ix) = wallet.compute_unit_price_ix {
@@ -270,11 +286,14 @@ impl ClaimCommand {
         if let TransactionOutcome::Executed(tx_sig) = tx_outcome {
             println!("Claimed: {tx_sig}");
             // The on-chain handler transfers the full balance of each holding,
-            // so the pre-claim balance equals what was drained.
+            // but the balances reported here were read pre-tx — if a top-up
+            // landed between the read and our claim, the actual drained amount
+            // is higher. To get the authoritative number, diff the destination
+            // ATA balance before and after.
             for (epoch, holding_pda, drained) in &pre_claim_balances {
-                println!("  epoch {epoch}: {drained} from {holding_pda}");
+                println!("  epoch {epoch}: {drained} from {holding_pda} (pre-claim)");
             }
-            println!("Total claimed: {total_drained}");
+            println!("Pre-claim total: {total_drained}");
 
             // Re-fetch the VCR to report the post-tx claim_holding_count.
             let post_count = match wallet
@@ -399,5 +418,22 @@ mod tests {
             &mint.to_string(),
         ]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn max_claim_epochs_keeps_tx_under_packet_limit() {
+        // Sanity-check the cap: at MAX_CLAIM_EPOCHS_PER_TX, the holding-id
+        // payload + per-holding account metas should stay well under the
+        // 1232-byte Solana packet limit (accounting for the ~256 bytes of
+        // fixed overhead from signature/header/fixed-accounts/blockhash).
+        let payload_per_epoch = 9; // ClaimHoldingId = u64 + u8
+        let account_meta_per_epoch = 32; // one Pubkey per holding
+        let approx_per_epoch = payload_per_epoch + account_meta_per_epoch;
+        let approx_overhead = 256;
+        let total = approx_overhead + approx_per_epoch * MAX_CLAIM_EPOCHS_PER_TX;
+        assert!(
+            total < 1232,
+            "MAX_CLAIM_EPOCHS_PER_TX={MAX_CLAIM_EPOCHS_PER_TX} produces approx tx size {total} >= 1232"
+        );
     }
 }

--- a/crates/solana-cli/src/command/shreds/validator_client_rewards/claim.rs
+++ b/crates/solana-cli/src/command/shreds/validator_client_rewards/claim.rs
@@ -1,0 +1,403 @@
+use anyhow::{Context, Result, anyhow, bail};
+use clap::Args;
+use doublezero_solana_client_tools::payer::{SolanaPayerOptions, TransactionOutcome, Wallet};
+use doublezero_solana_sdk::{
+    shred_subscription::{
+        ID,
+        instruction::{
+            ClaimHoldingId, ShredSubscriptionInstructionData,
+            account::ClaimValidatorClientRewardsAccounts,
+        },
+        state::{
+            find_claim_holding_address, find_program_config_address,
+            find_validator_client_rewards_address, parse_program_config_shred_oracle_key,
+            parse_validator_client_rewards,
+        },
+    },
+    try_build_instruction,
+};
+use solana_sdk::{
+    commitment_config::CommitmentConfig, compute_budget::ComputeBudgetInstruction,
+    instruction::AccountMeta, program_pack::Pack, pubkey::Pubkey,
+};
+use spl_associated_token_account_interface::address::get_associated_token_address;
+
+/*
+   doublezero-solana shreds validator-client-rewards claim \
+       --client-id <ID> --rewards-token-mint <PUBKEY> \
+       --subscription-epoch <EPOCH> [--subscription-epoch <EPOCH> ...] \
+       [--destination-token-account <PUBKEY>]
+*/
+
+#[derive(Debug, Args)]
+pub struct ClaimCommand {
+    /// Validator client ID.
+    #[arg(long)]
+    pub client_id: u16,
+    /// Token mint that holdings are denominated in.
+    #[arg(long)]
+    pub rewards_token_mint: Pubkey,
+    /// One or more subscription epochs to claim.
+    #[arg(long = "subscription-epoch", required = true, num_args = 1..)]
+    pub subscription_epochs: Vec<u64>,
+    /// Destination token account. Defaults to ATA(manager, rewards_token_mint).
+    #[arg(long)]
+    pub destination_token_account: Option<Pubkey>,
+    #[command(flatten)]
+    pub solana_payer_options: SolanaPayerOptions,
+}
+
+pub(crate) fn resolve_destination(
+    manager: &Pubkey,
+    mint: &Pubkey,
+    override_destination: Option<Pubkey>,
+) -> Pubkey {
+    override_destination.unwrap_or_else(|| get_associated_token_address(manager, mint))
+}
+
+pub(crate) fn validate_manager(wallet: &Pubkey, vcr_manager: &Pubkey) -> Result<()> {
+    if wallet != vcr_manager {
+        return Err(anyhow!(
+            "manager mismatch: wallet is {wallet}, VCR manager is {vcr_manager}"
+        ));
+    }
+    Ok(())
+}
+
+impl ClaimCommand {
+    pub async fn try_into_execute(self) -> Result<()> {
+        let dz_connection = self
+            .solana_payer_options
+            .connection_options
+            .clone()
+            .into_shred_subscription_connection();
+        let mut wallet = Wallet::try_from(self.solana_payer_options)?;
+        wallet.connection = dz_connection;
+        let wallet_key = wallet.pubkey();
+
+        // Derive every PDA we need.
+        let vcr_key = find_validator_client_rewards_address(self.client_id).0;
+        let program_config_key = find_program_config_address().0;
+        let holding_keys: Vec<Pubkey> = self
+            .subscription_epochs
+            .iter()
+            .map(|epoch| find_claim_holding_address(&vcr_key, *epoch, &self.rewards_token_mint).0)
+            .collect();
+
+        // Single getMultipleAccounts call: VCR, ProgramConfig, every holding.
+        let mut all_keys = vec![vcr_key, program_config_key];
+        all_keys.extend(holding_keys.iter().copied());
+        let accounts = wallet
+            .connection
+            .get_multiple_accounts(&all_keys)
+            .await
+            .with_context(|| "fetching VCR + program config + holdings")?;
+
+        let vcr_account = accounts.first().and_then(|a| a.as_ref()).ok_or_else(|| {
+            anyhow!(
+                "validator client rewards not initialized for client-id {} (PDA {})",
+                self.client_id,
+                vcr_key
+            )
+        })?;
+        let vcr_info = parse_validator_client_rewards(&vcr_account.data)
+            .ok_or_else(|| anyhow!("failed to parse ValidatorClientRewards at {vcr_key}"))?;
+        validate_manager(&wallet_key, &vcr_info.manager_key)?;
+
+        let cfg_account = accounts
+            .get(1)
+            .and_then(|a| a.as_ref())
+            .ok_or_else(|| anyhow!("ProgramConfig {program_config_key} not found onchain"))?;
+        let rent_beneficiary = parse_program_config_shred_oracle_key(&cfg_account.data)
+            .ok_or_else(|| anyhow!("failed to parse shred_oracle_key from ProgramConfig"))?;
+
+        // Validate every holding. Track per-holding pre-claim balances so the
+        // post-tx output can report what was drained from each.
+        let mut missing: Vec<u64> = Vec::new();
+        let mut wrong_owner: Vec<(u64, Pubkey)> = Vec::new();
+        let mut wrong_mint: Vec<(u64, Pubkey)> = Vec::new();
+        let mut zero_balance: Vec<u64> = Vec::new();
+        let mut total_drained: u64 = 0;
+        // (epoch, holding_pda, pre_claim_balance)
+        let mut pre_claim_balances: Vec<(u64, Pubkey, u64)> = Vec::new();
+        for ((epoch, key), maybe_acct) in self
+            .subscription_epochs
+            .iter()
+            .zip(holding_keys.iter())
+            .zip(accounts.iter().skip(2))
+        {
+            match maybe_acct.as_ref() {
+                None => missing.push(*epoch),
+                Some(acct) => {
+                    if acct.owner != spl_token_interface::ID {
+                        wrong_owner.push((*epoch, acct.owner));
+                        continue;
+                    }
+                    match spl_token_interface::state::Account::unpack(&acct.data) {
+                        Ok(token) => {
+                            if token.mint != self.rewards_token_mint {
+                                wrong_mint.push((*epoch, token.mint));
+                                continue;
+                            }
+                            if token.amount == 0 {
+                                zero_balance.push(*epoch);
+                            }
+                            total_drained = total_drained.saturating_add(token.amount);
+                            pre_claim_balances.push((*epoch, *key, token.amount));
+                        }
+                        Err(err) => bail!("holding {key} (epoch {epoch}) failed to unpack: {err}"),
+                    }
+                }
+            }
+        }
+        if !missing.is_empty() {
+            bail!(
+                "claim holdings not initialized for epochs: {:?}. Run `shreds validator-client-rewards init-holding ...` first.",
+                missing
+            );
+        }
+        if !wrong_owner.is_empty() {
+            bail!(
+                "claim holdings for epochs {:?} are not SPL token accounts (owners: {:?})",
+                wrong_owner.iter().map(|(e, _)| *e).collect::<Vec<_>>(),
+                wrong_owner
+            );
+        }
+        if !wrong_mint.is_empty() {
+            bail!(
+                "claim holdings for the following epochs are for the wrong mint: {:?}",
+                wrong_mint
+            );
+        }
+        for epoch in &zero_balance {
+            eprintln!(
+                "warning: epoch {epoch} holding has 0 balance; will still close and recover rent"
+            );
+        }
+
+        // Resolve destination ATA and validate it.
+        let destination = resolve_destination(
+            &wallet_key,
+            &self.rewards_token_mint,
+            self.destination_token_account,
+        );
+        let dest_account = wallet
+            .connection
+            .get_account_with_commitment(&destination, CommitmentConfig::confirmed())
+            .await
+            .with_context(|| format!("fetching destination token account {destination}"))?
+            .value
+            .ok_or_else(|| {
+                anyhow!(
+                    "destination token account {destination} does not exist. \
+                     Run: `spl-token create-account --owner {wallet_key} {} --fee-payer {wallet_key}`",
+                    self.rewards_token_mint
+                )
+            })?;
+        if dest_account.owner != spl_token_interface::ID {
+            bail!(
+                "destination {destination} is not an SPL token account (owner = {})",
+                dest_account.owner
+            );
+        }
+        let dest_token = spl_token_interface::state::Account::unpack(&dest_account.data)
+            .with_context(|| format!("unpacking destination token account {destination}"))?;
+        if dest_token.mint != self.rewards_token_mint {
+            bail!(
+                "destination {destination} mint mismatch: expected {}, found {}",
+                self.rewards_token_mint,
+                dest_token.mint
+            );
+        }
+
+        // Build the holding-id payload (re-derive bumps).
+        let claim_holding_ids: Vec<ClaimHoldingId> = self
+            .subscription_epochs
+            .iter()
+            .map(|epoch| {
+                let (_addr, bump) =
+                    find_claim_holding_address(&vcr_key, *epoch, &self.rewards_token_mint);
+                ClaimHoldingId {
+                    subscription_epoch: *epoch,
+                    bump_seed: bump,
+                }
+            })
+            .collect();
+
+        println!(
+            "Shred subscription - Claim Validator Client Rewards (client_id={}, mint={}, epochs={})",
+            self.client_id,
+            self.rewards_token_mint,
+            self.subscription_epochs
+                .iter()
+                .map(u64::to_string)
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        println!("  manager       : {wallet_key}");
+        println!("  destination   : {destination}");
+        println!("  rent recovers : {rent_beneficiary}");
+
+        // Build the claim instruction.
+        let claim_accounts = ClaimValidatorClientRewardsAccounts::new(
+            self.client_id,
+            &wallet_key,
+            &destination,
+            &rent_beneficiary,
+            &self.rewards_token_mint,
+            &self.subscription_epochs,
+        );
+        let metas: Vec<AccountMeta> = claim_accounts.into();
+        let ix = try_build_instruction(
+            &ID,
+            metas,
+            &ShredSubscriptionInstructionData::ClaimValidatorClientRewards(claim_holding_ids),
+        )?;
+
+        let mut instructions = vec![super::super::build_check_cli_version_instruction()?, ix];
+
+        // ~30k CU per holding (token transfer + close + state decrement), plus
+        // the check-cli-version ix.
+        let cu_limit: u32 = 30_000u32.saturating_mul(self.subscription_epochs.len() as u32 + 1);
+        instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(cu_limit));
+        if let Some(ref compute_unit_price_ix) = wallet.compute_unit_price_ix {
+            instructions.push(compute_unit_price_ix.clone());
+        }
+
+        let transaction = wallet.new_transaction(&instructions).await?;
+        let tx_outcome = wallet.send_or_simulate_transaction(&transaction).await?;
+
+        if let TransactionOutcome::Executed(tx_sig) = tx_outcome {
+            println!("Claimed: {tx_sig}");
+            // The on-chain handler transfers the full balance of each holding,
+            // so the pre-claim balance equals what was drained.
+            for (epoch, holding_pda, drained) in &pre_claim_balances {
+                println!("  epoch {epoch}: {drained} from {holding_pda}");
+            }
+            println!("Total claimed: {total_drained}");
+
+            // Re-fetch the VCR to report the post-tx claim_holding_count.
+            let post_count = match wallet
+                .connection
+                .get_account_with_commitment(&vcr_key, CommitmentConfig::confirmed())
+                .await
+            {
+                Ok(resp) => resp.value.and_then(|acct| {
+                    parse_validator_client_rewards(&acct.data).map(|i| i.claim_holding_count)
+                }),
+                Err(err) => {
+                    eprintln!("warning: post-claim VCR re-fetch failed: {err}");
+                    None
+                }
+            };
+            match post_count {
+                Some(count) => println!("Remaining claim holding count: {count}"),
+                None => println!("Remaining claim holding count: (unavailable)"),
+            }
+
+            wallet.print_verbose_output(&[tx_sig]).await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[derive(Parser)]
+    struct Cli {
+        #[command(flatten)]
+        cmd: ClaimCommand,
+    }
+
+    #[test]
+    fn parses_required_args_with_implicit_destination() {
+        let mint = Pubkey::new_unique();
+        let cli = Cli::try_parse_from([
+            "test",
+            "--client-id",
+            "7",
+            "--rewards-token-mint",
+            &mint.to_string(),
+            "--subscription-epoch",
+            "100",
+        ])
+        .unwrap();
+        assert_eq!(cli.cmd.client_id, 7);
+        assert_eq!(cli.cmd.rewards_token_mint, mint);
+        assert_eq!(cli.cmd.subscription_epochs, vec![100u64]);
+        assert!(cli.cmd.destination_token_account.is_none());
+    }
+
+    #[test]
+    fn parses_explicit_destination() {
+        let mint = Pubkey::new_unique();
+        let dest = Pubkey::new_unique();
+        let cli = Cli::try_parse_from([
+            "test",
+            "--client-id",
+            "7",
+            "--rewards-token-mint",
+            &mint.to_string(),
+            "--subscription-epoch",
+            "100",
+            "--destination-token-account",
+            &dest.to_string(),
+        ])
+        .unwrap();
+        assert_eq!(cli.cmd.destination_token_account, Some(dest));
+    }
+
+    #[test]
+    fn resolve_destination_uses_override_when_provided() {
+        let manager = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let override_dest = Pubkey::new_unique();
+        assert_eq!(
+            resolve_destination(&manager, &mint, Some(override_dest)),
+            override_dest
+        );
+    }
+
+    #[test]
+    fn resolve_destination_defaults_to_ata() {
+        let manager = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let expected = get_associated_token_address(&manager, &mint);
+        assert_eq!(resolve_destination(&manager, &mint, None), expected);
+    }
+
+    #[test]
+    fn validate_manager_matches() {
+        let wallet = Pubkey::new_unique();
+        assert!(validate_manager(&wallet, &wallet).is_ok());
+    }
+
+    #[test]
+    fn validate_manager_mismatch() {
+        let wallet = Pubkey::new_unique();
+        let manager = Pubkey::new_unique();
+        let err = validate_manager(&wallet, &manager).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("manager mismatch"));
+        assert!(msg.contains(&wallet.to_string()));
+        assert!(msg.contains(&manager.to_string()));
+    }
+
+    #[test]
+    fn rejects_missing_subscription_epoch() {
+        let mint = Pubkey::new_unique();
+        let result = Cli::try_parse_from([
+            "test",
+            "--client-id",
+            "7",
+            "--rewards-token-mint",
+            &mint.to_string(),
+        ]);
+        assert!(result.is_err());
+    }
+}

--- a/crates/solana-cli/src/command/shreds/validator_client_rewards/init_holding.rs
+++ b/crates/solana-cli/src/command/shreds/validator_client_rewards/init_holding.rs
@@ -1,0 +1,231 @@
+use anyhow::{Context, Result, bail};
+use clap::Args;
+use doublezero_solana_client_tools::payer::{SolanaPayerOptions, TransactionOutcome, Wallet};
+use doublezero_solana_sdk::{
+    shred_subscription::{
+        ID,
+        instruction::{
+            ShredSubscriptionInstructionData, account::InitializeClaimHoldingAccountAccounts,
+        },
+        state::{
+            find_claim_holding_address, find_validator_client_rewards_address,
+            parse_validator_client_rewards,
+        },
+    },
+    try_build_instruction,
+};
+use solana_sdk::{
+    commitment_config::CommitmentConfig, compute_budget::ComputeBudgetInstruction, pubkey::Pubkey,
+};
+
+/*
+   doublezero-solana shreds validator-client-rewards init-holding \
+       --client-id <ID> --rewards-token-mint <PUBKEY> \
+       --subscription-epoch <EPOCH> [--subscription-epoch <EPOCH> ...]
+*/
+
+#[derive(Debug, Args)]
+pub struct InitHoldingCommand {
+    /// Validator client ID.
+    #[arg(long)]
+    pub client_id: u16,
+    /// Token mint that the holding account will hold.
+    #[arg(long)]
+    pub rewards_token_mint: Pubkey,
+    /// One or more subscription epochs to initialize claim holding accounts for.
+    #[arg(long = "subscription-epoch", required = true, num_args = 1..)]
+    pub subscription_epochs: Vec<u64>,
+    #[command(flatten)]
+    pub solana_payer_options: SolanaPayerOptions,
+}
+
+impl InitHoldingCommand {
+    pub async fn try_into_execute(self) -> Result<()> {
+        let dz_connection = self
+            .solana_payer_options
+            .connection_options
+            .clone()
+            .into_shred_subscription_connection();
+        let mut wallet = Wallet::try_from(self.solana_payer_options)?;
+        wallet.connection = dz_connection;
+        let wallet_key = wallet.pubkey();
+
+        let vcr_key = find_validator_client_rewards_address(self.client_id).0;
+
+        // Verify VCR exists and has the right discriminator.
+        let vcr_account = wallet
+            .connection
+            .get_account_with_commitment(&vcr_key, CommitmentConfig::confirmed())
+            .await
+            .with_context(|| format!("fetching VCR PDA {vcr_key}"))?
+            .value;
+        let vcr_data = match vcr_account {
+            Some(acct) => acct.data,
+            None => bail!(
+                "validator client rewards not initialized for client-id {} (PDA {})",
+                self.client_id,
+                vcr_key
+            ),
+        };
+        if parse_validator_client_rewards(&vcr_data).is_none() {
+            bail!(
+                "account at {vcr_key} is not a ValidatorClientRewards (unexpected discriminator or data layout)"
+            );
+        }
+
+        // Pre-flight: filter epochs whose holding account already exists.
+        let holding_keys: Vec<Pubkey> = self
+            .subscription_epochs
+            .iter()
+            .map(|epoch| find_claim_holding_address(&vcr_key, *epoch, &self.rewards_token_mint).0)
+            .collect();
+        let holding_accounts = wallet
+            .connection
+            .get_multiple_accounts(&holding_keys)
+            .await
+            .with_context(|| "fetching claim holding accounts")?;
+
+        let mut to_init: Vec<(u64, Pubkey)> = Vec::new();
+        for ((epoch, key), maybe_acct) in self
+            .subscription_epochs
+            .iter()
+            .zip(holding_keys.iter())
+            .zip(holding_accounts.into_iter())
+        {
+            if maybe_acct.is_some() {
+                println!("epoch {epoch}: holding {key} already exists; skipping init");
+            } else {
+                to_init.push((*epoch, *key));
+            }
+        }
+
+        if to_init.is_empty() {
+            println!("All requested claim holdings already initialized.");
+            return Ok(());
+        }
+
+        println!(
+            "Shred subscription - Initialize Claim Holding Account (client_id={}, mint={}, epochs={})",
+            self.client_id,
+            self.rewards_token_mint,
+            to_init
+                .iter()
+                .map(|(e, _)| e.to_string())
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+
+        let mut instructions = vec![super::super::build_check_cli_version_instruction()?];
+        for (epoch, _) in &to_init {
+            let ix = try_build_instruction(
+                &ID,
+                InitializeClaimHoldingAccountAccounts::new(
+                    self.client_id,
+                    *epoch,
+                    &self.rewards_token_mint,
+                    &wallet_key,
+                ),
+                &ShredSubscriptionInstructionData::InitializeClaimHoldingAccount(*epoch),
+            )?;
+            instructions.push(ix);
+        }
+
+        // Allow ~25k CU per init (system create + spl-token init + state update),
+        // plus one for the check-cli-version ix.
+        let cu_limit: u32 = 25_000u32.saturating_mul(to_init.len() as u32 + 1);
+        instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(cu_limit));
+        if let Some(ref compute_unit_price_ix) = wallet.compute_unit_price_ix {
+            instructions.push(compute_unit_price_ix.clone());
+        }
+
+        let transaction = wallet.new_transaction(&instructions).await?;
+        let tx_outcome = wallet.send_or_simulate_transaction(&transaction).await?;
+
+        if let TransactionOutcome::Executed(tx_sig) = tx_outcome {
+            println!("Initialize claim holdings: {tx_sig}");
+            for (epoch, key) in &to_init {
+                println!("  epoch {epoch}: {key}");
+            }
+            wallet.print_verbose_output(&[tx_sig]).await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[derive(Parser)]
+    struct Cli {
+        #[command(flatten)]
+        cmd: InitHoldingCommand,
+    }
+
+    #[test]
+    fn parses_required_args() {
+        let mint = Pubkey::new_unique();
+        let cli = Cli::try_parse_from([
+            "test",
+            "--client-id",
+            "7",
+            "--rewards-token-mint",
+            &mint.to_string(),
+            "--subscription-epoch",
+            "100",
+        ])
+        .unwrap();
+        assert_eq!(cli.cmd.client_id, 7);
+        assert_eq!(cli.cmd.rewards_token_mint, mint);
+        assert_eq!(cli.cmd.subscription_epochs, vec![100u64]);
+    }
+
+    #[test]
+    fn parses_multiple_subscription_epochs() {
+        let mint = Pubkey::new_unique();
+        let cli = Cli::try_parse_from([
+            "test",
+            "--client-id",
+            "7",
+            "--rewards-token-mint",
+            &mint.to_string(),
+            "--subscription-epoch",
+            "100",
+            "--subscription-epoch",
+            "101",
+            "--subscription-epoch",
+            "102",
+        ])
+        .unwrap();
+        assert_eq!(cli.cmd.subscription_epochs, vec![100u64, 101, 102]);
+    }
+
+    #[test]
+    fn rejects_missing_client_id() {
+        let mint = Pubkey::new_unique();
+        let result = Cli::try_parse_from([
+            "test",
+            "--rewards-token-mint",
+            &mint.to_string(),
+            "--subscription-epoch",
+            "100",
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_missing_subscription_epoch() {
+        let mint = Pubkey::new_unique();
+        let result = Cli::try_parse_from([
+            "test",
+            "--client-id",
+            "7",
+            "--rewards-token-mint",
+            &mint.to_string(),
+        ]);
+        assert!(result.is_err());
+    }
+}

--- a/crates/solana-cli/src/command/shreds/validator_client_rewards/init_holding.rs
+++ b/crates/solana-cli/src/command/shreds/validator_client_rewards/init_holding.rs
@@ -24,6 +24,13 @@ use solana_sdk::{
        --subscription-epoch <EPOCH> [--subscription-epoch <EPOCH> ...]
 */
 
+/// Upper bound on epochs per init tx. Each init adds one instruction
+/// (~22 bytes incl. accounts/data) plus two new holding/mint-token accounts
+/// to the message; beyond ~20 the tx blows past the 1232-byte packet limit.
+/// 16 leaves headroom for the CheckCliVersion ix and the fee-payer/system
+/// account metas.
+pub(crate) const MAX_INIT_HOLDING_EPOCHS_PER_TX: usize = 16;
+
 #[derive(Debug, Args)]
 pub struct InitHoldingCommand {
     /// Validator client ID.
@@ -41,6 +48,14 @@ pub struct InitHoldingCommand {
 
 impl InitHoldingCommand {
     pub async fn try_into_execute(self) -> Result<()> {
+        if self.subscription_epochs.len() > MAX_INIT_HOLDING_EPOCHS_PER_TX {
+            bail!(
+                "too many --subscription-epoch values ({}); max {} per tx. Split into multiple `init-holding` calls.",
+                self.subscription_epochs.len(),
+                MAX_INIT_HOLDING_EPOCHS_PER_TX
+            );
+        }
+
         let dz_connection = self
             .solana_payer_options
             .connection_options

--- a/crates/solana-cli/src/command/shreds/validator_client_rewards/mod.rs
+++ b/crates/solana-cli/src/command/shreds/validator_client_rewards/mod.rs
@@ -1,0 +1,43 @@
+mod claim;
+mod init_holding;
+mod set_proportion;
+mod show;
+
+use anyhow::Result;
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub struct ValidatorClientRewardsCommand {
+    #[command(subcommand)]
+    pub command: ValidatorClientRewardsSubcommand,
+}
+
+impl ValidatorClientRewardsCommand {
+    pub async fn try_into_execute(self) -> Result<()> {
+        self.command.try_into_execute().await
+    }
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ValidatorClientRewardsSubcommand {
+    /// Set the rewards proportion for a validator client.
+    #[command(hide = true)]
+    SetProportion(set_proportion::SetProportionCommand),
+    /// Initialize one or more claim holding accounts (permissionless).
+    InitHolding(init_holding::InitHoldingCommand),
+    /// Drain N claim holdings into a destination token account.
+    Claim(claim::ClaimCommand),
+    /// Inspect a validator-client-rewards PDA and optional claim holdings.
+    Show(show::ShowCommand),
+}
+
+impl ValidatorClientRewardsSubcommand {
+    pub async fn try_into_execute(self) -> Result<()> {
+        match self {
+            Self::SetProportion(command) => command.try_into_execute().await,
+            Self::InitHolding(command) => command.try_into_execute().await,
+            Self::Claim(command) => command.try_into_execute().await,
+            Self::Show(command) => command.try_into_execute().await,
+        }
+    }
+}

--- a/crates/solana-cli/src/command/shreds/validator_client_rewards/set_proportion.rs
+++ b/crates/solana-cli/src/command/shreds/validator_client_rewards/set_proportion.rs
@@ -13,12 +13,12 @@ use doublezero_solana_sdk::{
 use solana_sdk::compute_budget::ComputeBudgetInstruction;
 
 /*
-   doublezero-solana shreds validator-client-rewards \
+   doublezero-solana shreds validator-client-rewards set-proportion \
        --client-id <ID> --proportion <PERCENT>
 */
 
 #[derive(Debug, Args)]
-pub struct ValidatorClientRewardsCommand {
+pub struct SetProportionCommand {
     /// Validator client ID.
     #[arg(long)]
     client_id: u16,
@@ -29,7 +29,7 @@ pub struct ValidatorClientRewardsCommand {
     solana_payer_options: SolanaPayerOptions,
 }
 
-impl ValidatorClientRewardsCommand {
+impl SetProportionCommand {
     pub async fn try_into_execute(self) -> Result<()> {
         let proportion_bps = percentage_to_bps(self.proportion)?;
 
@@ -54,7 +54,7 @@ impl ValidatorClientRewardsCommand {
             &ShredSubscriptionInstructionData::SetValidatorClientRewardsProportion(proportion_bps),
         )?;
 
-        let check_ix = super::build_check_cli_version_instruction()?;
+        let check_ix = super::super::build_check_cli_version_instruction()?;
         let mut instructions = vec![check_ix, ix];
 
         instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(35_000));

--- a/crates/solana-cli/src/command/shreds/validator_client_rewards/show.rs
+++ b/crates/solana-cli/src/command/shreds/validator_client_rewards/show.rs
@@ -1,0 +1,252 @@
+use anyhow::{Context, Result, bail};
+use clap::Args;
+use doublezero_solana_client_tools::payer::{SolanaPayerOptions, Wallet};
+use doublezero_solana_sdk::shred_subscription::state::{
+    ValidatorClientRewardsInfo, find_claim_holding_address, find_validator_client_rewards_address,
+    parse_validator_client_rewards,
+};
+use solana_sdk::{commitment_config::CommitmentConfig, program_pack::Pack, pubkey::Pubkey};
+use spl_associated_token_account_interface::address::get_associated_token_address;
+
+/*
+   doublezero-solana shreds validator-client-rewards show \
+       --client-id <ID> [--rewards-token-mint <PUBKEY>] \
+       [--subscription-epoch <EPOCH> ...]
+*/
+
+#[derive(Debug, Args)]
+pub struct ShowCommand {
+    /// Validator client ID.
+    #[arg(long)]
+    pub client_id: u16,
+    /// Filter to a specific token mint when listing holdings.
+    #[arg(long)]
+    pub rewards_token_mint: Option<Pubkey>,
+    /// One or more subscription epochs to inspect. Requires --rewards-token-mint.
+    #[arg(long = "subscription-epoch", num_args = 0..)]
+    pub subscription_epochs: Vec<u64>,
+    #[command(flatten)]
+    pub solana_payer_options: SolanaPayerOptions,
+}
+
+pub(crate) fn render_vcr_summary(
+    client_id: u16,
+    vcr_key: &Pubkey,
+    info: &ValidatorClientRewardsInfo,
+) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "Validator client rewards (client_id={client_id})\n"
+    ));
+    out.push_str(&format!("  PDA                 : {vcr_key}\n"));
+    out.push_str(&format!("  manager             : {}\n", info.manager_key));
+    out.push_str(&format!(
+        "  description         : {}\n",
+        info.short_description.as_deref().unwrap_or("(none)")
+    ));
+    out.push_str(&format!(
+        "  claim holding count : {}\n",
+        info.claim_holding_count
+    ));
+    out
+}
+
+// Format is grep'd by sh/test_doublezero_solana_fork.sh — keep
+// "  epoch <num>  <pda>  balance=<n>" stable or update the grep.
+pub(crate) fn render_holding_row(epoch: u64, holding_key: &Pubkey, amount: Option<u64>) -> String {
+    match amount {
+        Some(amt) => format!("  epoch {epoch:>5}  {holding_key}  balance={amt}"),
+        None => format!("  epoch {epoch:>5}  {holding_key}  (not initialized)"),
+    }
+}
+
+pub(crate) fn render_manager_ata_row(ata: &Pubkey, amount: Option<u64>) -> String {
+    match amount {
+        Some(amt) => format!("  manager ATA  {ata}  balance={amt}"),
+        None => format!("  manager ATA  {ata}  (not initialized)"),
+    }
+}
+
+impl ShowCommand {
+    pub async fn try_into_execute(self) -> Result<()> {
+        if !self.subscription_epochs.is_empty() && self.rewards_token_mint.is_none() {
+            bail!("--subscription-epoch requires --rewards-token-mint");
+        }
+
+        let dz_connection = self
+            .solana_payer_options
+            .connection_options
+            .clone()
+            .into_shred_subscription_connection();
+        let mut wallet = Wallet::try_from(self.solana_payer_options)?;
+        wallet.connection = dz_connection;
+
+        let vcr_key = find_validator_client_rewards_address(self.client_id).0;
+        let vcr_account = wallet
+            .connection
+            .get_account_with_commitment(&vcr_key, CommitmentConfig::confirmed())
+            .await
+            .with_context(|| format!("fetching VCR PDA {vcr_key}"))?
+            .value;
+        let vcr_data = match vcr_account {
+            Some(acct) => acct.data,
+            None => {
+                println!(
+                    "Validator client rewards not initialized for client-id {} (PDA {vcr_key})",
+                    self.client_id
+                );
+                return Ok(());
+            }
+        };
+        let info = parse_validator_client_rewards(&vcr_data)
+            .with_context(|| format!("failed to parse ValidatorClientRewards at {vcr_key}"))?;
+        print!("{}", render_vcr_summary(self.client_id, &vcr_key, &info));
+
+        // When a mint is supplied, always print the manager's ATA address and
+        // balance. Per-epoch holding rows are only listed when the user also
+        // supplies one or more `--subscription-epoch` values.
+        if let Some(mint) = self.rewards_token_mint {
+            println!("Claim holdings for mint {mint}:");
+            let manager_ata = get_associated_token_address(&info.manager_key, &mint);
+            let ata_account = wallet
+                .connection
+                .get_account_with_commitment(&manager_ata, CommitmentConfig::confirmed())
+                .await
+                .with_context(|| format!("fetching manager ATA {manager_ata}"))?
+                .value;
+            let ata_amount = match ata_account {
+                Some(acct) if acct.owner == spl_token_interface::ID => {
+                    spl_token_interface::state::Account::unpack(&acct.data)
+                        .ok()
+                        .map(|t| t.amount)
+                }
+                _ => None,
+            };
+            println!("{}", render_manager_ata_row(&manager_ata, ata_amount));
+
+            if !self.subscription_epochs.is_empty() {
+                let holding_keys: Vec<Pubkey> = self
+                    .subscription_epochs
+                    .iter()
+                    .map(|e| find_claim_holding_address(&vcr_key, *e, &mint).0)
+                    .collect();
+                let holding_accounts = wallet
+                    .connection
+                    .get_multiple_accounts(&holding_keys)
+                    .await
+                    .with_context(|| "fetching claim holdings")?;
+                for ((epoch, key), maybe_acct) in self
+                    .subscription_epochs
+                    .iter()
+                    .zip(holding_keys.iter())
+                    .zip(holding_accounts.into_iter())
+                {
+                    let amount = match maybe_acct {
+                        Some(acct) if acct.owner == spl_token_interface::ID => {
+                            spl_token_interface::state::Account::unpack(&acct.data)
+                                .ok()
+                                .map(|t| t.amount)
+                        }
+                        _ => None,
+                    };
+                    println!("{}", render_holding_row(*epoch, key, amount));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[derive(Parser)]
+    struct Cli {
+        #[command(flatten)]
+        cmd: ShowCommand,
+    }
+
+    #[test]
+    fn parses_minimum_args() {
+        let cli = Cli::try_parse_from(["test", "--client-id", "7"]).unwrap();
+        assert_eq!(cli.cmd.client_id, 7);
+        assert!(cli.cmd.rewards_token_mint.is_none());
+        assert!(cli.cmd.subscription_epochs.is_empty());
+    }
+
+    #[test]
+    fn parses_full_inspection_args() {
+        let mint = Pubkey::new_unique();
+        let cli = Cli::try_parse_from([
+            "test",
+            "--client-id",
+            "7",
+            "--rewards-token-mint",
+            &mint.to_string(),
+            "--subscription-epoch",
+            "100",
+            "--subscription-epoch",
+            "101",
+        ])
+        .unwrap();
+        assert_eq!(cli.cmd.rewards_token_mint, Some(mint));
+        assert_eq!(cli.cmd.subscription_epochs, vec![100u64, 101]);
+    }
+
+    #[test]
+    fn render_vcr_summary_uses_none_when_description_empty() {
+        let info = ValidatorClientRewardsInfo {
+            client_id: 7,
+            manager_key: Pubkey::new_from_array([1u8; 32]),
+            short_description: None,
+            claim_holding_count: 0,
+        };
+        let key = Pubkey::new_from_array([2u8; 32]);
+        let out = render_vcr_summary(7, &key, &info);
+        assert!(out.contains("description         : (none)"));
+        assert!(out.contains("claim holding count : 0"));
+        assert!(out.contains(&info.manager_key.to_string()));
+        assert!(out.contains(&key.to_string()));
+    }
+
+    #[test]
+    fn render_vcr_summary_renders_description() {
+        let info = ValidatorClientRewardsInfo {
+            client_id: 7,
+            manager_key: Pubkey::new_from_array([1u8; 32]),
+            short_description: Some("acme".to_string()),
+            claim_holding_count: 4,
+        };
+        let key = Pubkey::new_from_array([2u8; 32]);
+        let out = render_vcr_summary(7, &key, &info);
+        assert!(out.contains("description         : acme"));
+        assert!(out.contains("claim holding count : 4"));
+    }
+
+    #[test]
+    fn render_holding_row_present_and_absent() {
+        let key = Pubkey::new_from_array([3u8; 32]);
+        let present = render_holding_row(100, &key, Some(1_234_567));
+        let absent = render_holding_row(101, &key, None);
+        assert!(present.contains("epoch   100"));
+        assert!(present.contains("balance=1234567"));
+        assert!(absent.contains("(not initialized)"));
+    }
+
+    #[test]
+    fn render_manager_ata_row_present_and_absent() {
+        let ata = Pubkey::new_from_array([4u8; 32]);
+        let present = render_manager_ata_row(&ata, Some(9_876_543));
+        let absent = render_manager_ata_row(&ata, None);
+        assert!(present.contains("manager ATA"));
+        assert!(present.contains(&ata.to_string()));
+        assert!(present.contains("balance=9876543"));
+        assert!(absent.contains("manager ATA"));
+        assert!(absent.contains(&ata.to_string()));
+        assert!(absent.contains("(not initialized)"));
+    }
+}

--- a/crates/solana-cli/src/command/shreds/validator_client_rewards/show.rs
+++ b/crates/solana-cli/src/command/shreds/validator_client_rewards/show.rs
@@ -51,20 +51,78 @@ pub(crate) fn render_vcr_summary(
     out
 }
 
-// Format is grep'd by sh/test_doublezero_solana_fork.sh — keep
-// "  epoch <num>  <pda>  balance=<n>" stable or update the grep.
-pub(crate) fn render_holding_row(epoch: u64, holding_key: &Pubkey, amount: Option<u64>) -> String {
-    match amount {
-        Some(amt) => format!("  epoch {epoch:>5}  {holding_key}  balance={amt}"),
-        None => format!("  epoch {epoch:>5}  {holding_key}  (not initialized)"),
+/// Status of a token-bearing account (manager ATA or per-epoch holding PDA)
+/// for display purposes. Splits the cases that `Option<u64>` previously
+/// collapsed so the user can tell apart "wasn't created" from "wrong owner /
+/// malformed".
+pub(crate) enum TokenAccountStatus {
+    Balance(u64),
+    DoesNotExist,
+    WrongOwner(Pubkey),
+    Malformed,
+    WrongMint(Pubkey),
+}
+
+impl TokenAccountStatus {
+    fn render_tail(&self, expected_mint: Option<&Pubkey>) -> String {
+        match self {
+            TokenAccountStatus::Balance(amt) => format!("balance={amt}"),
+            TokenAccountStatus::DoesNotExist => "(does not exist)".to_string(),
+            TokenAccountStatus::WrongOwner(owner) => format!("(wrong owner: {owner})"),
+            TokenAccountStatus::Malformed => "(malformed token account)".to_string(),
+            TokenAccountStatus::WrongMint(found) => match expected_mint {
+                Some(expected) => {
+                    format!("(wrong mint: found {found}, expected {expected})")
+                }
+                None => format!("(wrong mint: found {found})"),
+            },
+        }
     }
 }
 
-pub(crate) fn render_manager_ata_row(ata: &Pubkey, amount: Option<u64>) -> String {
-    match amount {
-        Some(amt) => format!("  manager ATA  {ata}  balance={amt}"),
-        None => format!("  manager ATA  {ata}  (not initialized)"),
+/// Classify a fetched token account against the expected mint (when known).
+pub(crate) fn classify_token_account(
+    account: Option<&solana_sdk::account::Account>,
+    expected_mint: Option<&Pubkey>,
+) -> TokenAccountStatus {
+    let Some(account) = account else {
+        return TokenAccountStatus::DoesNotExist;
+    };
+    if account.owner != spl_token_interface::ID {
+        return TokenAccountStatus::WrongOwner(account.owner);
     }
+    match spl_token_interface::state::Account::unpack(&account.data) {
+        Err(_) => TokenAccountStatus::Malformed,
+        Ok(token) => match expected_mint {
+            Some(expected) if token.mint != *expected => TokenAccountStatus::WrongMint(token.mint),
+            _ => TokenAccountStatus::Balance(token.amount),
+        },
+    }
+}
+
+// Format is grep'd by sh/test_doublezero_solana_fork.sh — keep
+// "  epoch <num>  <pda>  balance=<n>" stable or update the grep.
+pub(crate) fn render_holding_row(
+    epoch: u64,
+    holding_key: &Pubkey,
+    status: &TokenAccountStatus,
+    expected_mint: Option<&Pubkey>,
+) -> String {
+    format!(
+        "  epoch {epoch:>5}  {holding_key}  {}",
+        status.render_tail(expected_mint)
+    )
+}
+
+pub(crate) fn render_manager_ata_row(
+    ata: &Pubkey,
+    status: &TokenAccountStatus,
+    expected_mint: Option<&Pubkey>,
+) -> String {
+    format!(
+        "  manager ATA  {ata}  {}",
+        status.render_tail(expected_mint)
+    )
 }
 
 impl ShowCommand {
@@ -114,15 +172,11 @@ impl ShowCommand {
                 .await
                 .with_context(|| format!("fetching manager ATA {manager_ata}"))?
                 .value;
-            let ata_amount = match ata_account {
-                Some(acct) if acct.owner == spl_token_interface::ID => {
-                    spl_token_interface::state::Account::unpack(&acct.data)
-                        .ok()
-                        .map(|t| t.amount)
-                }
-                _ => None,
-            };
-            println!("{}", render_manager_ata_row(&manager_ata, ata_amount));
+            let ata_status = classify_token_account(ata_account.as_ref(), Some(&mint));
+            println!(
+                "{}",
+                render_manager_ata_row(&manager_ata, &ata_status, Some(&mint))
+            );
 
             if !self.subscription_epochs.is_empty() {
                 let holding_keys: Vec<Pubkey> = self
@@ -141,15 +195,8 @@ impl ShowCommand {
                     .zip(holding_keys.iter())
                     .zip(holding_accounts.into_iter())
                 {
-                    let amount = match maybe_acct {
-                        Some(acct) if acct.owner == spl_token_interface::ID => {
-                            spl_token_interface::state::Account::unpack(&acct.data)
-                                .ok()
-                                .map(|t| t.amount)
-                        }
-                        _ => None,
-                    };
-                    println!("{}", render_holding_row(*epoch, key, amount));
+                    let status = classify_token_account(maybe_acct.as_ref(), Some(&mint));
+                    println!("{}", render_holding_row(*epoch, key, &status, Some(&mint)));
                 }
             }
         }
@@ -228,25 +275,60 @@ mod tests {
     }
 
     #[test]
-    fn render_holding_row_present_and_absent() {
+    fn render_holding_row_distinguishes_statuses() {
         let key = Pubkey::new_from_array([3u8; 32]);
-        let present = render_holding_row(100, &key, Some(1_234_567));
-        let absent = render_holding_row(101, &key, None);
-        assert!(present.contains("epoch   100"));
-        assert!(present.contains("balance=1234567"));
-        assert!(absent.contains("(not initialized)"));
+        let expected_mint = Pubkey::new_from_array([5u8; 32]);
+        let other_mint = Pubkey::new_from_array([6u8; 32]);
+        let wrong_owner = Pubkey::new_from_array([7u8; 32]);
+
+        let balance = render_holding_row(100, &key, &TokenAccountStatus::Balance(1_234_567), None);
+        assert!(balance.contains("epoch   100"));
+        assert!(balance.contains("balance=1234567"));
+
+        let missing = render_holding_row(101, &key, &TokenAccountStatus::DoesNotExist, None);
+        assert!(missing.contains("(does not exist)"));
+
+        let bad_owner = render_holding_row(
+            102,
+            &key,
+            &TokenAccountStatus::WrongOwner(wrong_owner),
+            None,
+        );
+        assert!(bad_owner.contains("(wrong owner:"));
+        assert!(bad_owner.contains(&wrong_owner.to_string()));
+
+        let malformed = render_holding_row(103, &key, &TokenAccountStatus::Malformed, None);
+        assert!(malformed.contains("(malformed token account)"));
+
+        let wrong_mint = render_holding_row(
+            104,
+            &key,
+            &TokenAccountStatus::WrongMint(other_mint),
+            Some(&expected_mint),
+        );
+        assert!(wrong_mint.contains("(wrong mint: found"));
+        assert!(wrong_mint.contains(&other_mint.to_string()));
+        assert!(wrong_mint.contains(&expected_mint.to_string()));
     }
 
     #[test]
-    fn render_manager_ata_row_present_and_absent() {
+    fn render_manager_ata_row_distinguishes_statuses() {
         let ata = Pubkey::new_from_array([4u8; 32]);
-        let present = render_manager_ata_row(&ata, Some(9_876_543));
-        let absent = render_manager_ata_row(&ata, None);
+        let present = render_manager_ata_row(&ata, &TokenAccountStatus::Balance(9_876_543), None);
+        let missing = render_manager_ata_row(&ata, &TokenAccountStatus::DoesNotExist, None);
+        let wrong_owner_key = Pubkey::new_from_array([8u8; 32]);
+        let wrong_owner =
+            render_manager_ata_row(&ata, &TokenAccountStatus::WrongOwner(wrong_owner_key), None);
+
         assert!(present.contains("manager ATA"));
         assert!(present.contains(&ata.to_string()));
         assert!(present.contains("balance=9876543"));
-        assert!(absent.contains("manager ATA"));
-        assert!(absent.contains(&ata.to_string()));
-        assert!(absent.contains("(not initialized)"));
+
+        assert!(missing.contains("manager ATA"));
+        assert!(missing.contains(&ata.to_string()));
+        assert!(missing.contains("(does not exist)"));
+
+        assert!(wrong_owner.contains("(wrong owner:"));
+        assert!(wrong_owner.contains(&wrong_owner_key.to_string()));
     }
 }

--- a/crates/solana-fork/CHANGELOG.md
+++ b/crates/solana-fork/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- add `--synthetic-vcr-manager <PUBKEY>` flag that bakes a `ValidatorClientRewards` PDA for `client_id=65535` with the given manager into the fork at genesis, for exercising `shreds validator-client-rewards claim` in fork tests
+- fix: synthetic VCR account body is 184 bytes — `StorageGap<2>` is 64 bytes (not 48); the prior 176-byte account was rejected at runtime by the on-chain `data_end == 184` const assertion
 - revert: seed journal and fills registry in localnet fork ([#322](https://github.com/doublezerofoundation/doublezero-offchain/pull/322))
 - seed journal and fills registry in localnet fork ([#309](https://github.com/doublezerofoundation/doublezero-offchain/pull/309))
 

--- a/crates/solana-fork/src/main.rs
+++ b/crates/solana-fork/src/main.rs
@@ -8,7 +8,7 @@ use doublezero_solana_client_tools::{
     rpc::{SolanaConnection, SolanaConnectionOptions},
 };
 use doublezero_solana_sdk::{
-    DISCRIMINATOR_LEN, NetworkEnvironment, PrecomputedDiscriminator, environment_2z_token_mint_key,
+    NetworkEnvironment, PrecomputedDiscriminator, environment_2z_token_mint_key,
     passport::{ID as PASSPORT_PROGRAM_ID, state::ProgramConfig as PassportProgramConfig},
     revenue_distribution::{
         self, ID as REVENUE_DISTRIBUTION_PROGRAM_ID,
@@ -676,35 +676,55 @@ fn try_write_synthetic_validator_client_rewards_account(
     use doublezero_solana_sdk::shred_subscription::{
         ID as SHRED_SUBSCRIPTION_PROGRAM_ID,
         state::{
-            VALIDATOR_CLIENT_REWARDS_DISCRIMINATOR, VCR_CLIENT_ID_OFFSET, VCR_MANAGER_KEY_OFFSET,
-            find_validator_client_rewards_address,
+            VALIDATOR_CLIENT_REWARDS_DISCRIMINATOR, VCR_ACCOUNT_DATA_LEN, VCR_BUMP_SEED_OFFSET,
+            VCR_CLIENT_ID_OFFSET, VCR_MANAGER_KEY_OFFSET, find_validator_client_rewards_address,
+            parse_validator_client_rewards,
         },
     };
     use solana_sdk::rent::Rent;
 
-    // Account size = discriminator (8) + struct body. The struct body is 176
-    // bytes: header (8: client_id + bump + padding) + manager (32) + desc (64) +
-    // claim_holding_count (4) + padding (4) + StorageGap<2> (64). Total
-    // account size = 8 + 176 = 184. Note: StorageGap<N> is [[u8; 32]; N], so
-    // StorageGap<2> = 64 bytes. The on-chain processor enforces this layout
-    // via `const _: () = assert!(zero_copy::data_end::<ValidatorClientRewards>() == 184);`.
-    const DATA_LEN: usize = 184;
-
+    // The total account size and per-field offsets are owned by the SDK
+    // (`VCR_ACCOUNT_DATA_LEN`, `VCR_*_OFFSET`). The on-chain processor
+    // enforces the same total via
+    // `const _: () = assert!(zero_copy::data_end::<ValidatorClientRewards>() == 184);`.
+    // After construction we round-trip through `parse_validator_client_rewards`
+    // as a runtime sanity check — if the SDK and on-chain layouts ever drift,
+    // we fail loudly at fork-load time instead of silently producing broken
+    // bytes.
     let (vcr_key, bump) = find_validator_client_rewards_address(SYNTHETIC_VCR_CLIENT_ID);
-    let mut data = vec![0u8; DATA_LEN];
+    let mut data = vec![0u8; VCR_ACCOUNT_DATA_LEN];
     let disc_bytes = borsh::to_vec(&VALIDATOR_CLIENT_REWARDS_DISCRIMINATOR)
         .expect("discriminator serialization");
     data[..disc_bytes.len()].copy_from_slice(&disc_bytes);
     data[VCR_CLIENT_ID_OFFSET..VCR_CLIENT_ID_OFFSET + 2]
         .copy_from_slice(&SYNTHETIC_VCR_CLIENT_ID.to_le_bytes());
-    // bump_seed lives at offset (discriminator + 2).
-    data[DISCRIMINATOR_LEN + 2] = bump;
+    data[VCR_BUMP_SEED_OFFSET] = bump;
     data[VCR_MANAGER_KEY_OFFSET..VCR_MANAGER_KEY_OFFSET + 32].copy_from_slice(manager_key.as_ref());
     // short_description stays zero (no description). claim_holding_count starts
     // at 0. Both are covered by the initial vec![0; ...].
 
+    let parsed = parse_validator_client_rewards(&data).with_context(|| {
+        "synthetic ValidatorClientRewards bytes failed to parse — \
+         SDK layout constants and the on-chain struct may have drifted"
+    })?;
+    ensure!(
+        parsed.client_id == SYNTHETIC_VCR_CLIENT_ID,
+        "synthetic VCR client_id round-trip mismatch: wrote {SYNTHETIC_VCR_CLIENT_ID}, parsed {}",
+        parsed.client_id
+    );
+    ensure!(
+        parsed.manager_key == *manager_key,
+        "synthetic VCR manager_key round-trip mismatch: wrote {manager_key}, parsed {}",
+        parsed.manager_key
+    );
+    ensure!(
+        parsed.claim_holding_count == 0,
+        "synthetic VCR claim_holding_count round-trip mismatch: wrote 0, parsed {}",
+        parsed.claim_holding_count
+    );
+
     let rent = Rent::default();
-    let lamports = rent.minimum_balance(DATA_LEN);
+    let lamports = rent.minimum_balance(VCR_ACCOUNT_DATA_LEN);
 
     let account = Account {
         lamports,

--- a/crates/solana-fork/src/main.rs
+++ b/crates/solana-fork/src/main.rs
@@ -8,13 +8,14 @@ use doublezero_solana_client_tools::{
     rpc::{SolanaConnection, SolanaConnectionOptions},
 };
 use doublezero_solana_sdk::{
-    NetworkEnvironment, PrecomputedDiscriminator, environment_2z_token_mint_key,
+    DISCRIMINATOR_LEN, NetworkEnvironment, PrecomputedDiscriminator, environment_2z_token_mint_key,
     passport::{ID as PASSPORT_PROGRAM_ID, state::ProgramConfig as PassportProgramConfig},
     revenue_distribution::{
         self, ID as REVENUE_DISTRIBUTION_PROGRAM_ID,
         state::{Distribution, Journal, ProgramConfig as RevenueDistributionProgramConfig},
         types::DoubleZeroEpoch,
     },
+    shred_subscription::ID as SHRED_SUBSCRIPTION_PROGRAM_ID,
     sol_conversion::{
         ID as SOL_CONVERSION_PROGRAM_ID, state::ProgramState as SolConversionProgramState,
     },
@@ -73,6 +74,13 @@ struct Args {
     #[arg(long, value_name = "EPOCH")]
     next_completed_dz_epoch_override: Option<u64>,
 
+    /// Pubkey to use as the manager of a synthetic ValidatorClientRewards PDA
+    /// (`client_id=65535`). When set, the fork loader bakes a VCR account at
+    /// genesis so the fork test can exercise `validator-client-rewards claim`.
+    /// Defaults to disabled (no synthetic VCR).
+    #[arg(long, env, value_name = "PUBKEY")]
+    synthetic_vcr_manager: Option<Pubkey>,
+
     #[command(flatten)]
     solana_connection_options: SolanaConnectionOptions,
 }
@@ -94,6 +102,7 @@ async fn main() -> Result<()> {
         reset: should_reset,
         god_mode: should_god_mode,
         next_completed_dz_epoch_override,
+        synthetic_vcr_manager,
         solana_connection_options,
     } = Args::parse();
 
@@ -144,6 +153,19 @@ async fn main() -> Result<()> {
         .await
         {
             Ok(_) => {
+                // Optionally bake a synthetic ValidatorClientRewards PDA into
+                // the fork. Used by fork tests to exercise
+                // `validator-client-rewards claim` without needing the
+                // shred-subscription admin keypair.
+                if let Some(ref manager) = synthetic_vcr_manager
+                    && let Err(e) = try_write_synthetic_validator_client_rewards_account(
+                        manager,
+                        TMP_ACCOUNTS_PATH,
+                    )
+                {
+                    fs::remove_dir_all(TMP_ACCOUNTS_PATH)?;
+                    return Err(e);
+                }
                 // Rename temporary directory to final location.
                 fs::rename(TMP_ACCOUNTS_PATH, ACCOUNTS_PATH)?;
             }
@@ -187,6 +209,10 @@ async fn main() -> Result<()> {
         .arg("--upgradeable-program")
         .arg(SOL_CONVERSION_PROGRAM_ID.to_string())
         .arg(format!("{ACCOUNTS_PATH}/sol_conversion.so"))
+        .arg(upgrade_authority_key.to_string())
+        .arg("--upgradeable-program")
+        .arg(SHRED_SUBSCRIPTION_PROGRAM_ID.to_string())
+        .arg(format!("{ACCOUNTS_PATH}/shred_subscription.so"))
         .arg(upgrade_authority_key.to_string());
 
     if should_reset {
@@ -260,6 +286,15 @@ async fn try_fetch_and_write_accounts(
     )
     .await?;
 
+    try_fetch_and_write_program_accounts(
+        connection,
+        &SHRED_SUBSCRIPTION_PROGRAM_ID,
+        "Shred Subscription",
+        TMP_ACCOUNTS_PATH,
+        &config,
+    )
+    .await?;
+
     // Dump programs.
 
     try_dump_program(
@@ -281,6 +316,13 @@ async fn try_fetch_and_write_accounts(
         &SOL_CONVERSION_PROGRAM_ID,
         "SOL Conversion",
         &format!("{TMP_ACCOUNTS_PATH}/sol_conversion.so"),
+    )?;
+
+    try_dump_program(
+        connection,
+        &SHRED_SUBSCRIPTION_PROGRAM_ID,
+        "Shred Subscription",
+        &format!("{TMP_ACCOUNTS_PATH}/shred_subscription.so"),
     )?;
 
     if should_god_mode {
@@ -620,4 +662,64 @@ fn try_dump_program(
 
     tracing::info!("{} program dumped successfully", program_name);
     Ok(())
+}
+
+const SYNTHETIC_VCR_CLIENT_ID: u16 = 65535;
+
+/// Bake a synthetic `ValidatorClientRewards` PDA into the fork's accounts
+/// directory. `manager_key` is the test-wallet pubkey (the same key that
+/// the fork test uses as `-k` for the `claim` command).
+fn try_write_synthetic_validator_client_rewards_account(
+    manager_key: &Pubkey,
+    accounts_dir: &str,
+) -> Result<()> {
+    use doublezero_solana_sdk::shred_subscription::{
+        ID as SHRED_SUBSCRIPTION_PROGRAM_ID,
+        state::{
+            VALIDATOR_CLIENT_REWARDS_DISCRIMINATOR, VCR_CLIENT_ID_OFFSET, VCR_MANAGER_KEY_OFFSET,
+            find_validator_client_rewards_address,
+        },
+    };
+    use solana_sdk::rent::Rent;
+
+    // Account size = discriminator (8) + struct body. The struct body is 176
+    // bytes: header (8: client_id + bump + padding) + manager (32) + desc (64) +
+    // claim_holding_count (4) + padding (4) + StorageGap<2> (64). Total
+    // account size = 8 + 176 = 184. Note: StorageGap<N> is [[u8; 32]; N], so
+    // StorageGap<2> = 64 bytes. The on-chain processor enforces this layout
+    // via `const _: () = assert!(zero_copy::data_end::<ValidatorClientRewards>() == 184);`.
+    const DATA_LEN: usize = 184;
+
+    let (vcr_key, bump) = find_validator_client_rewards_address(SYNTHETIC_VCR_CLIENT_ID);
+    let mut data = vec![0u8; DATA_LEN];
+    let disc_bytes = borsh::to_vec(&VALIDATOR_CLIENT_REWARDS_DISCRIMINATOR)
+        .expect("discriminator serialization");
+    data[..disc_bytes.len()].copy_from_slice(&disc_bytes);
+    data[VCR_CLIENT_ID_OFFSET..VCR_CLIENT_ID_OFFSET + 2]
+        .copy_from_slice(&SYNTHETIC_VCR_CLIENT_ID.to_le_bytes());
+    // bump_seed lives at offset (discriminator + 2).
+    data[DISCRIMINATOR_LEN + 2] = bump;
+    data[VCR_MANAGER_KEY_OFFSET..VCR_MANAGER_KEY_OFFSET + 32].copy_from_slice(manager_key.as_ref());
+    // short_description stays zero (no description). claim_holding_count starts
+    // at 0. Both are covered by the initial vec![0; ...].
+
+    let rent = Rent::default();
+    let lamports = rent.minimum_balance(DATA_LEN);
+
+    let account = Account {
+        lamports,
+        data,
+        owner: *SHRED_SUBSCRIPTION_PROGRAM_ID,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    tracing::info!(
+        "Baking synthetic ValidatorClientRewards (client_id={}, manager={}) at {} into {}",
+        SYNTHETIC_VCR_CLIENT_ID,
+        manager_key,
+        vcr_key,
+        accounts_dir,
+    );
+    try_write_account_to_file(&vcr_key, &account, accounts_dir)
 }

--- a/crates/solana-sdk/CHANGELOG.md
+++ b/crates/solana-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- add `find_claim_holding_address` PDA helper and `CLAIM_HOLDING_SEED_PREFIX` constant for `ValidatorClientRewards` claim holding accounts
+- add `ValidatorClientRewards` discriminator + offset constants and `parse_validator_client_rewards` parser
+- add `parse_program_config_shred_oracle_key` helper for reading `ProgramConfig.shred_oracle_key`
+- add `InitializeClaimHoldingAccount` and `ClaimValidatorClientRewards` instruction variants and the `ClaimHoldingId` Borsh struct
+- add `InitializeClaimHoldingAccountAccounts` builder for the `InitializeClaimHoldingAccount` instruction
+- add `ClaimValidatorClientRewardsAccounts` builder for the `ClaimValidatorClientRewards` instruction (6 fixed + N holding accounts)
 - add `RequestProratedInstantSeatWithdrawal` instruction variant and accounts builder
 - add `find_shred_distribution_address` PDA helper and `parse_client_seat_last_usdc_price_dollars` parser for prorated withdrawal integration
 - add `is_prorated_service_enabled` helper and `ProgramConfig` flag/offset constants for raw-byte parsing

--- a/crates/solana-sdk/src/shred_subscription/instruction/account.rs
+++ b/crates/solana-sdk/src/shred_subscription/instruction/account.rs
@@ -430,3 +430,225 @@ impl From<FundPaymentEscrowUsdcAccounts> for Vec<AccountMeta> {
         ]
     }
 }
+
+/// Accounts for the `InitializeClaimHoldingAccount` instruction (6 accounts).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InitializeClaimHoldingAccountAccounts {
+    pub parent_pda_key: Pubkey,
+    pub payer_key: Pubkey,
+    pub new_claim_holding_account_key: Pubkey,
+    pub mint_key: Pubkey,
+}
+
+impl InitializeClaimHoldingAccountAccounts {
+    pub fn new(
+        client_id: u16,
+        subscription_epoch: u64,
+        mint_key: &Pubkey,
+        payer_key: &Pubkey,
+    ) -> Self {
+        let parent_pda_key = state::find_validator_client_rewards_address(client_id).0;
+        let new_claim_holding_account_key =
+            state::find_claim_holding_address(&parent_pda_key, subscription_epoch, mint_key).0;
+        Self {
+            parent_pda_key,
+            payer_key: *payer_key,
+            new_claim_holding_account_key,
+            mint_key: *mint_key,
+        }
+    }
+}
+
+impl From<InitializeClaimHoldingAccountAccounts> for Vec<AccountMeta> {
+    fn from(accounts: InitializeClaimHoldingAccountAccounts) -> Self {
+        vec![
+            AccountMeta::new(accounts.parent_pda_key, false),
+            AccountMeta::new(accounts.payer_key, true),
+            AccountMeta::new(accounts.new_claim_holding_account_key, false),
+            AccountMeta::new_readonly(accounts.mint_key, false),
+            AccountMeta::new_readonly(spl_token_interface::ID, false),
+            AccountMeta::new_readonly(solana_sdk::system_program::ID, false),
+        ]
+    }
+}
+
+/// Accounts for the `ClaimValidatorClientRewards` instruction (6 fixed +
+/// one writable per claim holding in `claim_holding_account_keys`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaimValidatorClientRewardsAccounts {
+    pub program_config_key: Pubkey,
+    pub validator_client_rewards_key: Pubkey,
+    pub manager_key: Pubkey,
+    pub destination_token_account_key: Pubkey,
+    pub rent_beneficiary_key: Pubkey,
+    pub claim_holding_account_keys: Vec<Pubkey>,
+}
+
+impl ClaimValidatorClientRewardsAccounts {
+    pub fn new(
+        client_id: u16,
+        manager_key: &Pubkey,
+        destination_token_account_key: &Pubkey,
+        rent_beneficiary_key: &Pubkey,
+        mint_key: &Pubkey,
+        subscription_epochs: &[u64],
+    ) -> Self {
+        let validator_client_rewards_key =
+            state::find_validator_client_rewards_address(client_id).0;
+        let claim_holding_account_keys = subscription_epochs
+            .iter()
+            .map(|epoch| {
+                state::find_claim_holding_address(&validator_client_rewards_key, *epoch, mint_key).0
+            })
+            .collect();
+        Self {
+            program_config_key: state::find_program_config_address().0,
+            validator_client_rewards_key,
+            manager_key: *manager_key,
+            destination_token_account_key: *destination_token_account_key,
+            rent_beneficiary_key: *rent_beneficiary_key,
+            claim_holding_account_keys,
+        }
+    }
+}
+
+impl From<ClaimValidatorClientRewardsAccounts> for Vec<AccountMeta> {
+    fn from(accounts: ClaimValidatorClientRewardsAccounts) -> Self {
+        let mut metas = vec![
+            AccountMeta::new_readonly(accounts.program_config_key, false),
+            AccountMeta::new(accounts.validator_client_rewards_key, false),
+            AccountMeta::new_readonly(accounts.manager_key, true),
+            AccountMeta::new(accounts.destination_token_account_key, false),
+            AccountMeta::new(accounts.rent_beneficiary_key, false),
+            AccountMeta::new_readonly(spl_token_interface::ID, false),
+        ];
+        metas.extend(
+            accounts
+                .claim_holding_account_keys
+                .into_iter()
+                .map(|key| AccountMeta::new(key, false)),
+        );
+        metas
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use solana_sdk::pubkey::Pubkey;
+
+    use super::*;
+
+    #[test]
+    fn initialize_claim_holding_account_metas_order() {
+        let payer = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let client_id: u16 = 7;
+        let epoch: u64 = 1234;
+        let accounts = InitializeClaimHoldingAccountAccounts::new(client_id, epoch, &mint, &payer);
+        let parent_pda = state::find_validator_client_rewards_address(client_id).0;
+        let holding_pda = state::find_claim_holding_address(&parent_pda, epoch, &mint).0;
+        assert_eq!(accounts.parent_pda_key, parent_pda);
+        assert_eq!(accounts.new_claim_holding_account_key, holding_pda);
+        assert_eq!(accounts.payer_key, payer);
+        assert_eq!(accounts.mint_key, mint);
+
+        let metas: Vec<AccountMeta> = accounts.into();
+        assert_eq!(metas.len(), 6);
+        // 0: parent_pda (writable, not signer)
+        assert_eq!(metas[0].pubkey, parent_pda);
+        assert!(metas[0].is_writable && !metas[0].is_signer);
+        // 1: payer (writable, signer)
+        assert_eq!(metas[1].pubkey, payer);
+        assert!(metas[1].is_writable && metas[1].is_signer);
+        // 2: new_holding (writable, not signer)
+        assert_eq!(metas[2].pubkey, holding_pda);
+        assert!(metas[2].is_writable && !metas[2].is_signer);
+        // 3: mint (readonly, not signer)
+        assert_eq!(metas[3].pubkey, mint);
+        assert!(!metas[3].is_writable && !metas[3].is_signer);
+        // 4: spl token program (readonly, not signer)
+        assert_eq!(metas[4].pubkey, spl_token_interface::ID);
+        assert!(!metas[4].is_writable && !metas[4].is_signer);
+        // 5: system program (readonly, not signer)
+        assert_eq!(metas[5].pubkey, solana_sdk::system_program::ID);
+        assert!(!metas[5].is_writable && !metas[5].is_signer);
+    }
+
+    #[test]
+    fn claim_validator_client_rewards_metas_order_empty() {
+        let manager = Pubkey::new_unique();
+        let destination = Pubkey::new_unique();
+        let rent_beneficiary = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let client_id: u16 = 11;
+        let accounts = ClaimValidatorClientRewardsAccounts::new(
+            client_id,
+            &manager,
+            &destination,
+            &rent_beneficiary,
+            &mint,
+            &[],
+        );
+        let vcr = state::find_validator_client_rewards_address(client_id).0;
+        let cfg = state::find_program_config_address().0;
+        assert_eq!(accounts.program_config_key, cfg);
+        assert_eq!(accounts.validator_client_rewards_key, vcr);
+        assert_eq!(accounts.manager_key, manager);
+        assert_eq!(accounts.destination_token_account_key, destination);
+        assert_eq!(accounts.rent_beneficiary_key, rent_beneficiary);
+        assert!(accounts.claim_holding_account_keys.is_empty());
+
+        let metas: Vec<AccountMeta> = accounts.into();
+        assert_eq!(metas.len(), 6);
+        // 0: program_config (readonly, not signer)
+        assert_eq!(metas[0].pubkey, cfg);
+        assert!(!metas[0].is_writable && !metas[0].is_signer);
+        // 1: VCR (writable, not signer)
+        assert_eq!(metas[1].pubkey, vcr);
+        assert!(metas[1].is_writable && !metas[1].is_signer);
+        // 2: manager (readonly, SIGNER)
+        assert_eq!(metas[2].pubkey, manager);
+        assert!(!metas[2].is_writable && metas[2].is_signer);
+        // 3: destination (writable, not signer)
+        assert_eq!(metas[3].pubkey, destination);
+        assert!(metas[3].is_writable && !metas[3].is_signer);
+        // 4: rent_beneficiary (writable, not signer)
+        assert_eq!(metas[4].pubkey, rent_beneficiary);
+        assert!(metas[4].is_writable && !metas[4].is_signer);
+        // 5: spl token program (readonly, not signer)
+        assert_eq!(metas[5].pubkey, spl_token_interface::ID);
+        assert!(!metas[5].is_writable && !metas[5].is_signer);
+    }
+
+    #[test]
+    fn claim_validator_client_rewards_metas_with_three_holdings() {
+        let manager = Pubkey::new_unique();
+        let destination = Pubkey::new_unique();
+        let rent_beneficiary = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let client_id: u16 = 11;
+        let epochs: &[u64] = &[100, 101, 102];
+        let accounts = ClaimValidatorClientRewardsAccounts::new(
+            client_id,
+            &manager,
+            &destination,
+            &rent_beneficiary,
+            &mint,
+            epochs,
+        );
+        let vcr = state::find_validator_client_rewards_address(client_id).0;
+        let expected_holdings: Vec<Pubkey> = epochs
+            .iter()
+            .map(|e| state::find_claim_holding_address(&vcr, *e, &mint).0)
+            .collect();
+        assert_eq!(accounts.claim_holding_account_keys, expected_holdings);
+
+        let metas: Vec<AccountMeta> = accounts.into();
+        assert_eq!(metas.len(), 6 + 3);
+        for (i, expected_holding) in expected_holdings.iter().enumerate() {
+            let meta = &metas[6 + i];
+            assert_eq!(meta.pubkey, *expected_holding);
+            assert!(meta.is_writable && !meta.is_signer);
+        }
+    }
+}

--- a/crates/solana-sdk/src/shred_subscription/instruction/mod.rs
+++ b/crates/solana-sdk/src/shred_subscription/instruction/mod.rs
@@ -5,6 +5,15 @@ use std::io;
 use borsh::{BorshDeserialize, BorshSerialize};
 use doublezero_program_tools::{DISCRIMINATOR_LEN, Discriminator};
 
+/// Identifier for a single claim holding account, used as a payload element
+/// in `ClaimValidatorClientRewards`. Mirrors the on-chain struct byte for
+/// byte: `subscription_epoch: u64` followed by `bump_seed: u8`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct ClaimHoldingId {
+    pub subscription_epoch: u64,
+    pub bump_seed: u8,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ShredSubscriptionInstructionData {
     /// Initialize a client seat for a (device, client_ip) pair.
@@ -25,6 +34,14 @@ pub enum ShredSubscriptionInstructionData {
     RequestProratedInstantSeatWithdrawal,
     /// Set the rewards proportion for a validator client.
     SetValidatorClientRewardsProportion(u16),
+    /// Permissionless. Initialize a non-ATA claim holding token account
+    /// owned by the `ValidatorClientRewards` parent PDA for
+    /// `(subscription_epoch, mint)`. Payload is the subscription epoch.
+    InitializeClaimHoldingAccount(u64),
+    /// `ValidatorClientRewards.manager_key`-signed. Drain N claim holdings
+    /// into a destination token account and close each, recovering rent to
+    /// `program_config.shred_oracle_key`.
+    ClaimValidatorClientRewards(Vec<ClaimHoldingId>),
     /// Validates the provided CLI version against the onchain minimum.
     CheckCliVersion { major: u32, minor: u32, patch: u32 },
 }
@@ -46,6 +63,10 @@ impl ShredSubscriptionInstructionData {
         Discriminator::new_sha2(b"dz::ix::request_prorated_instant_seat_withdrawal");
     pub const SET_VALIDATOR_CLIENT_REWARDS_PROPORTION: Discriminator<DISCRIMINATOR_LEN> =
         Discriminator::new_sha2(b"dz::ix::set_validator_client_rewards_proportion");
+    pub const INITIALIZE_CLAIM_HOLDING_ACCOUNT: Discriminator<DISCRIMINATOR_LEN> =
+        Discriminator::new_sha2(b"dz::ix::initialize_claim_holding_account");
+    pub const CLAIM_VALIDATOR_CLIENT_REWARDS: Discriminator<DISCRIMINATOR_LEN> =
+        Discriminator::new_sha2(b"dz::ix::claim_validator_client_rewards");
     pub const CHECK_CLI_VERSION: Discriminator<DISCRIMINATOR_LEN> =
         Discriminator::new_sha2(b"dz::ix::check_cli_version");
 }
@@ -75,6 +96,14 @@ impl BorshSerialize for ShredSubscriptionInstructionData {
             Self::SetValidatorClientRewardsProportion(proportion) => {
                 Self::SET_VALIDATOR_CLIENT_REWARDS_PROPORTION.serialize(writer)?;
                 proportion.serialize(writer)
+            }
+            Self::InitializeClaimHoldingAccount(subscription_epoch) => {
+                Self::INITIALIZE_CLAIM_HOLDING_ACCOUNT.serialize(writer)?;
+                subscription_epoch.serialize(writer)
+            }
+            Self::ClaimValidatorClientRewards(holdings) => {
+                Self::CLAIM_VALIDATOR_CLIENT_REWARDS.serialize(writer)?;
+                holdings.serialize(writer)
             }
             Self::CheckCliVersion {
                 major,
@@ -112,6 +141,14 @@ impl BorshDeserialize for ShredSubscriptionInstructionData {
                 let proportion = u16::deserialize_reader(reader)?;
                 Ok(Self::SetValidatorClientRewardsProportion(proportion))
             }
+            Self::INITIALIZE_CLAIM_HOLDING_ACCOUNT => {
+                let subscription_epoch = u64::deserialize_reader(reader)?;
+                Ok(Self::InitializeClaimHoldingAccount(subscription_epoch))
+            }
+            Self::CLAIM_VALIDATOR_CLIENT_REWARDS => {
+                let holdings = Vec::<ClaimHoldingId>::deserialize_reader(reader)?;
+                Ok(Self::ClaimValidatorClientRewards(holdings))
+            }
             Self::CHECK_CLI_VERSION => {
                 let major = u32::deserialize_reader(reader)?;
                 let minor = u32::deserialize_reader(reader)?;
@@ -127,5 +164,100 @@ impl BorshDeserialize for ShredSubscriptionInstructionData {
                 "Invalid discriminator",
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claim_holding_id_round_trip() {
+        let id = ClaimHoldingId {
+            subscription_epoch: 0x1122_3344_5566_7788,
+            bump_seed: 0xAB,
+        };
+        let bytes = borsh::to_vec(&id).unwrap();
+        assert_eq!(bytes.len(), 9);
+        let decoded: ClaimHoldingId = borsh::from_slice(&bytes).unwrap();
+        assert_eq!(decoded, id);
+    }
+
+    #[test]
+    fn claim_holding_id_frozen_bytes() {
+        let id = ClaimHoldingId {
+            subscription_epoch: 0x0807_0605_0403_0201,
+            bump_seed: 0xFF,
+        };
+        let bytes = borsh::to_vec(&id).unwrap();
+        assert_eq!(
+            bytes,
+            vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0xFF]
+        );
+    }
+
+    #[test]
+    fn round_trip_initialize_claim_holding_account() {
+        let ix =
+            ShredSubscriptionInstructionData::InitializeClaimHoldingAccount(0xDEAD_BEEF_CAFE_BABE);
+        let bytes = borsh::to_vec(&ix).unwrap();
+        let decoded = ShredSubscriptionInstructionData::try_from_slice(&bytes).unwrap();
+        assert_eq!(decoded, ix);
+    }
+
+    #[test]
+    fn round_trip_claim_validator_client_rewards_empty() {
+        let ix = ShredSubscriptionInstructionData::ClaimValidatorClientRewards(vec![]);
+        let bytes = borsh::to_vec(&ix).unwrap();
+        let decoded = ShredSubscriptionInstructionData::try_from_slice(&bytes).unwrap();
+        assert_eq!(decoded, ix);
+    }
+
+    #[test]
+    fn round_trip_claim_validator_client_rewards_multiple() {
+        let ix = ShredSubscriptionInstructionData::ClaimValidatorClientRewards(vec![
+            ClaimHoldingId {
+                subscription_epoch: 100,
+                bump_seed: 254,
+            },
+            ClaimHoldingId {
+                subscription_epoch: 101,
+                bump_seed: 253,
+            },
+            ClaimHoldingId {
+                subscription_epoch: 102,
+                bump_seed: 252,
+            },
+        ]);
+        let bytes = borsh::to_vec(&ix).unwrap();
+        let decoded = ShredSubscriptionInstructionData::try_from_slice(&bytes).unwrap();
+        assert_eq!(decoded, ix);
+    }
+
+    #[test]
+    fn frozen_bytes_initialize_claim_holding_account() {
+        let ix = ShredSubscriptionInstructionData::InitializeClaimHoldingAccount(0x01);
+        let mut expected =
+            borsh::to_vec(&ShredSubscriptionInstructionData::INITIALIZE_CLAIM_HOLDING_ACCOUNT)
+                .expect("discriminator serialization");
+        expected.extend_from_slice(&1u64.to_le_bytes());
+        assert_eq!(borsh::to_vec(&ix).unwrap(), expected);
+    }
+
+    #[test]
+    fn frozen_bytes_claim_validator_client_rewards_one_entry() {
+        let ix =
+            ShredSubscriptionInstructionData::ClaimValidatorClientRewards(vec![ClaimHoldingId {
+                subscription_epoch: 7,
+                bump_seed: 250,
+            }]);
+        let mut expected =
+            borsh::to_vec(&ShredSubscriptionInstructionData::CLAIM_VALIDATOR_CLIENT_REWARDS)
+                .expect("discriminator serialization");
+        // Borsh vec length prefix is u32 LE.
+        expected.extend_from_slice(&1u32.to_le_bytes());
+        expected.extend_from_slice(&7u64.to_le_bytes());
+        expected.push(250);
+        assert_eq!(borsh::to_vec(&ix).unwrap(), expected);
     }
 }

--- a/crates/solana-sdk/src/shred_subscription/state.rs
+++ b/crates/solana-sdk/src/shred_subscription/state.rs
@@ -556,10 +556,16 @@ pub const VALIDATOR_CLIENT_REWARDS_DISCRIMINATOR: Discriminator<DISCRIMINATOR_LE
     Discriminator::new_sha2(b"dz::account::validator_client_rewards");
 
 pub const VCR_CLIENT_ID_OFFSET: usize = DISCRIMINATOR_LEN;
+pub const VCR_BUMP_SEED_OFFSET: usize = DISCRIMINATOR_LEN + 2;
 pub const VCR_MANAGER_KEY_OFFSET: usize = DISCRIMINATOR_LEN + 8;
 pub const VCR_SHORT_DESCRIPTION_OFFSET: usize = DISCRIMINATOR_LEN + 40;
 pub const VCR_CLAIM_HOLDING_COUNT_OFFSET: usize = DISCRIMINATOR_LEN + 104;
 pub const VCR_SHORT_DESCRIPTION_LEN: usize = 64;
+/// Total on-chain size of a `ValidatorClientRewards` account, including the
+/// 8-byte discriminator. Mirrors the program's
+/// `assert!(zero_copy::data_end::<ValidatorClientRewards>() == 184)`.
+/// Update both sides together if the on-chain layout changes.
+pub const VCR_ACCOUNT_DATA_LEN: usize = 184;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidatorClientRewardsInfo {

--- a/crates/solana-sdk/src/shred_subscription/state.rs
+++ b/crates/solana-sdk/src/shred_subscription/state.rs
@@ -14,6 +14,7 @@ pub const VALIDATOR_CLIENT_REWARDS_SEED_PREFIX: &[u8] = b"validator_client_rewar
 pub const INSTANT_ALLOCATION_REQUEST_SEED_PREFIX: &[u8] = b"instant_seat_allocation_request";
 pub const WITHDRAW_SEAT_REQUEST_SEED_PREFIX: &[u8] = b"withdraw_seat_request";
 pub const SHRED_DISTRIBUTION_SEED_PREFIX: &[u8] = b"shred_distribution";
+pub const CLAIM_HOLDING_SEED_PREFIX: &[u8] = b"claim";
 
 pub fn find_program_config_address() -> (Pubkey, u8) {
     Pubkey::find_program_address(
@@ -120,6 +121,22 @@ pub fn find_shred_distribution_address(subscription_epoch: u64) -> (Pubkey, u8) 
     )
 }
 
+pub fn find_claim_holding_address(
+    parent_pda_key: &Pubkey,
+    subscription_epoch: u64,
+    mint_key: &Pubkey,
+) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[
+            CLAIM_HOLDING_SEED_PREFIX,
+            parent_pda_key.as_ref(),
+            &subscription_epoch.to_le_bytes(),
+            mint_key.as_ref(),
+        ],
+        &crate::shred_subscription::ID,
+    )
+}
+
 // ---------------------------------------------------------------------------
 // ProgramConfig raw-byte parsing.
 //
@@ -134,6 +151,7 @@ pub const PROGRAM_CONFIG_DISCRIMINATOR: Discriminator<DISCRIMINATOR_LEN> =
     Discriminator::new_sha2(b"dz::account::program_config");
 
 pub const PROGRAM_CONFIG_FLAGS_OFFSET: usize = DISCRIMINATOR_LEN;
+pub const PROGRAM_CONFIG_SHRED_ORACLE_KEY_OFFSET: usize = DISCRIMINATOR_LEN + 48;
 
 const PROGRAM_CONFIG_FLAG_IS_PRORATED_SERVICE_ENABLED_BIT: u64 = 1 << 2;
 
@@ -152,6 +170,24 @@ pub fn is_prorated_service_enabled(data: &[u8]) -> bool {
     };
     let flags = u64::from_le_bytes(flags_bytes);
     flags & PROGRAM_CONFIG_FLAG_IS_PRORATED_SERVICE_ENABLED_BIT != 0
+}
+
+/// Parse the `shred_oracle_key` from a `ProgramConfig` account. Returns
+/// `None` when the data is too short or the discriminator does not match.
+pub fn parse_program_config_shred_oracle_key(data: &[u8]) -> Option<Pubkey> {
+    if data.len() < PROGRAM_CONFIG_SHRED_ORACLE_KEY_OFFSET + 32 {
+        return None;
+    }
+    let expected_disc =
+        borsh::to_vec(&PROGRAM_CONFIG_DISCRIMINATOR).expect("discriminator serialization");
+    if data[..DISCRIMINATOR_LEN] != expected_disc[..] {
+        return None;
+    }
+    Some(Pubkey::new_from_array(
+        data[PROGRAM_CONFIG_SHRED_ORACLE_KEY_OFFSET..PROGRAM_CONFIG_SHRED_ORACLE_KEY_OFFSET + 32]
+            .try_into()
+            .ok()?,
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -502,6 +538,79 @@ pub fn parse_metro_history(data: &[u8]) -> Option<MetroHistoryInfo> {
     })
 }
 
+// ---------------------------------------------------------------------------
+// ValidatorClientRewards raw-byte parsing.
+//
+// Layout (Pod with 8-byte discriminator prefix):
+//   [0..8)     discriminator
+//   [8..10)    client_id: u16
+//   [10..11)   bump_seed: u8
+//   [11..16)   _padding_0: [u8; 5]
+//   [16..48)   manager_key: Pubkey
+//   [48..112)  short_description_bytes: [u8; 64]
+//   [112..116) claim_holding_count: u32
+//   ...        remaining fields (padding + StorageGap) unused by the CLI
+// ---------------------------------------------------------------------------
+
+pub const VALIDATOR_CLIENT_REWARDS_DISCRIMINATOR: Discriminator<DISCRIMINATOR_LEN> =
+    Discriminator::new_sha2(b"dz::account::validator_client_rewards");
+
+pub const VCR_CLIENT_ID_OFFSET: usize = DISCRIMINATOR_LEN;
+pub const VCR_MANAGER_KEY_OFFSET: usize = DISCRIMINATOR_LEN + 8;
+pub const VCR_SHORT_DESCRIPTION_OFFSET: usize = DISCRIMINATOR_LEN + 40;
+pub const VCR_CLAIM_HOLDING_COUNT_OFFSET: usize = DISCRIMINATOR_LEN + 104;
+pub const VCR_SHORT_DESCRIPTION_LEN: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidatorClientRewardsInfo {
+    pub client_id: u16,
+    pub manager_key: Pubkey,
+    pub short_description: Option<String>,
+    pub claim_holding_count: u32,
+}
+
+/// Parse a `ValidatorClientRewards` from raw account data. Returns `None`
+/// when the data is too short or the discriminator does not match.
+pub fn parse_validator_client_rewards(data: &[u8]) -> Option<ValidatorClientRewardsInfo> {
+    if data.len() < VCR_CLAIM_HOLDING_COUNT_OFFSET + 4 {
+        return None;
+    }
+    let expected_disc = borsh::to_vec(&VALIDATOR_CLIENT_REWARDS_DISCRIMINATOR)
+        .expect("discriminator serialization");
+    if data[..DISCRIMINATOR_LEN] != expected_disc[..] {
+        return None;
+    }
+    let client_id = u16::from_le_bytes(
+        data[VCR_CLIENT_ID_OFFSET..VCR_CLIENT_ID_OFFSET + 2]
+            .try_into()
+            .ok()?,
+    );
+    let manager_key = Pubkey::new_from_array(
+        data[VCR_MANAGER_KEY_OFFSET..VCR_MANAGER_KEY_OFFSET + 32]
+            .try_into()
+            .ok()?,
+    );
+    let short_description_bytes = &data
+        [VCR_SHORT_DESCRIPTION_OFFSET..VCR_SHORT_DESCRIPTION_OFFSET + VCR_SHORT_DESCRIPTION_LEN];
+    let short_description = match short_description_bytes.iter().rposition(|&b| b != 0) {
+        Some(end) => std::str::from_utf8(&short_description_bytes[..=end])
+            .ok()
+            .map(str::to_string),
+        None => None,
+    };
+    let claim_holding_count = u32::from_le_bytes(
+        data[VCR_CLAIM_HOLDING_COUNT_OFFSET..VCR_CLAIM_HOLDING_COUNT_OFFSET + 4]
+            .try_into()
+            .ok()?,
+    );
+    Some(ValidatorClientRewardsInfo {
+        client_id,
+        manager_key,
+        short_description,
+        claim_holding_count,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -569,5 +678,104 @@ mod tests {
     fn last_usdc_price_short_buffer_returns_none() {
         let data = vec![0u8; CLIENT_SEAT_LAST_USDC_PRICE_OFFSET];
         assert_eq!(parse_client_seat_last_usdc_price_dollars(&data), None);
+    }
+
+    #[test]
+    fn find_claim_holding_address_matches_seed() {
+        use solana_sdk::pubkey::Pubkey;
+        let parent = Pubkey::new_from_array([7u8; 32]);
+        let mint = Pubkey::new_from_array([3u8; 32]);
+        let epoch: u64 = 42;
+        let (addr, bump) = find_claim_holding_address(&parent, epoch, &mint);
+        let (expected_addr, expected_bump) = Pubkey::find_program_address(
+            &[
+                CLAIM_HOLDING_SEED_PREFIX,
+                parent.as_ref(),
+                &epoch.to_le_bytes(),
+                mint.as_ref(),
+            ],
+            &crate::shred_subscription::ID,
+        );
+        assert_eq!(addr, expected_addr);
+        assert_eq!(bump, expected_bump);
+    }
+
+    fn vcr_data(client_id: u16, manager: Pubkey, desc: &[u8], count: u32) -> Vec<u8> {
+        let mut data = vec![0u8; VCR_CLAIM_HOLDING_COUNT_OFFSET + 4];
+        let disc_bytes = borsh::to_vec(&VALIDATOR_CLIENT_REWARDS_DISCRIMINATOR)
+            .expect("discriminator serialization");
+        data[..DISCRIMINATOR_LEN].copy_from_slice(&disc_bytes);
+        data[VCR_CLIENT_ID_OFFSET..VCR_CLIENT_ID_OFFSET + 2]
+            .copy_from_slice(&client_id.to_le_bytes());
+        data[VCR_MANAGER_KEY_OFFSET..VCR_MANAGER_KEY_OFFSET + 32].copy_from_slice(manager.as_ref());
+        let desc_end = VCR_SHORT_DESCRIPTION_OFFSET + desc.len();
+        data[VCR_SHORT_DESCRIPTION_OFFSET..desc_end].copy_from_slice(desc);
+        data[VCR_CLAIM_HOLDING_COUNT_OFFSET..VCR_CLAIM_HOLDING_COUNT_OFFSET + 4]
+            .copy_from_slice(&count.to_le_bytes());
+        data
+    }
+
+    #[test]
+    fn parse_validator_client_rewards_happy_path() {
+        use solana_sdk::pubkey::Pubkey;
+        let manager = Pubkey::new_from_array([11u8; 32]);
+        let data = vcr_data(42, manager, b"acme", 3);
+        let info = parse_validator_client_rewards(&data).expect("parse");
+        assert_eq!(info.client_id, 42);
+        assert_eq!(info.manager_key, manager);
+        assert_eq!(info.short_description.as_deref(), Some("acme"));
+        assert_eq!(info.claim_holding_count, 3);
+    }
+
+    #[test]
+    fn parse_validator_client_rewards_empty_description_returns_none_description() {
+        use solana_sdk::pubkey::Pubkey;
+        let data = vcr_data(0, Pubkey::default(), b"", 0);
+        let info = parse_validator_client_rewards(&data).expect("parse");
+        assert!(info.short_description.is_none());
+    }
+
+    #[test]
+    fn parse_validator_client_rewards_short_buffer_returns_none() {
+        let data = vec![0u8; VCR_CLAIM_HOLDING_COUNT_OFFSET + 3];
+        assert!(parse_validator_client_rewards(&data).is_none());
+    }
+
+    #[test]
+    fn parse_validator_client_rewards_wrong_discriminator_returns_none() {
+        use solana_sdk::pubkey::Pubkey;
+        let mut data = vcr_data(1, Pubkey::default(), b"x", 0);
+        data[0] ^= 0xff;
+        assert!(parse_validator_client_rewards(&data).is_none());
+    }
+
+    #[test]
+    fn parse_program_config_shred_oracle_key_happy_path() {
+        use solana_sdk::pubkey::Pubkey;
+        let oracle = Pubkey::new_from_array([5u8; 32]);
+        let mut data = vec![0u8; PROGRAM_CONFIG_SHRED_ORACLE_KEY_OFFSET + 32];
+        let disc_bytes =
+            borsh::to_vec(&PROGRAM_CONFIG_DISCRIMINATOR).expect("discriminator serialization");
+        data[..DISCRIMINATOR_LEN].copy_from_slice(&disc_bytes);
+        data[PROGRAM_CONFIG_SHRED_ORACLE_KEY_OFFSET..PROGRAM_CONFIG_SHRED_ORACLE_KEY_OFFSET + 32]
+            .copy_from_slice(oracle.as_ref());
+        assert_eq!(parse_program_config_shred_oracle_key(&data), Some(oracle));
+    }
+
+    #[test]
+    fn parse_program_config_shred_oracle_key_short_buffer_returns_none() {
+        let data = vec![0u8; PROGRAM_CONFIG_SHRED_ORACLE_KEY_OFFSET + 31];
+        assert_eq!(parse_program_config_shred_oracle_key(&data), None);
+    }
+
+    #[test]
+    fn parse_program_config_shred_oracle_key_wrong_discriminator_returns_none() {
+        use solana_sdk::pubkey::Pubkey;
+        let oracle = Pubkey::new_from_array([5u8; 32]);
+        let mut data = vec![0u8; PROGRAM_CONFIG_SHRED_ORACLE_KEY_OFFSET + 32];
+        data[0] = 0x01;
+        data[PROGRAM_CONFIG_SHRED_ORACLE_KEY_OFFSET..PROGRAM_CONFIG_SHRED_ORACLE_KEY_OFFSET + 32]
+            .copy_from_slice(oracle.as_ref());
+        assert_eq!(parse_program_config_shred_oracle_key(&data), None);
     }
 }

--- a/sh/test_doublezero_solana_fork.sh
+++ b/sh/test_doublezero_solana_fork.sh
@@ -213,12 +213,100 @@ $CLI_BIN revenue-distribution validator-deposit \
     --node-id $DUMMY_KEY
 echo
 
+### Validator-client claim commands.
+# Skipped when manager_keypair.json is not present. To exercise this block,
+# generate the keypair BEFORE starting the fork loader and pass its pubkey:
+#
+#   solana-keygen new --silent --no-bip39-passphrase -o manager_keypair.json
+#   cargo run --bin doublezero-solana-fork -- -um --reset \
+#       --synthetic-vcr-manager $(solana address -k manager_keypair.json)
+#   bash sh/test_doublezero_solana_fork.sh
+#
+# The fork loader bakes a synthetic ValidatorClientRewards PDA at
+# `client_id=65535` with the keypair's pubkey as the manager_key.
+#
+# Note: in v1, the on-chain `InitializeClaimHoldingAccount` handler
+# constrains the mint to the 2Z mint. We can't `mint-to` 2Z (no
+# authority on mainnet), so the holding stays at balance=0; claim still
+# exercises the full ix path and closes the holding, recovering rent.
+
+# Mainnet 2Z mint, hard-coded because the fork is `-um` mainnet.
+DOUBLEZERO_MINT=J6pQQ3FAcJQeWPPGppWRb4nM8jU3wLyYbRrLh7feMfvd
+MANAGER_KEY_PATH=manager_keypair.json
+if [ -f "$MANAGER_KEY_PATH" ]; then
+    CLIENT_ID=65535
+    MANAGER_PUBKEY=$(solana address -k $MANAGER_KEY_PATH)
+    TEST_EPOCH=100
+
+    echo "solana airdrop -ul 1 -k $MANAGER_KEY_PATH"
+    solana airdrop -ul 1 -k $MANAGER_KEY_PATH
+    echo
+
+    echo "solana-keygen new --silent --no-bip39-passphrase -o claim_payer.json"
+    solana-keygen new --silent --no-bip39-passphrase -o claim_payer.json
+    solana airdrop -ul 10 -k claim_payer.json
+    echo
+
+    echo "spl-token create-account -ul $DOUBLEZERO_MINT --owner $MANAGER_PUBKEY --fee-payer claim_payer.json"
+    spl-token create-account \
+        -ul \
+        $DOUBLEZERO_MINT \
+        --owner $MANAGER_PUBKEY \
+        --fee-payer claim_payer.json
+    echo
+
+    echo "doublezero-solana shreds validator-client-rewards show --client-id $CLIENT_ID -ul"
+    $CLI_BIN shreds validator-client-rewards show --client-id $CLIENT_ID -ul
+    echo
+
+    echo "doublezero-solana shreds validator-client-rewards init-holding -ul --client-id $CLIENT_ID --rewards-token-mint $DOUBLEZERO_MINT --subscription-epoch $TEST_EPOCH -k claim_payer.json"
+    $CLI_BIN shreds validator-client-rewards init-holding \
+        -ul \
+        --client-id $CLIENT_ID \
+        --rewards-token-mint $DOUBLEZERO_MINT \
+        --subscription-epoch $TEST_EPOCH \
+        -k claim_payer.json
+    echo
+
+    echo "doublezero-solana shreds validator-client-rewards show -ul --client-id $CLIENT_ID --rewards-token-mint $DOUBLEZERO_MINT --subscription-epoch $TEST_EPOCH"
+    $CLI_BIN shreds validator-client-rewards show \
+        -ul \
+        --client-id $CLIENT_ID \
+        --rewards-token-mint $DOUBLEZERO_MINT \
+        --subscription-epoch $TEST_EPOCH
+    echo
+
+    echo "doublezero-solana shreds validator-client-rewards claim -ul --client-id $CLIENT_ID --rewards-token-mint $DOUBLEZERO_MINT --subscription-epoch $TEST_EPOCH -k $MANAGER_KEY_PATH"
+    $CLI_BIN shreds validator-client-rewards claim \
+        -ul \
+        --client-id $CLIENT_ID \
+        --rewards-token-mint $DOUBLEZERO_MINT \
+        --subscription-epoch $TEST_EPOCH \
+        -k $MANAGER_KEY_PATH
+    echo
+
+    echo "doublezero-solana shreds validator-client-rewards show -ul --client-id $CLIENT_ID --rewards-token-mint $DOUBLEZERO_MINT --subscription-epoch $TEST_EPOCH"
+    $CLI_BIN shreds validator-client-rewards show \
+        -ul \
+        --client-id $CLIENT_ID \
+        --rewards-token-mint $DOUBLEZERO_MINT \
+        --subscription-epoch $TEST_EPOCH
+    echo
+else
+    echo "Skipping validator-client claim commands: $MANAGER_KEY_PATH not found."
+    echo "To exercise this block, generate the keypair before starting the fork loader:"
+    echo "  solana-keygen new --silent --no-bip39-passphrase -o $MANAGER_KEY_PATH"
+    echo "  cargo run --bin doublezero-solana-fork -- -um --reset --synthetic-vcr-manager \$(solana address -k $MANAGER_KEY_PATH)"
+    echo
+fi
+
 ### Clean up.
 
 echo "rm dummy.json another_payer.json rewards_manager.json " \
-     "service_key_1.json service_key_1.json validator_node_id.json"
+     "service_key_1.json validator_node_id.json claim_payer.json"
 rm \
     dummy.json \
     another_payer.json \
     rewards_manager.json \
     service_key_1.json
+rm -f claim_payer.json


### PR DESCRIPTION
## Summary of Changes
This PR adds in commands for validators to claim their rewards for publishing shreds in an approved currency. 

Gist outlining new [commands](https://gist.github.com/bgm-malbeclabs/28f0e9a73494c974c5fd85dcfce854a4)

## Testing Verification
* Unit tests have been added to exercise new commands
* Solana local fork has been updated to exercise new commands as well
