### PR TITLE
feat(contributor-rewards): add configurable public latency multiplier

### DIFF
--- a/crates/contributor-rewards/CHANGELOG.md
+++ b/crates/contributor-rewards/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+feat(contributor-rewards): add configurable public latency multiplier
+
+## [0.5.4](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/contributor-rewards%2Fv0.5.4) - 2026-05-18
+
 - fix(contributor-rewards) distribution summary reporting ([#366](https://github.com/doublezerofoundation/doublezero-offchain/pull/366))
 
 ## [0.5.3](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/contributor-rewards%2Fv0.5.3) - 2026-05-07

--- a/crates/contributor-rewards/README.md
+++ b/crates/contributor-rewards/README.md
@@ -100,6 +100,12 @@ contiguity_bonus = 5.0
 # Increases rewards in high-demand areas
 demand_multiplier = 1.2
 
+# ========== Shapley Input Parameters ==========
+[input]
+# Multiplier applied to public internet latency inputs.
+# 1.25 inflates single-packet public latency measurements by 25%.
+public_latency_multiplier = 1.25
+
 # ========== Demand Generation Parameters ==========
 [demand]
 # Traffic per receiver in Gbps, used for both IBRL and shred demands
@@ -107,7 +113,7 @@ traffic = 0.15
 
 # Priority for IBRL validator-to-validator demands
 # Shred demand priority remains derived from metro price
-priority = 0.0
+priority = 20.0
 
 # Demand kind/type values written into Shapley demand rows
 kind = 1

--- a/crates/contributor-rewards/example.config.toml
+++ b/crates/contributor-rewards/example.config.toml
@@ -49,6 +49,14 @@ contiguity_bonus = 5.0
 # Increases rewards in high-demand areas
 demand_multiplier = 1.2
 
+# ========== Shapley Input Parameters ==========
+# All fields can be overridden via environment variables:
+#   DZ__INPUT__PUBLIC_LATENCY_MULTIPLIER
+[input]
+# Multiplier applied to public internet latency inputs.
+# 1.25 inflates single-packet public latency measurements by 25%.
+public_latency_multiplier = 1.25
+
 # ========== Demand Generation Parameters ==========
 # All fields can be overridden via environment variables:
 #   DZ__DEMAND__TRAFFIC
@@ -63,7 +71,7 @@ traffic = 0.15
 
 # Priority for IBRL validator-to-validator demands
 # Shred demand priority remains derived from metro price
-priority = 0.0
+priority = 20.0
 
 # Demand kind/type values written into Shapley demand rows
 kind = 1

--- a/crates/contributor-rewards/src/calculator/shapley/handler.rs
+++ b/crates/contributor-rewards/src/calculator/shapley/handler.rs
@@ -339,6 +339,17 @@ pub fn build_public_links(
     // Sort by city pairs for consistent output
     public_links.sort_by(|a, b| (&a.city1, &a.city2).cmp(&(&b.city1, &b.city2)));
 
+    let public_latency_multiplier = settings.input.public_latency_multiplier;
+    if (public_latency_multiplier - 1.0).abs() > f64::EPSILON {
+        info!(
+            "Applying public latency multiplier: {}",
+            public_latency_multiplier
+        );
+        for link in &mut public_links {
+            link.latency *= public_latency_multiplier;
+        }
+    }
+
     Ok(public_links)
 }
 

--- a/crates/contributor-rewards/src/ingestor/demand.rs
+++ b/crates/contributor-rewards/src/ingestor/demand.rs
@@ -296,7 +296,7 @@ pub fn generate(city_stats: &CityStats, demand_settings: &DemandSettings) -> Dem
         .filter(|(_, stats)| stats.subscriber_count > 0 && stats.city_price > 0)
         .collect();
 
-    // Generate IBRL demands (validator-to-validator, priority = 0)
+    // Generate IBRL demands (validator-to-validator, priority = demand_settings.priority)
     let ibrl_demands: Vec<Demand> = cities_with_validators
         .par_iter()
         .flat_map(|(start_city, _start_stats)| {

--- a/crates/contributor-rewards/src/settings/mod.rs
+++ b/crates/contributor-rewards/src/settings/mod.rs
@@ -24,6 +24,9 @@ pub struct Settings {
     /// Demand generation parameters
     #[serde(default)]
     pub demand: DemandSettings,
+    /// Shapley input preparation parameters
+    #[serde(default)]
+    pub input: InputSettings,
     /// RPC endpoint configuration
     pub rpc: RpcSettings,
     /// Solana program IDs
@@ -86,6 +89,22 @@ impl Default for DemandSettings {
             multicast_enabled: false,
             shred_kind: 2,
             shred_multicast_enabled: true,
+        }
+    }
+}
+
+/// Shapley input preparation parameters
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct InputSettings {
+    /// Multiplier applied to public internet latency inputs
+    pub public_latency_multiplier: f64,
+}
+
+impl Default for InputSettings {
+    fn default() -> Self {
+        Self {
+            public_latency_multiplier: 1.0,
         }
     }
 }
@@ -289,6 +308,7 @@ impl fmt::Display for Settings {
              \tDemand Multicast Enabled: {}\n\
              \tDemand Shred Kind: {}\n\
              \tDemand Shred Multicast Enabled: {}\n\
+             \tInput Public Latency Multiplier: {}\n\
              }}",
             self.network,
             self.log_level,
@@ -305,6 +325,7 @@ impl fmt::Display for Settings {
             self.demand.multicast_enabled,
             self.demand.shred_kind,
             self.demand.shred_multicast_enabled,
+            self.input.public_latency_multiplier,
         )
     }
 }
@@ -324,6 +345,7 @@ mod tests {
         "DZ__DEMAND__SHRED_KIND",
         "DZ__DEMAND__MULTICAST_ENABLED",
         "DZ__DEMAND__SHRED_MULTICAST_ENABLED",
+        "DZ__INPUT__PUBLIC_LATENCY_MULTIPLIER",
     ];
 
     struct DemandEnvCleanup;
@@ -413,6 +435,35 @@ storage_backend = "local-file"
     }
 
     #[test]
+    fn input_settings_default_when_section_missing() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_demand_env();
+        let _cleanup = DemandEnvCleanup;
+        let path = write_config(&base_config(""));
+
+        let settings = Settings::from_path(&path).unwrap();
+
+        assert_eq!(settings.input, InputSettings::default());
+    }
+
+    #[test]
+    fn input_settings_toml_section() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_demand_env();
+        let _cleanup = DemandEnvCleanup;
+        let path = write_config(&base_config(
+            r#"
+[input]
+public_latency_multiplier = 1.25
+"#,
+        ));
+
+        let settings = Settings::from_path(&path).unwrap();
+
+        assert_eq!(settings.input.public_latency_multiplier, 1.25);
+    }
+
+    #[test]
     fn demand_settings_partial_section_uses_defaults() {
         let _guard = ENV_LOCK.lock().unwrap();
         clear_demand_env();
@@ -457,5 +508,25 @@ kind = 3
 
         assert_eq!(settings.demand.priority, 4.25);
         assert_eq!(settings.demand.kind, 9);
+    }
+
+    #[test]
+    fn input_settings_env_overrides_toml() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_demand_env();
+        let _cleanup = DemandEnvCleanup;
+        unsafe {
+            std::env::set_var("DZ__INPUT__PUBLIC_LATENCY_MULTIPLIER", "1.25");
+        }
+        let path = write_config(&base_config(
+            r#"
+[input]
+public_latency_multiplier = 1.0
+"#,
+        ));
+
+        let settings = Settings::from_path(&path).unwrap();
+
+        assert_eq!(settings.input.public_latency_multiplier, 1.25);
     }
 }

--- a/crates/contributor-rewards/src/settings/validation.rs
+++ b/crates/contributor-rewards/src/settings/validation.rs
@@ -51,6 +51,16 @@ pub fn validate_config(settings: &Settings) -> Result<()> {
         bail!("Demand shred_kind must be non-zero");
     }
 
+    // Validate input settings
+    if !settings.input.public_latency_multiplier.is_finite()
+        || settings.input.public_latency_multiplier <= 0.0
+    {
+        bail!(
+            "Input public_latency_multiplier must be finite and positive, got {}",
+            settings.input.public_latency_multiplier
+        );
+    }
+
     // Validate RPC settings
     if settings.rpc.dz_url.is_empty() {
         bail!("DZ RPC URL cannot be empty");
@@ -199,8 +209,8 @@ mod tests {
 
     use super::*;
     use crate::settings::{
-        DemandSettings, InetLookbackSettings, MetricsSettings, PrefixSettings, ProgramSettings,
-        RpcSettings, SchedulerSettings, ShapleySettings, TelemetryDefaultSettings,
+        DemandSettings, InetLookbackSettings, InputSettings, MetricsSettings, PrefixSettings,
+        ProgramSettings, RpcSettings, SchedulerSettings, ShapleySettings, TelemetryDefaultSettings,
         aws::{AwsSettings, StorageBackend},
         network::Network,
     };
@@ -215,6 +225,7 @@ mod tests {
                 demand_multiplier: 1.2,
             },
             demand: DemandSettings::default(),
+            input: InputSettings::default(),
             rpc: RpcSettings {
                 dz_url: "https://api.mainnet-beta.solana.com".to_string(),
                 solana_read_url: "https://api.mainnet-beta.solana.com".to_string(),
@@ -302,6 +313,25 @@ mod tests {
 
         config = create_valid_config();
         config.demand.shred_kind = 0;
+        assert!(validate_config(&config).is_err());
+    }
+
+    #[test]
+    fn test_invalid_input_settings() {
+        let mut config = create_valid_config();
+        config.input.public_latency_multiplier = 0.0;
+        assert!(validate_config(&config).is_err());
+
+        config = create_valid_config();
+        config.input.public_latency_multiplier = -0.1;
+        assert!(validate_config(&config).is_err());
+
+        config = create_valid_config();
+        config.input.public_latency_multiplier = f64::INFINITY;
+        assert!(validate_config(&config).is_err());
+
+        config = create_valid_config();
+        config.input.public_latency_multiplier = f64::NAN;
         assert!(validate_config(&config).is_err());
     }
 

--- a/crates/contributor-rewards/test.config.toml
+++ b/crates/contributor-rewards/test.config.toml
@@ -23,10 +23,14 @@ operator_uptime = 0.98
 contiguity_bonus = 5.0
 demand_multiplier = 1.2
 
+# ========== Shapley Input Parameters ==========
+[input]
+public_latency_multiplier = 1.25
+
 # ========== Demand Generation Parameters ==========
 [demand]
 traffic = 0.15
-priority = 0.0
+priority = 20.0
 kind = 1
 shred_kind = 2
 multicast_enabled = false

--- a/crates/contributor-rewards/tests/common/mod.rs
+++ b/crates/contributor-rewards/tests/common/mod.rs
@@ -15,6 +15,7 @@ pub fn create_test_settings(
             demand_multiplier: 1.2,
         },
         demand: settings::DemandSettings::default(),
+        input: settings::InputSettings::default(),
         rpc: settings::RpcSettings {
             dz_url: "https://test.com".to_string(),
             solana_read_url: "https://test.com".to_string(),

--- a/crates/contributor-rewards/tests/test_pub_links.rs
+++ b/crates/contributor-rewards/tests/test_pub_links.rs
@@ -31,6 +31,7 @@ fn test_settings() -> settings::Settings {
             demand_multiplier: 1.2,
         },
         demand: settings::DemandSettings::default(),
+        input: settings::InputSettings::default(),
         rpc: settings::RpcSettings {
             dz_url: "https://test.com".to_string(),
             solana_read_url: "https://test.com".to_string(),
@@ -231,6 +232,48 @@ mod tests {
                     "Latency mismatch for {city1} -> {city2}: got {actual_latency}, expected {expected_latency}"
                 );
             }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_public_latency_multiplier() -> Result<()> {
+        let fetch_data = load_test_data()?;
+        let internet_stats = InternetTelemetryProcessor::process(&fetch_data)?;
+        let previous_epoch_cache = PreviousEpochCache::new();
+
+        let settings = test_settings();
+        let public_links = build_public_links(
+            &settings,
+            &internet_stats,
+            &fetch_data,
+            &previous_epoch_cache,
+        )?;
+
+        let mut adjusted_settings = test_settings();
+        adjusted_settings.input.public_latency_multiplier = 1.25;
+        let adjusted_public_links = build_public_links(
+            &adjusted_settings,
+            &internet_stats,
+            &fetch_data,
+            &previous_epoch_cache,
+        )?;
+
+        assert_eq!(public_links.len(), adjusted_public_links.len());
+        for (base_link, adjusted_link) in public_links.iter().zip(adjusted_public_links.iter()) {
+            assert_eq!(base_link.city1, adjusted_link.city1);
+            assert_eq!(base_link.city2, adjusted_link.city2);
+            let expected_latency = base_link.latency * 1.25;
+            let diff = (adjusted_link.latency - expected_latency).abs();
+            assert!(
+                diff < f64::EPSILON,
+                "Latency mismatch for {} -> {}: got {}, expected {}",
+                adjusted_link.city1,
+                adjusted_link.city2,
+                adjusted_link.latency,
+                expected_latency
+            );
         }
 
         Ok(())

--- a/crates/contributor-rewards/tests/test_pvt_links.rs
+++ b/crates/contributor-rewards/tests/test_pvt_links.rs
@@ -105,6 +105,7 @@ fn test_settings() -> settings::Settings {
             demand_multiplier: 1.2,
         },
         demand: settings::DemandSettings::default(),
+        input: settings::InputSettings::default(),
         rpc: settings::RpcSettings {
             dz_url: "https://test.com".to_string(),
             solana_read_url: "https://test.com".to_string(),

--- a/crates/contributor-rewards/tests/test_s3_storage.rs
+++ b/crates/contributor-rewards/tests/test_s3_storage.rs
@@ -5,7 +5,7 @@ use doublezero_contributor_rewards::{
     cli::snapshot::{CompleteSnapshot, SnapshotMetadata},
     ingestor::types::FetchData,
     settings::{
-        DemandSettings, Settings,
+        DemandSettings, InputSettings, Settings,
         aws::{AwsSettings, StorageBackend},
         network::Network,
     },
@@ -47,6 +47,7 @@ fn create_test_settings(
             demand_multiplier: 1.2,
         },
         demand: DemandSettings::default(),
+        input: InputSettings::default(),
         rpc: doublezero_contributor_rewards::settings::RpcSettings {
             dz_url: "https://test.com".to_string(),
             solana_read_url: "https://test.com".to_string(),


### PR DESCRIPTION
# Summary

Fix https://github.com/malbeclabs/doublezero/issues/3728

 - Added InputSettings with `public_latency_multiplier` defaulting to 1.0.
 - Applied multiplier in `build_public_links()` so reward calc/export/inspect paths stay consistent.
 - Added validation for finite positive multiplier.
 - Updated config/docs to use:
     - `DZ__INPUT__PUBLIC_LATENCY_MULTIPLIER=1.25`
     - `DZ__DEMAND__PRIORITY=20.0`
 - Added tests for input settings and public latency multiplier.

