### PR TITLE
solana-cli: distribute pending rewards on validator configure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2667,6 +2667,7 @@ dependencies = [
  "doublezero-solana-sdk",
  "doublezero-solana-validator-debt",
  "doublezero_sdk",
+ "futures",
  "humantime",
  "itertools 0.14.0",
  "libc",

--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `shreds publisher-rewards configure`: after the configure tx lands, scan the last 20 subscription epochs and submit `DistributeValidatorRewards` for any unsettled leaf so the validator's pending rewards land in the same operator session. Skipped under dry-run; per-epoch soft-fail so one bad epoch doesn't tank the rest (#375)
+
 ## [0.5.5](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.5)
 
 - uptick crate to v0.5.5 (#372)

--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- `shreds publisher-rewards configure`: after the configure tx lands, scan the last 20 subscription epochs and submit `DistributeValidatorRewards` for any unsettled leaf so the validator's pending rewards land in the same operator session. Skipped under dry-run; per-epoch soft-fail so one bad epoch doesn't tank the rest (#375)
+- `shreds publisher-rewards configure`: after the configure tx lands, scan the last 100 subscription epochs and submit `DistributeValidatorRewards` for any unsettled leaf so the validator's pending rewards land in the same operator session. Skipped under dry-run; per-epoch soft-fail so one bad epoch doesn't tank the rest (#375)
 
 ## [0.5.5](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.5)
 

--- a/crates/solana-cli/Cargo.toml
+++ b/crates/solana-cli/Cargo.toml
@@ -25,6 +25,7 @@ doublezero-solana-client-tools.workspace = true
 doublezero-solana-sdk.workspace = true
 doublezero-solana-validator-debt.workspace = true
 doublezero_sdk.workspace = true
+futures.workspace = true
 humantime.workspace = true
 itertools.workspace = true
 libc.workspace = true

--- a/crates/solana-cli/src/command/shreds/payments.rs
+++ b/crates/solana-cli/src/command/shreds/payments.rs
@@ -227,12 +227,6 @@ impl PaymentsCommand {
                             )
                             | ShredSubscriptionInstructionData::InitializeClaimHolding(_)
                             | ShredSubscriptionInstructionData::ClaimValidatorClientRewards(_)
-                            | ShredSubscriptionInstructionData::InitializeValidatorPublisherRewards(
-                                _,
-                            )
-                            | ShredSubscriptionInstructionData::ConfigureValidatorPublisherRewards {
-                                ..
-                            }
                             | ShredSubscriptionInstructionData::CheckCliVersion { .. },
                         ) => {}
                         Ok(_) => {}

--- a/crates/solana-cli/src/command/shreds/payments.rs
+++ b/crates/solana-cli/src/command/shreds/payments.rs
@@ -227,6 +227,12 @@ impl PaymentsCommand {
                             )
                             | ShredSubscriptionInstructionData::InitializeClaimHolding(_)
                             | ShredSubscriptionInstructionData::ClaimValidatorClientRewards(_)
+                            | ShredSubscriptionInstructionData::InitializeValidatorPublisherRewards(
+                                _,
+                            )
+                            | ShredSubscriptionInstructionData::ConfigureValidatorPublisherRewards {
+                                ..
+                            }
                             | ShredSubscriptionInstructionData::CheckCliVersion { .. },
                         ) => {}
                         Ok(_) => {}

--- a/crates/solana-cli/src/command/shreds/publisher_rewards/configure.rs
+++ b/crates/solana-cli/src/command/shreds/publisher_rewards/configure.rs
@@ -336,10 +336,8 @@ impl ConfigureCommand {
             match distribute_result {
                 Ok(outcome) => {
                     println!(
-                        "\nDistribute pass complete:\n  \
-                         submits: {} succeeded, {} failed\n  \
-                         epochs:  {} still unsettled for this leaf",
-                        outcome.submits_succeeded, outcome.submits_failed, outcome.epochs_unsettled,
+                        "\nDistribute pass complete: {} distributed, {} failed.",
+                        outcome.distributed, outcome.failed,
                     );
                 }
                 Err(error) => {

--- a/crates/solana-cli/src/command/shreds/publisher_rewards/configure.rs
+++ b/crates/solana-cli/src/command/shreds/publisher_rewards/configure.rs
@@ -305,9 +305,31 @@ impl ConfigureCommand {
         let transaction = wallet.new_transaction(&instructions).await?;
 
         let tx_outcome = wallet.send_or_simulate_transaction(&transaction).await?;
+        let configure_executed = matches!(tx_outcome, TransactionOutcome::Executed(_));
         if let TransactionOutcome::Executed(tx_sig) = tx_outcome {
             println!("Configured validator publisher rewards: {tx_sig}");
             wallet.print_verbose_output(&[tx_sig]).await?;
+        }
+
+        // Post-configure: distribute this validator's pending rewards for
+        // any recent subscription epoch where accumulation has completed
+        // but distribute hasn't run for this leaf yet. Skipped under
+        // dry-run (the configure tx never actually wrote the VPR state we
+        // would distribute under).
+        if configure_executed {
+            let network_env = wallet
+                .connection
+                .try_network_environment()
+                .await
+                .context("detecting network environment")?;
+            super::distribute::try_distribute_pending(
+                &wallet,
+                &self.node_id,
+                &self.rewards_token_owner,
+                &rewards_token_mint,
+                network_env,
+            )
+            .await?;
         }
 
         Ok(())

--- a/crates/solana-cli/src/command/shreds/publisher_rewards/configure.rs
+++ b/crates/solana-cli/src/command/shreds/publisher_rewards/configure.rs
@@ -314,22 +314,40 @@ impl ConfigureCommand {
         // Post-configure: distribute this validator's pending rewards for
         // any recent subscription epoch where accumulation has completed
         // but distribute hasn't run for this leaf yet. Skipped under
-        // dry-run (the configure tx never actually wrote the VPR state we
-        // would distribute under).
+        // dry-run (the configure tx never actually wrote the ValidatorPublisherRewards
+        // state we would distribute under).
         if configure_executed {
-            let network_env = wallet
-                .connection
-                .try_network_environment()
+            let distribute_result = async {
+                let network_env = wallet
+                    .connection
+                    .try_network_environment()
+                    .await
+                    .context("detecting network environment")?;
+                super::distribute::try_distribute_pending(
+                    &wallet,
+                    &solana_connection,
+                    &self.node_id,
+                    &self.rewards_token_owner,
+                    network_env,
+                )
                 .await
-                .context("detecting network environment")?;
-            super::distribute::try_distribute_pending(
-                &wallet,
-                &self.node_id,
-                &self.rewards_token_owner,
-                &rewards_token_mint,
-                network_env,
-            )
-            .await?;
+            }
+            .await;
+            match distribute_result {
+                Ok(outcome) => {
+                    println!(
+                        "\nDistribute pass complete:\n  \
+                         submits: {} succeeded, {} failed\n  \
+                         epochs:  {} still unsettled for this leaf",
+                        outcome.submits_succeeded, outcome.submits_failed, outcome.epochs_unsettled,
+                    );
+                }
+                Err(error) => {
+                    eprintln!(
+                        "\nDistribute pass failed (configure already landed; safe to re-run): {error:#}"
+                    );
+                }
+            }
         }
 
         Ok(())

--- a/crates/solana-cli/src/command/shreds/publisher_rewards/distribute.rs
+++ b/crates/solana-cli/src/command/shreds/publisher_rewards/distribute.rs
@@ -22,7 +22,6 @@ use doublezero_solana_client_tools::{
     account::zero_copy::ZeroCopyAccountOwnedData,
     payer::{TransactionOutcome, Wallet},
     rpc::{NetworkEnvironment, SolanaConnection},
-    transaction::try_new_transaction,
 };
 use doublezero_solana_sdk::{
     Pubkey, environment_2z_token_mint_key, environment_usdc_token_mint_key,
@@ -47,10 +46,7 @@ use doublezero_solana_sdk::{
     try_build_instruction,
 };
 use futures::stream::{self, StreamExt};
-use solana_sdk::{
-    compute_budget::ComputeBudgetInstruction, hash::Hash, instruction::Instruction,
-    signature::Keypair, signer::Signer,
-};
+use solana_sdk::{compute_budget::ComputeBudgetInstruction, instruction::Instruction};
 use spl_associated_token_account_interface::{
     address::get_associated_token_address, instruction::create_associated_token_account_idempotent,
 };
@@ -325,7 +321,7 @@ pub async fn try_distribute_pending(
         .await
         .context("fetching claim holding accounts")?;
 
-    // ----- Step 6: pre-fetch destination ATAs + cache the blockhash -----
+    // ----- Step 6: pre-fetch destination ATAs -----
     //
     // Across the entire pass there are at most three distinct
     // destination ATAs (one per candidate reward mint:
@@ -335,12 +331,6 @@ pub async fn try_distribute_pending(
     // the destination is actually missing — saves ~25k CU per tx that
     // would otherwise pay the SPL Token existence check on a no-op
     // create. The set is mutated as freshly-created ATAs land.
-    //
-    // The blockhash is also cached once. `new_transaction` normally
-    // calls `getLatestBlockhash` per tx; for ~300 distribute txs that's
-    // 300 redundant RPCs. Blockhashes stay valid for ~60-90 s, well
-    // above this pass's wall time; on `BlockhashNotFound` at submit the
-    // operator re-runs (the pass is idempotent).
     let candidate_destination_atas: Vec<Pubkey> = journal_mint_candidates
         .iter()
         .map(|mint| get_associated_token_address(rewards_token_owner_key, mint))
@@ -355,12 +345,6 @@ pub async fn try_distribute_pending(
         .zip(candidate_destination_ata_accounts.iter())
         .filter_map(|(ata, account)| (!account.data.is_empty()).then_some(*ata))
         .collect();
-
-    let cached_blockhash = wallet
-        .connection
-        .get_latest_blockhash()
-        .await
-        .context("fetching cached blockhash for distribute pass")?;
 
     // ----- Step 7: in-memory decision loop, submit per (epoch, mint) -----
     //
@@ -452,7 +436,6 @@ pub async fn try_distribute_pending(
                 &dz_mint_key,
                 needs_init,
                 needs_ata_create,
-                cached_blockhash,
             )
             .await
             {
@@ -499,7 +482,6 @@ async fn submit_distribute_tx(
     dz_mint_key: &Pubkey,
     needs_init: bool,
     needs_ata_create: bool,
-    recent_blockhash: Hash,
 ) -> Result<()> {
     let mut instructions: Vec<Instruction> = Vec::new();
 
@@ -565,24 +547,11 @@ async fn submit_distribute_tx(
         instructions.push(compute_unit_price_ix.clone());
     }
 
-    // Inlined tx build (replaces `wallet.new_transaction`) so we can reuse
-    // the cached blockhash and skip the per-tx `getLatestBlockhash` RPC.
-    // Signer assembly mirrors `Wallet::new_transaction_with_additional_signers_and_lookup_tables`:
-    // when `--fee-payer` is set it signs first; the `-k` signer is added
-    // only if its pubkey differs from the fee payer's.
-    let mut signers: Vec<&Keypair> = Vec::with_capacity(2);
-    match wallet.fee_payer {
-        Some(ref fee_payer) => {
-            signers.push(fee_payer);
-            if wallet.signer.pubkey() != fee_payer.pubkey() {
-                signers.push(&wallet.signer);
-            }
-        }
-        None => {
-            signers.push(&wallet.signer);
-        }
-    }
-    let transaction = try_new_transaction(&instructions, &signers, &[], recent_blockhash)?;
+    // Fetch a fresh blockhash per tx. The pass submits sequentially and a
+    // validator with many pending epochs can run long enough that a single
+    // blockhash cached up front ages out of the cluster's validity window
+    // mid-pass — every later tx then fails with "Blockhash not found".
+    let transaction = wallet.new_transaction(&instructions).await?;
     let tx_outcome = wallet.send_or_simulate_transaction(&transaction).await?;
     if let TransactionOutcome::Executed(tx_sig) = tx_outcome {
         println!(

--- a/crates/solana-cli/src/command/shreds/publisher_rewards/distribute.rs
+++ b/crates/solana-cli/src/command/shreds/publisher_rewards/distribute.rs
@@ -38,8 +38,9 @@ use doublezero_solana_sdk::{
         },
         state::{
             ShredDistribution, ShredDistributionJournal, find_claim_holding_address,
-            find_shred_distribution_address, find_shred_distribution_journal_address,
-            find_validator_client_rewards_address,
+            find_program_config_address, find_shred_distribution_address,
+            find_shred_distribution_journal_address, find_validator_client_rewards_address,
+            is_distribute_validator_rewards_enabled,
         },
         types::ValidatorRewardsLeaf,
     },
@@ -99,6 +100,24 @@ pub async fn try_distribute_pending(
     rewards_token_owner_key: &Pubkey,
     network_env: NetworkEnvironment,
 ) -> Result<DistributeOutcome> {
+    let mut outcome = DistributeOutcome::default();
+
+    // Check if distribute flag is enabled in ProgramConfig.
+    let program_config_account = wallet
+        .connection
+        .try_fetch_multiple_accounts(&[find_program_config_address().0])
+        .await
+        .context("fetching program config")?;
+    let distribute_enabled = program_config_account
+        .first()
+        .is_some_and(|account| is_distribute_validator_rewards_enabled(&account.data));
+    if !distribute_enabled {
+        println!(
+            "\nDistribute is not enabled on this cluster yet; skipping pending-rewards distribution."
+        );
+        return Ok(outcome);
+    }
+
     // `wallet.connection` is the DZ-Ledger RPC (program host). Its epoch
     // is the DZ-Ledger epoch, which has no relation to the Solana epoch
     // on testnet/localnet. `subscription_epoch` PDAs and S3 file names
@@ -121,8 +140,6 @@ pub async fn try_distribute_pending(
     let usdc_mint_key = environment_usdc_token_mint_key(network_env);
     let wsol_mint_key = spl_token_interface::native_mint::ID;
     let journal_mint_candidates = [dz_mint_key, usdc_mint_key, wsol_mint_key];
-
-    let mut outcome = DistributeOutcome::default();
 
     // ----- Step 1: batch fetch ShredDistribution accounts in the window -----
 
@@ -454,8 +471,10 @@ pub async fn try_distribute_pending(
                     }
                 }
                 Err(error) => {
+                    let full = format!("{error:#}");
+                    let summary = full.lines().next().unwrap_or(&full);
                     eprintln!(
-                        "  epoch {} mint {publisher_mint}: failed: {error:#}",
+                        "  epoch {} mint {publisher_mint}: failed: {summary}",
                         candidate.subscription_epoch
                     );
                     outcome.submits_failed += 1;

--- a/crates/solana-cli/src/command/shreds/publisher_rewards/distribute.rs
+++ b/crates/solana-cli/src/command/shreds/publisher_rewards/distribute.rs
@@ -68,19 +68,20 @@ const DISTRIBUTE_LOOKBACK_EPOCHS: u64 = 100;
 /// that roughly 8x while staying polite to S3.
 const S3_FETCH_CONCURRENCY: usize = 8;
 
-/// Counters surfaced at the end of a distribute pass. The three counters
-/// have **different units** on purpose — read the summary line, not the
-/// raw struct:
-/// - `submits_succeeded` / `submits_failed`: per-`(epoch, mint)` tx
-///   submission. One epoch can contribute up to 3 of either.
-/// - `epochs_unsettled`: per-epoch. Fires when the pass ended without any
-///   successful distribute for this leaf in that epoch (covers both
-///   "nothing eligible to do" and "tried and all submits failed").
+/// Counters surfaced at the end of a distribute pass.
+/// - `distributed`: distribute txs that landed.
+/// - `failed`: distribute txs that errored, plus epochs we couldn't even
+///   evaluate (S3 fetch / merkle-leaf failures). Each has a logged reason.
+///
+/// Epochs with nothing to do — the leaf's bitmap bit is already clear
+/// because it was distributed in a prior run or never routed to this
+/// journal — are intentionally NOT counted. A clear bit means "settled",
+/// so counting it would make every re-run report a growing pile of
+/// phantom "unsettled" epochs.
 #[derive(Debug, Default)]
 pub struct DistributeOutcome {
-    pub submits_succeeded: u32,
-    pub submits_failed: u32,
-    pub epochs_unsettled: u32,
+    pub distributed: u32,
+    pub failed: u32,
 }
 
 /// Per-(epoch, leaf) bundle of everything needed to build a distribute tx
@@ -204,7 +205,7 @@ pub async fn try_distribute_pending(
             Ok(entries) => entries,
             Err(err) => {
                 eprintln!("  epoch {epoch}: failed to fetch S3 leaves: {err:#}");
-                outcome.epochs_unsettled += 1;
+                outcome.failed += 1;
                 continue;
             }
         };
@@ -219,7 +220,7 @@ pub async fn try_distribute_pending(
             Ok(c) => c,
             Err(err) => {
                 eprintln!("  epoch {epoch}: failed to compute merkle leaves: {err:#}");
-                outcome.epochs_unsettled += 1;
+                outcome.failed += 1;
                 continue;
             }
         };
@@ -382,7 +383,6 @@ pub async fn try_distribute_pending(
                 "  epoch {}: skipped — parent distribution missing",
                 candidate.subscription_epoch
             );
-            outcome.epochs_unsettled += 1;
             continue;
         }
         let parent_distribution: ZeroCopyAccountOwnedData<ParentDistribution> =
@@ -393,7 +393,6 @@ pub async fn try_distribute_pending(
                         "  epoch {}: skipped — parent distribution malformed",
                         candidate.subscription_epoch
                     );
-                    outcome.epochs_unsettled += 1;
                     continue;
                 }
             };
@@ -402,12 +401,10 @@ pub async fn try_distribute_pending(
                 "  epoch {}: skipped — parent rewards not finalized",
                 candidate.subscription_epoch
             );
-            outcome.epochs_unsettled += 1;
             continue;
         }
 
         let claim_holding_exists = !claim_holding_accounts[candidate_index].data.is_empty();
-        let mut any_distributed_this_epoch = false;
 
         for (mint_index, publisher_mint) in journal_mint_candidates.iter().enumerate() {
             let journal_account = &journal_accounts[candidate_index * 3 + mint_index];
@@ -460,8 +457,7 @@ pub async fn try_distribute_pending(
             .await
             {
                 Ok(()) => {
-                    outcome.submits_succeeded += 1;
-                    any_distributed_this_epoch = true;
+                    outcome.distributed += 1;
                     if needs_init {
                         emitted_init_for_holding.insert(init_key);
                     }
@@ -477,13 +473,9 @@ pub async fn try_distribute_pending(
                         "  epoch {} mint {publisher_mint}: failed: {summary}",
                         candidate.subscription_epoch
                     );
-                    outcome.submits_failed += 1;
+                    outcome.failed += 1;
                 }
             }
-        }
-
-        if !any_distributed_this_epoch {
-            outcome.epochs_unsettled += 1;
         }
     }
 

--- a/crates/solana-cli/src/command/shreds/publisher_rewards/distribute.rs
+++ b/crates/solana-cli/src/command/shreds/publisher_rewards/distribute.rs
@@ -1,13 +1,20 @@
-// Per-epoch distribute pass run after a successful `configure`. Walks back N
-// recent subscription epochs, identifies which ones have this validator's
-// rewards still pending, and submits a `DistributeValidatorRewards`
-// instruction for each (prepended with `InitializeClaimHolding` when the
-// per-(epoch, mint=2Z) claim holding account does not yet exist).
+// Per-epoch distribute pass run after a successful `configure`. Walks back
+// `DISTRIBUTE_LOOKBACK_EPOCHS` recent subscription epochs, fans out S3 leaf
+// fetches to find this validator's leaf position per epoch, then batches
+// state reads (publisher journals across 2Z/USDC/WSOL, parent
+// distributions, claim holdings) into a handful of upfront RPCs so the
+// per-epoch loop runs in memory. For each (epoch, journal-mint) where the
+// publisher-accumulation bitmap's leaf bit is still set, submits a
+// `DistributeValidatorRewards` ix (prepended with `InitializeClaimHolding`
+// on the first distribute per epoch when the 2Z claim holding doesn't yet
+// exist).
 //
 // Subscription epoch == Solana epoch in this codebase (the S3 export and
-// `ShredDistribution.subscription_epoch` use the same value), so we resolve
-// the current epoch via `getEpochInfo` on the connection that hosts the
-// program and scan `[current - lookback, current]`.
+// `ShredDistribution.subscription_epoch` use the same value), so we
+// resolve the current epoch via `getEpochInfo` on the connection that
+// hosts the program and scan `[current - lookback, current]`.
+
+use std::collections::{HashMap, HashSet};
 
 use anyhow::{Context, Result};
 use doublezero_solana_client_tools::{
@@ -16,7 +23,8 @@ use doublezero_solana_client_tools::{
     rpc::NetworkEnvironment,
 };
 use doublezero_solana_sdk::{
-    Pubkey, environment_2z_token_mint_key,
+    Pubkey, environment_2z_token_mint_key, environment_usdc_token_mint_key,
+    merkle::MerkleProof,
     revenue_distribution::{state::Distribution as ParentDistribution, types::DoubleZeroEpoch},
     shred_subscription::{
         ID,
@@ -31,23 +39,35 @@ use doublezero_solana_sdk::{
             find_shred_distribution_address, find_shred_distribution_journal_address,
             find_validator_client_rewards_address,
         },
+        types::ValidatorRewardsLeaf,
     },
     try_build_instruction,
 };
 use solana_sdk::{compute_budget::ComputeBudgetInstruction, instruction::Instruction};
+use spl_associated_token_account_interface::instruction::create_associated_token_account_idempotent;
 
 use super::s3;
 
-/// Subscription-epoch lookback window for the post-configure distribute pass.
-/// Wider than typical "validator just rejoined" gaps; bounded so the S3 fan-out
-/// stays sane.
-const DISTRIBUTE_LOOKBACK_EPOCHS: u64 = 20;
+/// Subscription-epoch lookback window for the post-configure distribute
+/// pass. Sized to fit one `getMultipleAccounts` chunk (100 keys) for the
+/// `ShredDistribution` batch; journal batches at 3 mints fit in 3 chunks.
+const DISTRIBUTE_LOOKBACK_EPOCHS: u64 = 100;
 
 #[derive(Debug, Default)]
 pub struct DistributeOutcome {
     pub successful: u32,
     pub skipped: u32,
     pub failed: u32,
+}
+
+/// Per-(epoch, leaf) bundle of everything needed to build a distribute tx
+/// after the upfront batched fetches complete.
+struct Candidate {
+    subscription_epoch: u64,
+    associated_dz_epoch: u64,
+    leaf_index: usize,
+    leaf: ValidatorRewardsLeaf,
+    proof: MerkleProof,
 }
 
 pub async fn try_distribute_pending(
@@ -57,9 +77,6 @@ pub async fn try_distribute_pending(
     rewards_token_mint_key: &Pubkey,
     network_env: NetworkEnvironment,
 ) -> Result<DistributeOutcome> {
-    let lookback = DISTRIBUTE_LOOKBACK_EPOCHS;
-    // The latest in-flight epoch may not have accumulated yet; the
-    // `is_validator_rewards_accumulated()` check below filters those out.
     let current_epoch = wallet
         .connection
         .0
@@ -67,58 +84,277 @@ pub async fn try_distribute_pending(
         .await
         .context("fetching current epoch")?
         .epoch;
-    let from_epoch = current_epoch.saturating_sub(lookback);
+    let from_epoch = current_epoch.saturating_sub(DISTRIBUTE_LOOKBACK_EPOCHS);
 
     println!("\nScanning epochs {from_epoch}..={current_epoch} for unsettled validator rewards.");
 
-    let candidate_pdas = (from_epoch..=current_epoch)
+    // Mints we probe each epoch. We don't assume the validator's current
+    // VPR mint matches what they were configured against historically;
+    // accumulate may have routed earlier-epoch rewards into a different
+    // journal. Probing all three covers that case.
+    let dz_mint_key = environment_2z_token_mint_key(network_env);
+    let usdc_mint_key = environment_usdc_token_mint_key(network_env);
+    let wsol_mint_key = spl_token_interface::native_mint::ID;
+    let journal_mint_candidates = [dz_mint_key, usdc_mint_key, wsol_mint_key];
+    let _ = rewards_token_mint_key; // kept in signature for callers that want
+    // to log it; not load-bearing now that we
+    // probe all three mints.
+
+    let mut outcome = DistributeOutcome::default();
+
+    // ----- Step 1: batch fetch ShredDistribution accounts in the window -----
+
+    let shred_distribution_pdas: Vec<Pubkey> = (from_epoch..=current_epoch)
         .map(|epoch| find_shred_distribution_address(epoch).0)
-        .collect::<Vec<_>>();
-    let shred_distributions = wallet
+        .collect();
+    let shred_distribution_accounts = wallet
         .connection
-        .try_fetch_multiple_accounts(&candidate_pdas)
+        .try_fetch_multiple_accounts(&shred_distribution_pdas)
         .await
         .context("fetching candidate ShredDistribution accounts")?;
 
-    let dz_mint_key = environment_2z_token_mint_key(network_env);
+    let accumulated: Vec<(u64, ZeroCopyAccountOwnedData<ShredDistribution>)> =
+        shred_distribution_accounts
+            .into_iter()
+            .enumerate()
+            .filter_map(|(offset, account)| {
+                if account.data.is_empty() {
+                    return None;
+                }
+                let epoch = from_epoch + offset as u64;
+                let shred_distribution: ZeroCopyAccountOwnedData<ShredDistribution> =
+                    account.try_into().ok()?;
+                shred_distribution
+                    .is_validator_rewards_accumulated()
+                    .then_some((epoch, shred_distribution))
+            })
+            .collect();
+
+    if accumulated.is_empty() {
+        println!("No accumulated epochs in the window; nothing to distribute.");
+        return Ok(outcome);
+    }
+
+    // ----- Step 2: fan out S3 to find this validator's leaf per epoch -----
+
     let s3_client = s3::build_s3_client()?;
-
-    let mut outcome = DistributeOutcome::default();
-    for (offset, account) in shred_distributions.into_iter().enumerate() {
-        let epoch = from_epoch + offset as u64;
-        if account.data.is_empty() {
-            continue;
-        }
-        let shred_distribution: ZeroCopyAccountOwnedData<ShredDistribution> =
-            match account.try_into() {
-                Ok(data) => data,
-                Err(_) => continue,
-            };
-        if !shred_distribution.is_validator_rewards_accumulated() {
-            continue;
-        }
-
-        match try_distribute_one_epoch(
-            wallet,
-            &s3_client,
-            epoch,
-            &shred_distribution,
-            node_id,
-            rewards_token_owner_key,
-            rewards_token_mint_key,
-            &dz_mint_key,
-        )
-        .await
-        {
-            Ok(EpochOutcome::Distributed) => outcome.successful += 1,
-            Ok(EpochOutcome::Skipped(reason)) => {
-                println!("  epoch {epoch}: skipped — {reason}");
-                outcome.skipped += 1;
-            }
-            Err(error) => {
-                eprintln!("  epoch {epoch}: failed: {error:#}");
+    let mut candidates: Vec<Candidate> = Vec::new();
+    for (epoch, _shred_distribution) in &accumulated {
+        let entries = match s3::fetch_leader_slot_data(&s3_client, *epoch).await {
+            Ok(entries) => entries,
+            Err(err) => {
+                eprintln!("  epoch {epoch}: failed to fetch S3 leaves: {err:#}");
                 outcome.failed += 1;
+                continue;
             }
+        };
+        let leaves = match s3::compute_leaves_with_proofs(&entries) {
+            Ok(leaves) => leaves,
+            Err(err) => {
+                eprintln!("  epoch {epoch}: failed to compute merkle proofs: {err:#}");
+                outcome.failed += 1;
+                continue;
+            }
+        };
+        let Some(leaf_index) = leaves
+            .leaves
+            .iter()
+            .position(|leaf| &leaf.node_id == node_id)
+        else {
+            // Validator wasn't a leader this epoch; silent skip (no work
+            // to do, not an error).
+            continue;
+        };
+        let shred_distribution = accumulated
+            .iter()
+            .find(|(e, _)| e == epoch)
+            .map(|(_, sd)| sd)
+            .expect("epoch was just iterated from `accumulated`");
+        candidates.push(Candidate {
+            subscription_epoch: *epoch,
+            associated_dz_epoch: shred_distribution.associated_dz_epoch.value(),
+            leaf_index,
+            leaf: leaves.leaves[leaf_index],
+            proof: leaves.proofs[leaf_index].clone(),
+        });
+    }
+
+    if candidates.is_empty() {
+        println!("No candidate epochs with this validator as a leaf; nothing to distribute.");
+        return Ok(outcome);
+    }
+
+    // ----- Step 3: batch fetch journals at all three mints per candidate -----
+    //
+    // Layout: journal_accounts[candidate_idx * 3 + mint_idx]. The internal
+    // chunking in `try_fetch_multiple_accounts` keeps a single call under
+    // the 100-key getMultipleAccounts limit, so a 100-candidate × 3-mint
+    // (= 300-key) batch lands in three RPCs.
+
+    let mut journal_pdas: Vec<Pubkey> = Vec::with_capacity(candidates.len() * 3);
+    for candidate in &candidates {
+        for mint in &journal_mint_candidates {
+            journal_pdas.push(
+                find_shred_distribution_journal_address(candidate.subscription_epoch, mint).0,
+            );
+        }
+    }
+    let journal_accounts = wallet
+        .connection
+        .try_fetch_multiple_accounts(&journal_pdas)
+        .await
+        .context("fetching journal accounts")?;
+
+    // ----- Step 4: batch fetch parent distributions, deduped by DZ epoch -----
+
+    let mut parent_index_for_dz_epoch: HashMap<u64, usize> = HashMap::new();
+    let mut parent_pdas: Vec<Pubkey> = Vec::new();
+    for candidate in &candidates {
+        parent_index_for_dz_epoch
+            .entry(candidate.associated_dz_epoch)
+            .or_insert_with(|| {
+                let pda = ParentDistribution::find_address(DoubleZeroEpoch::new(
+                    candidate.associated_dz_epoch,
+                ))
+                .0;
+                parent_pdas.push(pda);
+                parent_pdas.len() - 1
+            });
+    }
+    let parent_accounts = wallet
+        .connection
+        .try_fetch_multiple_accounts(&parent_pdas)
+        .await
+        .context("fetching parent Distribution accounts")?;
+
+    // ----- Step 5: batch fetch claim holdings (one per candidate) -----
+
+    let claim_holding_pdas: Vec<Pubkey> = candidates
+        .iter()
+        .map(|candidate| {
+            let validator_client_rewards_key =
+                find_validator_client_rewards_address(candidate.leaf.client_id).0;
+            find_claim_holding_address(
+                &validator_client_rewards_key,
+                candidate.subscription_epoch,
+                &dz_mint_key,
+            )
+            .0
+        })
+        .collect();
+    let claim_holding_accounts = wallet
+        .connection
+        .try_fetch_multiple_accounts(&claim_holding_pdas)
+        .await
+        .context("fetching claim holding accounts")?;
+
+    // ----- Step 6: in-memory decision loop, submit per (epoch, mint) -----
+    //
+    // `InitializeClaimHolding` is idempotent on-chain but a re-issued init
+    // still costs a CPI and tx bytes. Track which epochs we've already
+    // emitted an init for in this pass so subsequent (epoch, mint) txs
+    // skip it.
+
+    let mut emitted_init_for_epoch: HashSet<u64> = HashSet::new();
+
+    for (candidate_index, candidate) in candidates.iter().enumerate() {
+        // Parent distribution gate.
+        let parent_index = parent_index_for_dz_epoch[&candidate.associated_dz_epoch];
+        let parent_account = &parent_accounts[parent_index];
+        if parent_account.data.is_empty() {
+            println!(
+                "  epoch {}: skipped — parent distribution missing",
+                candidate.subscription_epoch
+            );
+            outcome.skipped += 1;
+            continue;
+        }
+        let parent_distribution: ZeroCopyAccountOwnedData<ParentDistribution> =
+            match parent_account.clone().try_into() {
+                Ok(data) => data,
+                Err(_) => {
+                    println!(
+                        "  epoch {}: skipped — parent distribution malformed",
+                        candidate.subscription_epoch
+                    );
+                    outcome.skipped += 1;
+                    continue;
+                }
+            };
+        if !parent_distribution.is_rewards_calculation_finalized() {
+            println!(
+                "  epoch {}: skipped — parent rewards not finalized",
+                candidate.subscription_epoch
+            );
+            outcome.skipped += 1;
+            continue;
+        }
+
+        let claim_holding_exists = !claim_holding_accounts[candidate_index].data.is_empty();
+        let mut any_distributed_this_epoch = false;
+
+        for (mint_index, publisher_mint) in journal_mint_candidates.iter().enumerate() {
+            let journal_account = &journal_accounts[candidate_index * 3 + mint_index];
+            if journal_account.data.is_empty() {
+                continue;
+            }
+            let publisher_journal: ZeroCopyAccountOwnedData<ShredDistributionJournal> =
+                match journal_account.clone().try_into() {
+                    Ok(data) => data,
+                    Err(_) => continue,
+                };
+            if !publisher_journal.is_swap_complete() {
+                continue;
+            }
+            let Some(bitmap_range) =
+                publisher_journal.checked_publisher_accumulation_bitmap_range()
+            else {
+                continue;
+            };
+            let bitmap = match publisher_journal
+                .remaining_data
+                .get(bitmap_range.start..bitmap_range.end)
+            {
+                Some(slice) => slice,
+                None => continue,
+            };
+            if !bitmap_bit_set(bitmap, candidate.leaf_index) {
+                continue;
+            }
+
+            let needs_init = !claim_holding_exists
+                && !emitted_init_for_epoch.contains(&candidate.subscription_epoch);
+            match submit_distribute_tx(
+                wallet,
+                candidate,
+                &publisher_journal,
+                publisher_mint,
+                rewards_token_owner_key,
+                node_id,
+                &dz_mint_key,
+                needs_init,
+            )
+            .await
+            {
+                Ok(()) => {
+                    outcome.successful += 1;
+                    any_distributed_this_epoch = true;
+                    if needs_init {
+                        emitted_init_for_epoch.insert(candidate.subscription_epoch);
+                    }
+                }
+                Err(error) => {
+                    eprintln!(
+                        "  epoch {} mint {publisher_mint}: failed: {error:#}",
+                        candidate.subscription_epoch
+                    );
+                    outcome.failed += 1;
+                }
+            }
+        }
+
+        if !any_distributed_this_epoch {
+            outcome.skipped += 1;
         }
     }
 
@@ -129,174 +365,80 @@ pub async fn try_distribute_pending(
     Ok(outcome)
 }
 
-enum EpochOutcome {
-    Distributed,
-    Skipped(&'static str),
-}
-
 #[allow(clippy::too_many_arguments)]
-async fn try_distribute_one_epoch(
+async fn submit_distribute_tx(
     wallet: &Wallet,
-    s3_client: &reqwest::Client,
-    subscription_epoch: u64,
-    shred_distribution: &ShredDistribution,
-    node_id: &Pubkey,
+    candidate: &Candidate,
+    publisher_journal: &ZeroCopyAccountOwnedData<ShredDistributionJournal>,
+    publisher_mint_key: &Pubkey,
     rewards_token_owner_key: &Pubkey,
-    rewards_token_mint_key: &Pubkey,
+    node_id: &Pubkey,
     dz_mint_key: &Pubkey,
-) -> Result<EpochOutcome> {
-    // Pull S3 leaves for this epoch. The merkle tree is built from the full
-    // leaf set; per-leaf proofs are positional, so the index in the sorted
-    // vec is the same as the on-chain `leaf_index`.
-    let entries = s3::fetch_leader_slot_data(s3_client, subscription_epoch)
-        .await
-        .with_context(|| format!("fetching S3 leaves for epoch {subscription_epoch}"))?;
-    let leaves_with_proofs = s3::compute_leaves_with_proofs(&entries)
-        .with_context(|| format!("computing merkle proofs for epoch {subscription_epoch}"))?;
-
-    let Some(leaf_index) = leaves_with_proofs
-        .leaves
-        .iter()
-        .position(|leaf| &leaf.node_id == node_id)
-    else {
-        return Ok(EpochOutcome::Skipped("no leaf for this validator"));
-    };
-    let leaf = leaves_with_proofs.leaves[leaf_index];
-    let proof = leaves_with_proofs.proofs[leaf_index].clone();
-
-    // Publisher journal is at (subscription_epoch, vpr.rewards_token_mint_key).
-    // If it doesn't exist, accumulate never routed this validator's leaf here
-    // — nothing to distribute under the current configuration.
-    let publisher_journal_key =
-        find_shred_distribution_journal_address(subscription_epoch, rewards_token_mint_key).0;
-    let parent_distribution_key = ParentDistribution::find_address(DoubleZeroEpoch::new(
-        shred_distribution.associated_dz_epoch.value(),
-    ))
-    .0;
-
-    let prefetch = wallet
-        .connection
-        .try_fetch_multiple_accounts(&[publisher_journal_key, parent_distribution_key])
-        .await
-        .context("fetching journal/parent")?;
-    let [publisher_journal_account, parent_distribution_account] =
-        <[_; 2]>::try_from(prefetch).expect("requested 2 accounts");
-    if publisher_journal_account.data.is_empty() {
-        return Ok(EpochOutcome::Skipped(
-            "no publisher journal for this mint at this epoch",
-        ));
-    }
-    let publisher_journal: ZeroCopyAccountOwnedData<ShredDistributionJournal> =
-        match publisher_journal_account.try_into() {
-            Ok(data) => data,
-            Err(_) => return Ok(EpochOutcome::Skipped("publisher journal malformed")),
-        };
-    if !publisher_journal.is_swap_complete() {
-        return Ok(EpochOutcome::Skipped("publisher journal swap incomplete"));
-    }
-    if parent_distribution_account.data.is_empty() {
-        return Ok(EpochOutcome::Skipped("parent distribution missing"));
-    }
-    let parent_distribution: ZeroCopyAccountOwnedData<ParentDistribution> =
-        match parent_distribution_account.try_into() {
-            Ok(data) => data,
-            Err(_) => return Ok(EpochOutcome::Skipped("parent distribution malformed")),
-        };
-    if !parent_distribution.is_rewards_calculation_finalized() {
-        return Ok(EpochOutcome::Skipped("parent rewards not finalized"));
-    }
-
-    // Check the publisher accumulation bitmap. A SET bit means accumulate
-    // routed here and distribute has not yet run; a CLEAR bit means either
-    // accumulate didn't route here (different mint) or distribute already
-    // ran (replay).
-    let Some(bitmap_range) = publisher_journal.checked_publisher_accumulation_bitmap_range() else {
-        return Ok(EpochOutcome::Skipped("journal bitmap not allocated"));
-    };
-    let journal_account_data = wallet
-        .connection
-        .0
-        .get_account_data(&publisher_journal_key)
-        .await
-        .context("re-reading journal data for bitmap")?;
-    let inline_data_offset =
-        doublezero_solana_sdk::DISCRIMINATOR_LEN + std::mem::size_of::<ShredDistributionJournal>();
-    let bitmap = journal_account_data
-        .get(inline_data_offset + bitmap_range.start..inline_data_offset + bitmap_range.end)
-        .context("journal data shorter than declared bitmap range")?;
-    if !bitmap_bit_set(bitmap, leaf_index) {
-        return Ok(EpochOutcome::Skipped(
-            "leaf bit clear (already distributed or routed elsewhere)",
-        ));
-    }
-
-    // Determine whether the client claim holding exists. If not, prepend
-    // the `InitializeClaimHolding` ix in the same tx.
-    let validator_client_rewards_key = find_validator_client_rewards_address(leaf.client_id).0;
-    let client_claim_holding_key = find_claim_holding_address(
-        &validator_client_rewards_key,
-        subscription_epoch,
-        dz_mint_key,
-    )
-    .0;
-    let needs_claim_holding_init = wallet
-        .connection
-        .0
-        .get_account(&client_claim_holding_key)
-        .await
-        .is_err();
-
+    needs_init: bool,
+) -> Result<()> {
     let mut instructions: Vec<Instruction> =
         vec![super::super::build_check_cli_version_instruction()?];
 
-    if needs_claim_holding_init {
-        let init_claim_holding_ix = try_build_instruction(
+    if needs_init {
+        let init_ix = try_build_instruction(
             &ID,
             InitializeClaimHoldingAccounts::new(
-                leaf.client_id,
-                subscription_epoch,
+                candidate.leaf.client_id,
+                candidate.subscription_epoch,
                 dz_mint_key,
                 &wallet.pubkey(),
             ),
-            &ShredSubscriptionInstructionData::InitializeClaimHolding(subscription_epoch),
+            &ShredSubscriptionInstructionData::InitializeClaimHolding(candidate.subscription_epoch),
         )?;
-        instructions.push(init_claim_holding_ix);
+        instructions.push(init_ix);
     }
 
-    // The publisher-and-client-same-mint case fires the omit-rule and
-    // collapses to a single journal account. We model that by passing
-    // `None` for `client_mint_key` when our publisher mint is already 2Z.
-    let client_mint_arg = if rewards_token_mint_key == dz_mint_key {
+    // The destination ATA is at `(rewards_token_owner_key, journal's
+    // reward_mint_key)` — which can differ from the validator's currently
+    // configured mint when we're distributing from a journal seeded
+    // historically against a different mint. `configure` only creates the
+    // ATA for the current mint, so we (idempotently) create whatever
+    // destination this specific tx needs. No-op when it already exists.
+    instructions.push(create_associated_token_account_idempotent(
+        &wallet.pubkey(),
+        rewards_token_owner_key,
+        &publisher_journal.reward_mint_key,
+        &spl_token_interface::ID,
+    ));
+
+    // Omit-rule: when the validator's publisher mint is already 2Z, the
+    // publisher journal also plays the client role. Signal that to the
+    // account-builder by passing `None`.
+    let client_mint_arg = if publisher_mint_key == dz_mint_key {
         None
     } else {
         Some(dz_mint_key)
     };
+
     let distribute_ix = try_build_instruction(
         &ID,
         DistributeValidatorRewardsAccountsInitializer {
-            subscription_epoch,
-            associated_dz_epoch: shred_distribution.associated_dz_epoch.value(),
+            subscription_epoch: candidate.subscription_epoch,
+            associated_dz_epoch: candidate.associated_dz_epoch,
             node_id,
-            client_id: leaf.client_id,
+            client_id: candidate.leaf.client_id,
             rewards_token_owner_key,
-            publisher_mint_key: rewards_token_mint_key,
+            publisher_mint_key,
             publisher_reward_mint_key: &publisher_journal.reward_mint_key,
             client_mint_key: client_mint_arg,
         },
         &ShredSubscriptionInstructionData::DistributeValidatorRewards {
-            leader_slots: leaf.leader_slots,
-            proof,
+            leader_slots: candidate.leaf.leader_slots,
+            proof: candidate.proof.clone(),
         },
     )?;
     instructions.push(distribute_ix);
 
-    // ~30k CU per ix (init_claim_holding + distribute) — both upper bounds
-    // observed in the admin command's submission loop.
-    let cu_limit = if needs_claim_holding_init {
-        180_000
-    } else {
-        150_000
-    };
+    // Per-ix headroom: ~30k init_claim_holding (only when `needs_init`),
+    // ~25k create_ata_idempotent (no-op if the ATA already exists, but the
+    // SPL Token program's existence check still costs some CU), ~150k
+    // distribute. Same upper bounds as the admin command's submission loop.
+    let cu_limit = if needs_init { 205_000 } else { 175_000 };
     instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(cu_limit));
     if let Some(ref compute_unit_price_ix) = wallet.compute_unit_price_ix {
         instructions.push(compute_unit_price_ix.clone());
@@ -305,11 +447,14 @@ async fn try_distribute_one_epoch(
     let transaction = wallet.new_transaction(&instructions).await?;
     let tx_outcome = wallet.send_or_simulate_transaction(&transaction).await?;
     if let TransactionOutcome::Executed(tx_sig) = tx_outcome {
-        println!("  epoch {subscription_epoch}: distributed ({tx_sig})");
+        println!(
+            "  epoch {} mint {publisher_mint_key}: distributed ({tx_sig})",
+            candidate.subscription_epoch
+        );
         wallet.print_verbose_output(&[tx_sig]).await?;
     }
 
-    Ok(EpochOutcome::Distributed)
+    Ok(())
 }
 
 fn bitmap_bit_set(bitmap: &[u8], leaf_index: usize) -> bool {

--- a/crates/solana-cli/src/command/shreds/publisher_rewards/distribute.rs
+++ b/crates/solana-cli/src/command/shreds/publisher_rewards/distribute.rs
@@ -1,0 +1,349 @@
+// Per-epoch distribute pass run after a successful `configure`. Walks back N
+// recent subscription epochs, identifies which ones have this validator's
+// rewards still pending, and submits a `DistributeValidatorRewards`
+// instruction for each (prepended with `InitializeClaimHolding` when the
+// per-(epoch, mint=2Z) claim holding account does not yet exist).
+//
+// Subscription epoch == Solana epoch in this codebase (the S3 export and
+// `ShredDistribution.subscription_epoch` use the same value), so we resolve
+// the current epoch via `getEpochInfo` on the connection that hosts the
+// program and scan `[current - lookback, current]`.
+
+use anyhow::{Context, Result};
+use doublezero_solana_client_tools::{
+    account::zero_copy::ZeroCopyAccountOwnedData,
+    payer::{TransactionOutcome, Wallet},
+    rpc::NetworkEnvironment,
+};
+use doublezero_solana_sdk::{
+    Pubkey, environment_2z_token_mint_key,
+    revenue_distribution::{state::Distribution as ParentDistribution, types::DoubleZeroEpoch},
+    shred_subscription::{
+        ID,
+        instruction::{
+            ShredSubscriptionInstructionData,
+            account::{
+                DistributeValidatorRewardsAccountsInitializer, InitializeClaimHoldingAccounts,
+            },
+        },
+        state::{
+            ShredDistribution, ShredDistributionJournal, find_claim_holding_address,
+            find_shred_distribution_address, find_shred_distribution_journal_address,
+            find_validator_client_rewards_address,
+        },
+    },
+    try_build_instruction,
+};
+use solana_sdk::{compute_budget::ComputeBudgetInstruction, instruction::Instruction};
+
+use super::s3;
+
+/// Subscription-epoch lookback window for the post-configure distribute pass.
+/// Wider than typical "validator just rejoined" gaps; bounded so the S3 fan-out
+/// stays sane.
+const DISTRIBUTE_LOOKBACK_EPOCHS: u64 = 20;
+
+#[derive(Debug, Default)]
+pub struct DistributeOutcome {
+    pub successful: u32,
+    pub skipped: u32,
+    pub failed: u32,
+}
+
+pub async fn try_distribute_pending(
+    wallet: &Wallet,
+    node_id: &Pubkey,
+    rewards_token_owner_key: &Pubkey,
+    rewards_token_mint_key: &Pubkey,
+    network_env: NetworkEnvironment,
+) -> Result<DistributeOutcome> {
+    let lookback = DISTRIBUTE_LOOKBACK_EPOCHS;
+    // The latest in-flight epoch may not have accumulated yet; the
+    // `is_validator_rewards_accumulated()` check below filters those out.
+    let current_epoch = wallet
+        .connection
+        .0
+        .get_epoch_info()
+        .await
+        .context("fetching current epoch")?
+        .epoch;
+    let from_epoch = current_epoch.saturating_sub(lookback);
+
+    println!("\nScanning epochs {from_epoch}..={current_epoch} for unsettled validator rewards.");
+
+    let candidate_pdas = (from_epoch..=current_epoch)
+        .map(|epoch| find_shred_distribution_address(epoch).0)
+        .collect::<Vec<_>>();
+    let shred_distributions = wallet
+        .connection
+        .try_fetch_multiple_accounts(&candidate_pdas)
+        .await
+        .context("fetching candidate ShredDistribution accounts")?;
+
+    let dz_mint_key = environment_2z_token_mint_key(network_env);
+    let s3_client = s3::build_s3_client()?;
+
+    let mut outcome = DistributeOutcome::default();
+    for (offset, account) in shred_distributions.into_iter().enumerate() {
+        let epoch = from_epoch + offset as u64;
+        if account.data.is_empty() {
+            continue;
+        }
+        let shred_distribution: ZeroCopyAccountOwnedData<ShredDistribution> =
+            match account.try_into() {
+                Ok(data) => data,
+                Err(_) => continue,
+            };
+        if !shred_distribution.is_validator_rewards_accumulated() {
+            continue;
+        }
+
+        match try_distribute_one_epoch(
+            wallet,
+            &s3_client,
+            epoch,
+            &shred_distribution,
+            node_id,
+            rewards_token_owner_key,
+            rewards_token_mint_key,
+            &dz_mint_key,
+        )
+        .await
+        {
+            Ok(EpochOutcome::Distributed) => outcome.successful += 1,
+            Ok(EpochOutcome::Skipped(reason)) => {
+                println!("  epoch {epoch}: skipped — {reason}");
+                outcome.skipped += 1;
+            }
+            Err(error) => {
+                eprintln!("  epoch {epoch}: failed: {error:#}");
+                outcome.failed += 1;
+            }
+        }
+    }
+
+    println!(
+        "\nDistribute pass complete: {} succeeded, {} skipped, {} failed.",
+        outcome.successful, outcome.skipped, outcome.failed,
+    );
+    Ok(outcome)
+}
+
+enum EpochOutcome {
+    Distributed,
+    Skipped(&'static str),
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn try_distribute_one_epoch(
+    wallet: &Wallet,
+    s3_client: &reqwest::Client,
+    subscription_epoch: u64,
+    shred_distribution: &ShredDistribution,
+    node_id: &Pubkey,
+    rewards_token_owner_key: &Pubkey,
+    rewards_token_mint_key: &Pubkey,
+    dz_mint_key: &Pubkey,
+) -> Result<EpochOutcome> {
+    // Pull S3 leaves for this epoch. The merkle tree is built from the full
+    // leaf set; per-leaf proofs are positional, so the index in the sorted
+    // vec is the same as the on-chain `leaf_index`.
+    let entries = s3::fetch_leader_slot_data(s3_client, subscription_epoch)
+        .await
+        .with_context(|| format!("fetching S3 leaves for epoch {subscription_epoch}"))?;
+    let leaves_with_proofs = s3::compute_leaves_with_proofs(&entries)
+        .with_context(|| format!("computing merkle proofs for epoch {subscription_epoch}"))?;
+
+    let Some(leaf_index) = leaves_with_proofs
+        .leaves
+        .iter()
+        .position(|leaf| &leaf.node_id == node_id)
+    else {
+        return Ok(EpochOutcome::Skipped("no leaf for this validator"));
+    };
+    let leaf = leaves_with_proofs.leaves[leaf_index];
+    let proof = leaves_with_proofs.proofs[leaf_index].clone();
+
+    // Publisher journal is at (subscription_epoch, vpr.rewards_token_mint_key).
+    // If it doesn't exist, accumulate never routed this validator's leaf here
+    // — nothing to distribute under the current configuration.
+    let publisher_journal_key =
+        find_shred_distribution_journal_address(subscription_epoch, rewards_token_mint_key).0;
+    let parent_distribution_key = ParentDistribution::find_address(DoubleZeroEpoch::new(
+        shred_distribution.associated_dz_epoch.value(),
+    ))
+    .0;
+
+    let prefetch = wallet
+        .connection
+        .try_fetch_multiple_accounts(&[publisher_journal_key, parent_distribution_key])
+        .await
+        .context("fetching journal/parent")?;
+    let [publisher_journal_account, parent_distribution_account] =
+        <[_; 2]>::try_from(prefetch).expect("requested 2 accounts");
+    if publisher_journal_account.data.is_empty() {
+        return Ok(EpochOutcome::Skipped(
+            "no publisher journal for this mint at this epoch",
+        ));
+    }
+    let publisher_journal: ZeroCopyAccountOwnedData<ShredDistributionJournal> =
+        match publisher_journal_account.try_into() {
+            Ok(data) => data,
+            Err(_) => return Ok(EpochOutcome::Skipped("publisher journal malformed")),
+        };
+    if !publisher_journal.is_swap_complete() {
+        return Ok(EpochOutcome::Skipped("publisher journal swap incomplete"));
+    }
+    if parent_distribution_account.data.is_empty() {
+        return Ok(EpochOutcome::Skipped("parent distribution missing"));
+    }
+    let parent_distribution: ZeroCopyAccountOwnedData<ParentDistribution> =
+        match parent_distribution_account.try_into() {
+            Ok(data) => data,
+            Err(_) => return Ok(EpochOutcome::Skipped("parent distribution malformed")),
+        };
+    if !parent_distribution.is_rewards_calculation_finalized() {
+        return Ok(EpochOutcome::Skipped("parent rewards not finalized"));
+    }
+
+    // Check the publisher accumulation bitmap. A SET bit means accumulate
+    // routed here and distribute has not yet run; a CLEAR bit means either
+    // accumulate didn't route here (different mint) or distribute already
+    // ran (replay).
+    let Some(bitmap_range) = publisher_journal.checked_publisher_accumulation_bitmap_range() else {
+        return Ok(EpochOutcome::Skipped("journal bitmap not allocated"));
+    };
+    let journal_account_data = wallet
+        .connection
+        .0
+        .get_account_data(&publisher_journal_key)
+        .await
+        .context("re-reading journal data for bitmap")?;
+    let inline_data_offset =
+        doublezero_solana_sdk::DISCRIMINATOR_LEN + std::mem::size_of::<ShredDistributionJournal>();
+    let bitmap = journal_account_data
+        .get(inline_data_offset + bitmap_range.start..inline_data_offset + bitmap_range.end)
+        .context("journal data shorter than declared bitmap range")?;
+    if !bitmap_bit_set(bitmap, leaf_index) {
+        return Ok(EpochOutcome::Skipped(
+            "leaf bit clear (already distributed or routed elsewhere)",
+        ));
+    }
+
+    // Determine whether the client claim holding exists. If not, prepend
+    // the `InitializeClaimHolding` ix in the same tx.
+    let validator_client_rewards_key = find_validator_client_rewards_address(leaf.client_id).0;
+    let client_claim_holding_key = find_claim_holding_address(
+        &validator_client_rewards_key,
+        subscription_epoch,
+        dz_mint_key,
+    )
+    .0;
+    let needs_claim_holding_init = wallet
+        .connection
+        .0
+        .get_account(&client_claim_holding_key)
+        .await
+        .is_err();
+
+    let mut instructions: Vec<Instruction> =
+        vec![super::super::build_check_cli_version_instruction()?];
+
+    if needs_claim_holding_init {
+        let init_claim_holding_ix = try_build_instruction(
+            &ID,
+            InitializeClaimHoldingAccounts::new(
+                leaf.client_id,
+                subscription_epoch,
+                dz_mint_key,
+                &wallet.pubkey(),
+            ),
+            &ShredSubscriptionInstructionData::InitializeClaimHolding(subscription_epoch),
+        )?;
+        instructions.push(init_claim_holding_ix);
+    }
+
+    // The publisher-and-client-same-mint case fires the omit-rule and
+    // collapses to a single journal account. We model that by passing
+    // `None` for `client_mint_key` when our publisher mint is already 2Z.
+    let client_mint_arg = if rewards_token_mint_key == dz_mint_key {
+        None
+    } else {
+        Some(dz_mint_key)
+    };
+    let distribute_ix = try_build_instruction(
+        &ID,
+        DistributeValidatorRewardsAccountsInitializer {
+            subscription_epoch,
+            associated_dz_epoch: shred_distribution.associated_dz_epoch.value(),
+            node_id,
+            client_id: leaf.client_id,
+            rewards_token_owner_key,
+            publisher_mint_key: rewards_token_mint_key,
+            publisher_reward_mint_key: &publisher_journal.reward_mint_key,
+            client_mint_key: client_mint_arg,
+        },
+        &ShredSubscriptionInstructionData::DistributeValidatorRewards {
+            leader_slots: leaf.leader_slots,
+            proof,
+        },
+    )?;
+    instructions.push(distribute_ix);
+
+    // ~30k CU per ix (init_claim_holding + distribute) — both upper bounds
+    // observed in the admin command's submission loop.
+    let cu_limit = if needs_claim_holding_init {
+        180_000
+    } else {
+        150_000
+    };
+    instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(cu_limit));
+    if let Some(ref compute_unit_price_ix) = wallet.compute_unit_price_ix {
+        instructions.push(compute_unit_price_ix.clone());
+    }
+
+    let transaction = wallet.new_transaction(&instructions).await?;
+    let tx_outcome = wallet.send_or_simulate_transaction(&transaction).await?;
+    if let TransactionOutcome::Executed(tx_sig) = tx_outcome {
+        println!("  epoch {subscription_epoch}: distributed ({tx_sig})");
+        wallet.print_verbose_output(&[tx_sig]).await?;
+    }
+
+    Ok(EpochOutcome::Distributed)
+}
+
+fn bitmap_bit_set(bitmap: &[u8], leaf_index: usize) -> bool {
+    let byte_idx = leaf_index / 8;
+    let bit_idx = leaf_index % 8;
+    bitmap
+        .get(byte_idx)
+        .map(|b| (b >> bit_idx) & 1 == 1)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bitmap_bit_set_in_range() {
+        let bitmap = vec![0b0000_1001, 0b0000_0010];
+        assert!(bitmap_bit_set(&bitmap, 0));
+        assert!(!bitmap_bit_set(&bitmap, 1));
+        assert!(bitmap_bit_set(&bitmap, 3));
+        assert!(!bitmap_bit_set(&bitmap, 8));
+        assert!(bitmap_bit_set(&bitmap, 9));
+    }
+
+    #[test]
+    fn test_bitmap_bit_set_out_of_range() {
+        let bitmap = vec![0xff];
+        assert!(!bitmap_bit_set(&bitmap, 8));
+        assert!(!bitmap_bit_set(&bitmap, 1_000));
+    }
+
+    #[test]
+    fn test_bitmap_bit_set_empty() {
+        assert!(!bitmap_bit_set(&[], 0));
+    }
+}

--- a/crates/solana-cli/src/command/shreds/publisher_rewards/distribute.rs
+++ b/crates/solana-cli/src/command/shreds/publisher_rewards/distribute.rs
@@ -11,8 +11,9 @@
 //
 // Subscription epoch == Solana epoch in this codebase (the S3 export and
 // `ShredDistribution.subscription_epoch` use the same value), so we
-// resolve the current epoch via `getEpochInfo` on the connection that
-// hosts the program and scan `[current - lookback, current]`.
+// resolve the current epoch via `getEpochInfo` on a Solana RPC (NOT the
+// DZ-Ledger one that hosts the program — on testnet/localnet those are
+// distinct chains with independent epoch numbers).
 
 use std::collections::{HashMap, HashSet};
 
@@ -20,7 +21,8 @@ use anyhow::{Context, Result};
 use doublezero_solana_client_tools::{
     account::zero_copy::ZeroCopyAccountOwnedData,
     payer::{TransactionOutcome, Wallet},
-    rpc::NetworkEnvironment,
+    rpc::{NetworkEnvironment, SolanaConnection},
+    transaction::try_new_transaction,
 };
 use doublezero_solana_sdk::{
     Pubkey, environment_2z_token_mint_key, environment_usdc_token_mint_key,
@@ -43,8 +45,14 @@ use doublezero_solana_sdk::{
     },
     try_build_instruction,
 };
-use solana_sdk::{compute_budget::ComputeBudgetInstruction, instruction::Instruction};
-use spl_associated_token_account_interface::instruction::create_associated_token_account_idempotent;
+use futures::stream::{self, StreamExt};
+use solana_sdk::{
+    compute_budget::ComputeBudgetInstruction, hash::Hash, instruction::Instruction,
+    signature::Keypair, signer::Signer,
+};
+use spl_associated_token_account_interface::{
+    address::get_associated_token_address, instruction::create_associated_token_account_idempotent,
+};
 
 use super::s3;
 
@@ -53,11 +61,25 @@ use super::s3;
 /// `ShredDistribution` batch; journal batches at 3 mints fit in 3 chunks.
 const DISTRIBUTE_LOOKBACK_EPOCHS: u64 = 100;
 
+/// Max in-flight S3 fetches during the leaf-discovery fan-out. The full
+/// lookback at typical S3 latencies (~50-200 ms per request) is
+/// 5-20 seconds wall-clock when sequential; 8 concurrent fetches cuts
+/// that roughly 8x while staying polite to S3.
+const S3_FETCH_CONCURRENCY: usize = 8;
+
+/// Counters surfaced at the end of a distribute pass. The three counters
+/// have **different units** on purpose — read the summary line, not the
+/// raw struct:
+/// - `submits_succeeded` / `submits_failed`: per-`(epoch, mint)` tx
+///   submission. One epoch can contribute up to 3 of either.
+/// - `epochs_unsettled`: per-epoch. Fires when the pass ended without any
+///   successful distribute for this leaf in that epoch (covers both
+///   "nothing eligible to do" and "tried and all submits failed").
 #[derive(Debug, Default)]
 pub struct DistributeOutcome {
-    pub successful: u32,
-    pub skipped: u32,
-    pub failed: u32,
+    pub submits_succeeded: u32,
+    pub submits_failed: u32,
+    pub epochs_unsettled: u32,
 }
 
 /// Per-(epoch, leaf) bundle of everything needed to build a distribute tx
@@ -72,17 +94,20 @@ struct Candidate {
 
 pub async fn try_distribute_pending(
     wallet: &Wallet,
+    solana_connection: &SolanaConnection,
     node_id: &Pubkey,
     rewards_token_owner_key: &Pubkey,
-    rewards_token_mint_key: &Pubkey,
     network_env: NetworkEnvironment,
 ) -> Result<DistributeOutcome> {
-    let current_epoch = wallet
-        .connection
+    // `wallet.connection` is the DZ-Ledger RPC (program host). Its epoch
+    // is the DZ-Ledger epoch, which has no relation to the Solana epoch
+    // on testnet/localnet. `subscription_epoch` PDAs and S3 file names
+    // are Solana-epoch keyed, so we must ask a Solana RPC.
+    let current_epoch = solana_connection
         .0
         .get_epoch_info()
         .await
-        .context("fetching current epoch")?
+        .context("fetching current Solana epoch")?
         .epoch;
     let from_epoch = current_epoch.saturating_sub(DISTRIBUTE_LOOKBACK_EPOCHS);
 
@@ -96,9 +121,6 @@ pub async fn try_distribute_pending(
     let usdc_mint_key = environment_usdc_token_mint_key(network_env);
     let wsol_mint_key = spl_token_interface::native_mint::ID;
     let journal_mint_candidates = [dz_mint_key, usdc_mint_key, wsol_mint_key];
-    let _ = rewards_token_mint_key; // kept in signature for callers that want
-    // to log it; not load-bearing now that we
-    // probe all three mints.
 
     let mut outcome = DistributeOutcome::default();
 
@@ -138,45 +160,82 @@ pub async fn try_distribute_pending(
     // ----- Step 2: fan out S3 to find this validator's leaf per epoch -----
 
     let s3_client = s3::build_s3_client()?;
+
+    // Issue all S3 fetches concurrently (capped at `S3_FETCH_CONCURRENCY`),
+    // carrying the `shred_distribution` reference alongside the fetch
+    // result so the post-fetch loop doesn't have to re-scan
+    // `accumulated`. `reqwest::Client` clones are Arc-cheap. Each tuple
+    // element: `(epoch, &shred_distribution, fetch_result)`.
+    let mut fetch_results = stream::iter(accumulated.iter())
+        .map(|(epoch, shred_distribution)| {
+            let s3_client = s3_client.clone();
+            async move {
+                let result = s3::fetch_leader_slot_data(&s3_client, *epoch).await;
+                (*epoch, shred_distribution, result)
+            }
+        })
+        .buffer_unordered(S3_FETCH_CONCURRENCY)
+        .collect::<Vec<_>>()
+        .await;
+    // `buffer_unordered` yields in completion order; sort ascending by
+    // epoch so the per-epoch logs below print chronologically.
+    fetch_results.sort_by_key(|(epoch, _, _)| *epoch);
+
     let mut candidates: Vec<Candidate> = Vec::new();
-    for (epoch, _shred_distribution) in &accumulated {
-        let entries = match s3::fetch_leader_slot_data(&s3_client, *epoch).await {
+    for (epoch, shred_distribution, fetch_result) in fetch_results {
+        let entries = match fetch_result {
             Ok(entries) => entries,
             Err(err) => {
                 eprintln!("  epoch {epoch}: failed to fetch S3 leaves: {err:#}");
-                outcome.failed += 1;
+                outcome.epochs_unsettled += 1;
                 continue;
             }
         };
-        let leaves = match s3::compute_leaves_with_proofs(&entries) {
-            Ok(leaves) => leaves,
+        // Build the sorted leaf set once per epoch, then compute proofs
+        // ONLY for the leaves matching this validator. With ~1500
+        // validators per epoch × 100 epochs of lookback, computing all
+        // proofs up front would be tens of millions of SHA-256 ops per
+        // configure call; this restricts us to O(log N) work per matched
+        // leaf (typically 1, occasionally 2+ for multi-client-id
+        // validators).
+        let computed = match s3::compute_leaves(&entries) {
+            Ok(c) => c,
             Err(err) => {
-                eprintln!("  epoch {epoch}: failed to compute merkle proofs: {err:#}");
-                outcome.failed += 1;
+                eprintln!("  epoch {epoch}: failed to compute merkle leaves: {err:#}");
+                outcome.epochs_unsettled += 1;
                 continue;
             }
         };
-        let Some(leaf_index) = leaves
-            .leaves
-            .iter()
-            .position(|leaf| &leaf.node_id == node_id)
-        else {
-            // Validator wasn't a leader this epoch; silent skip (no work
-            // to do, not an error).
-            continue;
-        };
-        let shred_distribution = accumulated
-            .iter()
-            .find(|(e, _)| e == epoch)
-            .map(|(_, sd)| sd)
-            .expect("epoch was just iterated from `accumulated`");
-        candidates.push(Candidate {
-            subscription_epoch: *epoch,
-            associated_dz_epoch: shred_distribution.associated_dz_epoch.value(),
-            leaf_index,
-            leaf: leaves.leaves[leaf_index],
-            proof: leaves.proofs[leaf_index].clone(),
-        });
+        // A validator can legitimately appear under multiple client_ids
+        // in the same epoch — the leaf schema's dedup key is
+        // `(node_id, client_id)`, not `node_id` alone. Each `(node_id,
+        // client_id)` leaf has its own merkle proof and its own bit in
+        // the journal's bitmap, so we emit one `Candidate` per match
+        // here. Downstream batching and the per-leaf bitmap check
+        // already handle each `Candidate` independently.
+        for (leaf_index, leaf) in computed.leaves.iter().enumerate() {
+            if &leaf.node_id != node_id {
+                continue;
+            }
+            let proof = match s3::compute_proof_for_leaf(&computed.leaves, leaf_index) {
+                Ok(proof) => proof,
+                Err(err) => {
+                    eprintln!(
+                        "  epoch {epoch} leaf {leaf_index}: failed to compute proof: {err:#}"
+                    );
+                    continue;
+                }
+            };
+            candidates.push(Candidate {
+                subscription_epoch: epoch,
+                associated_dz_epoch: shred_distribution.associated_dz_epoch.value(),
+                leaf_index,
+                leaf: *leaf,
+                proof,
+            });
+        }
+        // If no leaves matched, the validator wasn't a leader this
+        // epoch — silent skip (no work to do, not an error).
     }
 
     if candidates.is_empty() {
@@ -248,14 +307,54 @@ pub async fn try_distribute_pending(
         .await
         .context("fetching claim holding accounts")?;
 
-    // ----- Step 6: in-memory decision loop, submit per (epoch, mint) -----
+    // ----- Step 6: pre-fetch destination ATAs + cache the blockhash -----
+    //
+    // Across the entire pass there are at most three distinct
+    // destination ATAs (one per candidate reward mint:
+    // `get_associated_token_address(rewards_token_owner_key, mint)`).
+    // Probe them once via a single `getMultipleAccounts` so per-tx
+    // we only emit `create_associated_token_account_idempotent` when
+    // the destination is actually missing — saves ~25k CU per tx that
+    // would otherwise pay the SPL Token existence check on a no-op
+    // create. The set is mutated as freshly-created ATAs land.
+    //
+    // The blockhash is also cached once. `new_transaction` normally
+    // calls `getLatestBlockhash` per tx; for ~300 distribute txs that's
+    // 300 redundant RPCs. Blockhashes stay valid for ~60-90 s, well
+    // above this pass's wall time; on `BlockhashNotFound` at submit the
+    // operator re-runs (the pass is idempotent).
+    let candidate_destination_atas: Vec<Pubkey> = journal_mint_candidates
+        .iter()
+        .map(|mint| get_associated_token_address(rewards_token_owner_key, mint))
+        .collect();
+    let candidate_destination_ata_accounts = wallet
+        .connection
+        .try_fetch_multiple_accounts(&candidate_destination_atas)
+        .await
+        .context("pre-fetching destination ATAs")?;
+    let mut known_existing_atas: HashSet<Pubkey> = candidate_destination_atas
+        .iter()
+        .zip(candidate_destination_ata_accounts.iter())
+        .filter_map(|(ata, account)| (!account.data.is_empty()).then_some(*ata))
+        .collect();
+
+    let cached_blockhash = wallet
+        .connection
+        .get_latest_blockhash()
+        .await
+        .context("fetching cached blockhash for distribute pass")?;
+
+    // ----- Step 7: in-memory decision loop, submit per (epoch, mint) -----
     //
     // `InitializeClaimHolding` is idempotent on-chain but a re-issued init
-    // still costs a CPI and tx bytes. Track which epochs we've already
-    // emitted an init for in this pass so subsequent (epoch, mint) txs
-    // skip it.
+    // still costs a CPI and tx bytes. Dedup by `(epoch, client_id)` —
+    // the claim_holding PDA is seeded by `validator_client_rewards_key`
+    // (per-client_id) + epoch + 2Z mint, so a validator that appears
+    // under two client_ids in the same epoch has TWO separate claim
+    // holdings and needs an init for each. Keying by epoch alone would
+    // wrongly skip the second init.
 
-    let mut emitted_init_for_epoch: HashSet<u64> = HashSet::new();
+    let mut emitted_init_for_holding: HashSet<(u64, u16)> = HashSet::new();
 
     for (candidate_index, candidate) in candidates.iter().enumerate() {
         // Parent distribution gate.
@@ -266,7 +365,7 @@ pub async fn try_distribute_pending(
                 "  epoch {}: skipped — parent distribution missing",
                 candidate.subscription_epoch
             );
-            outcome.skipped += 1;
+            outcome.epochs_unsettled += 1;
             continue;
         }
         let parent_distribution: ZeroCopyAccountOwnedData<ParentDistribution> =
@@ -277,7 +376,7 @@ pub async fn try_distribute_pending(
                         "  epoch {}: skipped — parent distribution malformed",
                         candidate.subscription_epoch
                     );
-                    outcome.skipped += 1;
+                    outcome.epochs_unsettled += 1;
                     continue;
                 }
             };
@@ -286,7 +385,7 @@ pub async fn try_distribute_pending(
                 "  epoch {}: skipped — parent rewards not finalized",
                 candidate.subscription_epoch
             );
-            outcome.skipped += 1;
+            outcome.epochs_unsettled += 1;
             continue;
         }
 
@@ -322,8 +421,13 @@ pub async fn try_distribute_pending(
                 continue;
             }
 
-            let needs_init = !claim_holding_exists
-                && !emitted_init_for_epoch.contains(&candidate.subscription_epoch);
+            let init_key = (candidate.subscription_epoch, candidate.leaf.client_id);
+            let needs_init = !claim_holding_exists && !emitted_init_for_holding.contains(&init_key);
+            let destination_ata = get_associated_token_address(
+                rewards_token_owner_key,
+                &publisher_journal.reward_mint_key,
+            );
+            let needs_ata_create = !known_existing_atas.contains(&destination_ata);
             match submit_distribute_tx(
                 wallet,
                 candidate,
@@ -333,14 +437,20 @@ pub async fn try_distribute_pending(
                 node_id,
                 &dz_mint_key,
                 needs_init,
+                needs_ata_create,
+                cached_blockhash,
             )
             .await
             {
                 Ok(()) => {
-                    outcome.successful += 1;
+                    outcome.submits_succeeded += 1;
                     any_distributed_this_epoch = true;
                     if needs_init {
-                        emitted_init_for_epoch.insert(candidate.subscription_epoch);
+                        emitted_init_for_holding.insert(init_key);
+                    }
+                    if needs_ata_create {
+                        // Now-created ATA exists for the rest of the pass.
+                        known_existing_atas.insert(destination_ata);
                     }
                 }
                 Err(error) => {
@@ -348,23 +458,25 @@ pub async fn try_distribute_pending(
                         "  epoch {} mint {publisher_mint}: failed: {error:#}",
                         candidate.subscription_epoch
                     );
-                    outcome.failed += 1;
+                    outcome.submits_failed += 1;
                 }
             }
         }
 
         if !any_distributed_this_epoch {
-            outcome.skipped += 1;
+            outcome.epochs_unsettled += 1;
         }
     }
 
-    println!(
-        "\nDistribute pass complete: {} succeeded, {} skipped, {} failed.",
-        outcome.successful, outcome.skipped, outcome.failed,
-    );
     Ok(outcome)
 }
 
+// Builds and submits one distribute tx. The CLI version check is NOT
+// prepended here — the configure tx that ran before this pass already
+// enforced version compatibility for the operator session, so re-running
+// it ~300 times during the pass is wasted CU. Future callers that invoke
+// `try_distribute_pending` outside the configure flow are responsible for
+// running their own version gate at the top of the pass.
 #[allow(clippy::too_many_arguments)]
 async fn submit_distribute_tx(
     wallet: &Wallet,
@@ -375,9 +487,10 @@ async fn submit_distribute_tx(
     node_id: &Pubkey,
     dz_mint_key: &Pubkey,
     needs_init: bool,
+    needs_ata_create: bool,
+    recent_blockhash: Hash,
 ) -> Result<()> {
-    let mut instructions: Vec<Instruction> =
-        vec![super::super::build_check_cli_version_instruction()?];
+    let mut instructions: Vec<Instruction> = Vec::new();
 
     if needs_init {
         let init_ix = try_build_instruction(
@@ -398,22 +511,17 @@ async fn submit_distribute_tx(
     // configured mint when we're distributing from a journal seeded
     // historically against a different mint. `configure` only creates the
     // ATA for the current mint, so we (idempotently) create whatever
-    // destination this specific tx needs. No-op when it already exists.
-    instructions.push(create_associated_token_account_idempotent(
-        &wallet.pubkey(),
-        rewards_token_owner_key,
-        &publisher_journal.reward_mint_key,
-        &spl_token_interface::ID,
-    ));
-
-    // Omit-rule: when the validator's publisher mint is already 2Z, the
-    // publisher journal also plays the client role. Signal that to the
-    // account-builder by passing `None`.
-    let client_mint_arg = if publisher_mint_key == dz_mint_key {
-        None
-    } else {
-        Some(dz_mint_key)
-    };
+    // destination this specific tx needs. Skipped when we already know
+    // the destination ATA exists (pre-fetched at the top of the pass,
+    // plus any ATA freshly created earlier in the same pass).
+    if needs_ata_create {
+        instructions.push(create_associated_token_account_idempotent(
+            &wallet.pubkey(),
+            rewards_token_owner_key,
+            &publisher_journal.reward_mint_key,
+            &spl_token_interface::ID,
+        ));
+    }
 
     let distribute_ix = try_build_instruction(
         &ID,
@@ -425,7 +533,9 @@ async fn submit_distribute_tx(
             rewards_token_owner_key,
             publisher_mint_key,
             publisher_reward_mint_key: &publisher_journal.reward_mint_key,
-            client_mint_key: client_mint_arg,
+            // Builder applies the omit-rule when this equals
+            // `publisher_mint_key`.
+            client_mint_key: dz_mint_key,
         },
         &ShredSubscriptionInstructionData::DistributeValidatorRewards {
             leader_slots: candidate.leaf.leader_slots,
@@ -435,16 +545,33 @@ async fn submit_distribute_tx(
     instructions.push(distribute_ix);
 
     // Per-ix headroom: ~30k init_claim_holding (only when `needs_init`),
-    // ~25k create_ata_idempotent (no-op if the ATA already exists, but the
-    // SPL Token program's existence check still costs some CU), ~150k
+    // ~25k create_ata_idempotent (only when `needs_ata_create`), ~150k
     // distribute. Same upper bounds as the admin command's submission loop.
-    let cu_limit = if needs_init { 205_000 } else { 175_000 };
+    let cu_limit =
+        150_000 + if needs_init { 30_000 } else { 0 } + if needs_ata_create { 25_000 } else { 0 };
     instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(cu_limit));
     if let Some(ref compute_unit_price_ix) = wallet.compute_unit_price_ix {
         instructions.push(compute_unit_price_ix.clone());
     }
 
-    let transaction = wallet.new_transaction(&instructions).await?;
+    // Inlined tx build (replaces `wallet.new_transaction`) so we can reuse
+    // the cached blockhash and skip the per-tx `getLatestBlockhash` RPC.
+    // Signer assembly mirrors `Wallet::new_transaction_with_additional_signers_and_lookup_tables`:
+    // when `--fee-payer` is set it signs first; the `-k` signer is added
+    // only if its pubkey differs from the fee payer's.
+    let mut signers: Vec<&Keypair> = Vec::with_capacity(2);
+    match wallet.fee_payer {
+        Some(ref fee_payer) => {
+            signers.push(fee_payer);
+            if wallet.signer.pubkey() != fee_payer.pubkey() {
+                signers.push(&wallet.signer);
+            }
+        }
+        None => {
+            signers.push(&wallet.signer);
+        }
+    }
+    let transaction = try_new_transaction(&instructions, &signers, &[], recent_blockhash)?;
     let tx_outcome = wallet.send_or_simulate_transaction(&transaction).await?;
     if let TransactionOutcome::Executed(tx_sig) = tx_outcome {
         println!(
@@ -490,5 +617,40 @@ mod tests {
     #[test]
     fn test_bitmap_bit_set_empty() {
         assert!(!bitmap_bit_set(&[], 0));
+    }
+
+    /// Mirrors on-chain `try_process_remaining_data_leaf_index` (see
+    /// `programs/shred-subscription/src/processor/common.rs`) byte-for-byte:
+    /// `bitmap[leaf_index / 8] |= 1 << (leaf_index % 8)` (LSB-first within
+    /// the byte, via `ByteFlags::set_bit`). If the on-chain accumulate ix
+    /// ever changes either the byte indexing or the bit ordering, update
+    /// this helper to match — the parity test below will then fail until
+    /// `bitmap_bit_set` is brought back in sync.
+    fn set_leaf_accumulated_onchain_style(bitmap: &mut [u8], leaf_index: u32) {
+        let byte_index = (leaf_index as usize) / 8;
+        let bit_index = (leaf_index as usize) % 8;
+        bitmap[byte_index] |= 1 << bit_index;
+    }
+
+    #[test]
+    fn bitmap_bit_set_matches_onchain_accumulate_convention() {
+        // Build a bitmap by following the on-chain accumulate steps for a
+        // chosen set of leaf indices, then verify our reader sees exactly
+        // those bits set. Indices are deliberately sparse across byte
+        // boundaries (0, 7, 8 hit the byte-boundary edge; 64, 100, 127
+        // exercise sparse high indices).
+        let mut bitmap = vec![0u8; 16];
+        let accumulated_indices: &[u32] = &[0, 3, 7, 8, 9, 17, 64, 100, 127];
+        for &leaf_index in accumulated_indices {
+            set_leaf_accumulated_onchain_style(&mut bitmap, leaf_index);
+        }
+        for leaf_index in 0u32..128 {
+            let expected = accumulated_indices.contains(&leaf_index);
+            assert_eq!(
+                bitmap_bit_set(&bitmap, leaf_index as usize),
+                expected,
+                "leaf_index {leaf_index}"
+            );
+        }
     }
 }

--- a/crates/solana-cli/src/command/shreds/publisher_rewards/mod.rs
+++ b/crates/solana-cli/src/command/shreds/publisher_rewards/mod.rs
@@ -1,7 +1,9 @@
 pub mod configure;
+pub mod distribute;
 pub mod init;
 pub mod prepare_offchain_message;
 pub mod rewards_mint_arg;
+pub mod s3;
 pub mod show;
 
 use anyhow::{Context, Result, bail};

--- a/crates/solana-cli/src/command/shreds/publisher_rewards/s3.rs
+++ b/crates/solana-cli/src/command/shreds/publisher_rewards/s3.rs
@@ -1,0 +1,210 @@
+// VENDORED from `malbeclabs/doublezero-shreds`:
+// `crates/shred-oracle/src/validator_rewards/s3.rs`. Kept in sync by hand
+// because offchain only needs the S3 fetch + merkle-tree primitives, not the
+// rest of the oracle. Remove this file once the shreds repo is merged into
+// the monorepo and we can depend on `doublezero_shred_oracle::validator_rewards::s3`
+// directly.
+
+use std::{str::FromStr, time::Duration};
+
+use anyhow::{Context, Result, ensure};
+use doublezero_solana_sdk::{
+    Pubkey,
+    merkle::{MerkleProof, merkle_root_from_indexed_pod_leaves},
+    sha2::Hash,
+    shred_subscription::types::ValidatorRewardsLeaf,
+};
+use reqwest::Client;
+use serde::Deserialize;
+use tracing::debug;
+
+pub const S3_BASE_URL: &str = "https://doublezero-foundation-public.s3.us-east-2.amazonaws.com/exports/multicast_validator_leader_slots";
+
+pub fn build_s3_client() -> Result<Client> {
+    Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .context("build S3 reqwest client")
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)] // `epoch` is in the wire format but unused offchain (URL carries it).
+pub struct ValidatorLeaderSlotEntry {
+    pub epoch: u64,
+    pub node_identity: String,
+    pub client_id: u16,
+    pub number_of_leader_slots: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct ComputedLeaves {
+    pub leaves: Vec<ValidatorRewardsLeaf>,
+    pub root: Hash,
+    pub total_publishing_validators: u32,
+    pub total_published_leader_slots: u32,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // `root` + totals are kept for parity with the canonical impl; not used offchain today.
+pub struct DistributionLeaves {
+    pub leaves: Vec<ValidatorRewardsLeaf>,
+    pub proofs: Vec<MerkleProof>,
+    pub root: Hash,
+    pub total_publishing_validators: u32,
+    pub total_published_leader_slots: u32,
+}
+
+pub async fn fetch_leader_slot_data(
+    client: &Client,
+    solana_epoch: u64,
+) -> Result<Vec<ValidatorLeaderSlotEntry>> {
+    let url = format!("{S3_BASE_URL}/{solana_epoch}.json");
+    debug!(url, "Fetching validator leader-slot data");
+
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .with_context(|| format!("HTTP request to {url}"))?;
+
+    ensure!(
+        response.status().is_success(),
+        "S3 returned status {} for epoch {solana_epoch}",
+        response.status(),
+    );
+
+    let entries = response
+        .json::<Vec<ValidatorLeaderSlotEntry>>()
+        .await
+        .with_context(|| format!("deserialize leader-slot JSON for epoch {solana_epoch}"))?;
+
+    debug!(count = entries.len(), "Fetched validator entries");
+    Ok(entries)
+}
+
+pub fn compute_leaves(entries: &[ValidatorLeaderSlotEntry]) -> Result<ComputedLeaves> {
+    ensure!(!entries.is_empty(), "no validator entries to compute root");
+
+    let mut leaves = entries
+        .iter()
+        .filter_map(|entry| {
+            let pubkey = Pubkey::from_str(&entry.node_identity).ok()?;
+            Some(ValidatorRewardsLeaf::new(
+                pubkey,
+                entry.number_of_leader_slots,
+                entry.client_id,
+            ))
+        })
+        .collect::<Vec<_>>();
+
+    leaves.sort_unstable_by_key(|l| (l.node_id, l.client_id));
+
+    if let Some(pair) = leaves
+        .windows(2)
+        .find(|w| w[0].node_id == w[1].node_id && w[0].client_id == w[1].client_id)
+    {
+        anyhow::bail!(
+            "duplicate (node_id, client_id) pair: node_id {}, client_id {} in validator leader-slot data",
+            pair[0].node_id,
+            pair[0].client_id,
+        );
+    }
+
+    let total = <u32>::try_from(leaves.len()).context("too many validators")?;
+    ensure!(total > 0, "no valid validator entries after filtering");
+
+    let total_published_leader_slots = leaves.iter().map(|leaf| leaf.leader_slots).try_fold(
+        u32::default(),
+        |running_total, slots| {
+            running_total
+                .checked_add(slots)
+                .context("total published leader slots overflow")
+        },
+    )?;
+
+    let root =
+        merkle_root_from_indexed_pod_leaves(&leaves, Some(ValidatorRewardsLeaf::LEAF_PREFIX))
+            .context("failed to compute merkle root")?;
+
+    Ok(ComputedLeaves {
+        leaves,
+        root,
+        total_publishing_validators: total,
+        total_published_leader_slots,
+    })
+}
+
+pub fn compute_leaves_with_proofs(
+    entries: &[ValidatorLeaderSlotEntry],
+) -> Result<DistributionLeaves> {
+    let ComputedLeaves {
+        leaves,
+        root,
+        total_publishing_validators,
+        total_published_leader_slots,
+    } = compute_leaves(entries)?;
+
+    let proofs = (0..total_publishing_validators)
+        .map(|i| {
+            MerkleProof::from_indexed_pod_leaves(
+                &leaves,
+                i,
+                Some(ValidatorRewardsLeaf::LEAF_PREFIX),
+            )
+            .with_context(|| format!("compute merkle proof for leaf {i}"))
+        })
+        .collect::<Result<_>>()?;
+
+    Ok(DistributionLeaves {
+        leaves,
+        proofs,
+        root,
+        total_publishing_validators,
+        total_published_leader_slots,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_entry(identity: &str, client_id: u16, slots: u32) -> ValidatorLeaderSlotEntry {
+        ValidatorLeaderSlotEntry {
+            epoch: 951,
+            node_identity: identity.to_string(),
+            client_id,
+            number_of_leader_slots: slots,
+        }
+    }
+
+    #[test]
+    fn test_compute_leaves_with_proofs_returns_sorted_leaves_and_valid_proofs() {
+        let pk1 = Pubkey::new_unique();
+        let pk2 = Pubkey::new_unique();
+        let pk3 = Pubkey::new_unique();
+        let entries = vec![
+            make_entry(&pk2.to_string(), 2, 200),
+            make_entry(&pk1.to_string(), 1, 100),
+            make_entry(&pk3.to_string(), 3, 300),
+        ];
+
+        let distribution_leaves = compute_leaves_with_proofs(&entries).unwrap();
+
+        assert_eq!(distribution_leaves.leaves.len(), 3);
+        assert_eq!(distribution_leaves.proofs.len(), 3);
+        assert_eq!(distribution_leaves.total_publishing_validators, 3);
+        assert_eq!(distribution_leaves.total_published_leader_slots, 600);
+
+        assert!(distribution_leaves.leaves[0].node_id < distribution_leaves.leaves[1].node_id);
+        assert!(distribution_leaves.leaves[1].node_id < distribution_leaves.leaves[2].node_id);
+
+        for (i, proof) in distribution_leaves.proofs.iter().enumerate() {
+            let reconstructed = proof.root_from_pod_leaf(
+                &distribution_leaves.leaves[i],
+                Some(ValidatorRewardsLeaf::LEAF_PREFIX),
+            );
+            assert_eq!(reconstructed, distribution_leaves.root);
+        }
+    }
+}

--- a/crates/solana-cli/src/command/shreds/publisher_rewards/s3.rs
+++ b/crates/solana-cli/src/command/shreds/publisher_rewards/s3.rs
@@ -16,7 +16,7 @@ use doublezero_solana_sdk::{
 };
 use reqwest::Client;
 use serde::Deserialize;
-use tracing::debug;
+use tracing::{debug, warn};
 
 pub const S3_BASE_URL: &str = "https://doublezero-foundation-public.s3.us-east-2.amazonaws.com/exports/multicast_validator_leader_slots";
 
@@ -38,18 +38,9 @@ pub struct ValidatorLeaderSlotEntry {
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)] // `root` + totals are kept for parity with the canonical impl; not used offchain today.
 pub struct ComputedLeaves {
     pub leaves: Vec<ValidatorRewardsLeaf>,
-    pub root: Hash,
-    pub total_publishing_validators: u32,
-    pub total_published_leader_slots: u32,
-}
-
-#[derive(Debug, Clone)]
-#[allow(dead_code)] // `root` + totals are kept for parity with the canonical impl; not used offchain today.
-pub struct DistributionLeaves {
-    pub leaves: Vec<ValidatorRewardsLeaf>,
-    pub proofs: Vec<MerkleProof>,
     pub root: Hash,
     pub total_publishing_validators: u32,
     pub total_published_leader_slots: u32,
@@ -88,13 +79,23 @@ pub fn compute_leaves(entries: &[ValidatorLeaderSlotEntry]) -> Result<ComputedLe
 
     let mut leaves = entries
         .iter()
-        .filter_map(|entry| {
-            let pubkey = Pubkey::from_str(&entry.node_identity).ok()?;
-            Some(ValidatorRewardsLeaf::new(
+        .filter_map(|entry| match Pubkey::from_str(&entry.node_identity) {
+            Ok(pubkey) => Some(ValidatorRewardsLeaf::new(
                 pubkey,
                 entry.number_of_leader_slots,
                 entry.client_id,
-            ))
+            )),
+            Err(err) => {
+                warn!(
+                    node_identity = %entry.node_identity,
+                    client_id = entry.client_id,
+                    %err,
+                    "dropping entry with unparseable node_identity \
+                     (must match canonical oracle; if this is a real \
+                     validator the merkle root will diverge from on-chain)"
+                );
+                None
+            }
         })
         .collect::<Vec<_>>();
 
@@ -135,34 +136,32 @@ pub fn compute_leaves(entries: &[ValidatorLeaderSlotEntry]) -> Result<ComputedLe
     })
 }
 
-pub fn compute_leaves_with_proofs(
-    entries: &[ValidatorLeaderSlotEntry],
-) -> Result<DistributionLeaves> {
-    let ComputedLeaves {
-        leaves,
-        root,
-        total_publishing_validators,
-        total_published_leader_slots,
-    } = compute_leaves(entries)?;
+// ---------------------------------------------------------------------------
+// OFFCHAIN-ONLY ADDITIONS (not in canonical doublezero-shreds).
+// These helpers layer on top of the vendored primitives above for offchain
+// CLI use. When the shreds repo merges into the monorepo, decide whether
+// to upstream these or fold them back into the caller.
+// ---------------------------------------------------------------------------
 
-    let proofs = (0..total_publishing_validators)
-        .map(|i| {
-            MerkleProof::from_indexed_pod_leaves(
-                &leaves,
-                i,
-                Some(ValidatorRewardsLeaf::LEAF_PREFIX),
-            )
-            .with_context(|| format!("compute merkle proof for leaf {i}"))
-        })
-        .collect::<Result<_>>()?;
-
-    Ok(DistributionLeaves {
+/// Compute the merkle proof for a single leaf at `leaf_index` against the
+/// sorted leaf set returned by [`compute_leaves`]. Per-leaf cost is
+/// O(log N), so callers that only need a few proofs out of a tree pay
+/// proportionally — for the post-configure distribute pass at ~1500
+/// validators × 100 epochs of lookback, that's ~10 ops per matched leaf
+/// instead of the ~16k ops per epoch a build-every-proof approach would
+/// cost.
+pub fn compute_proof_for_leaf(
+    leaves: &[ValidatorRewardsLeaf],
+    leaf_index: usize,
+) -> Result<MerkleProof> {
+    let leaf_index_u32 =
+        u32::try_from(leaf_index).context("leaf_index too large for merkle proof")?;
+    MerkleProof::from_indexed_pod_leaves(
         leaves,
-        proofs,
-        root,
-        total_publishing_validators,
-        total_published_leader_slots,
-    })
+        leaf_index_u32,
+        Some(ValidatorRewardsLeaf::LEAF_PREFIX),
+    )
+    .with_context(|| format!("compute merkle proof for leaf {leaf_index}"))
 }
 
 #[cfg(test)]
@@ -178,8 +177,41 @@ mod tests {
         }
     }
 
+    /// PARITY PIN: canonical oracle's `compute_leaves` silently drops
+    /// entries whose `node_identity` doesn't parse as a Pubkey. This
+    /// test pins the same behavior in our offchain mirror — if a future
+    /// PR changes `compute_leaves` to hard-fail on bad parses, this
+    /// test fails and forces the author to also update the canonical
+    /// (or document why the divergence is acceptable).
     #[test]
-    fn test_compute_leaves_with_proofs_returns_sorted_leaves_and_valid_proofs() {
+    fn compute_leaves_drops_unparseable_pubkeys_silently() {
+        let valid_pubkey = Pubkey::new_unique();
+        let entries = vec![
+            make_entry(&valid_pubkey.to_string(), 1, 100),
+            // Two clearly unparseable entries — different malformations
+            // to exercise both lengths/charsets.
+            make_entry("not-a-pubkey", 2, 200),
+            make_entry("", 3, 300),
+        ];
+        let computed =
+            compute_leaves(&entries).expect("valid entry survives; bad entries are dropped");
+        assert_eq!(
+            computed.leaves.len(),
+            1,
+            "only the valid entry should remain"
+        );
+        assert_eq!(computed.leaves[0].node_id, valid_pubkey);
+        assert_eq!(computed.total_publishing_validators, 1);
+        assert_eq!(computed.total_published_leader_slots, 100);
+    }
+
+    /// End-to-end check of the offchain proof path: build the sorted
+    /// leaf set, then assert each per-leaf proof reconstructs the same
+    /// root that `compute_leaves` produced. This is the contract that
+    /// matters on-chain — the distribute ix verifies leaves against the
+    /// posted root via these proofs.
+    #[test]
+    fn compute_proof_for_leaf_reconstructs_root() {
         let pk1 = Pubkey::new_unique();
         let pk2 = Pubkey::new_unique();
         let pk3 = Pubkey::new_unique();
@@ -189,22 +221,21 @@ mod tests {
             make_entry(&pk3.to_string(), 3, 300),
         ];
 
-        let distribution_leaves = compute_leaves_with_proofs(&entries).unwrap();
+        let computed = compute_leaves(&entries).unwrap();
 
-        assert_eq!(distribution_leaves.leaves.len(), 3);
-        assert_eq!(distribution_leaves.proofs.len(), 3);
-        assert_eq!(distribution_leaves.total_publishing_validators, 3);
-        assert_eq!(distribution_leaves.total_published_leader_slots, 600);
+        assert_eq!(computed.leaves.len(), 3);
+        assert_eq!(computed.total_publishing_validators, 3);
+        assert_eq!(computed.total_published_leader_slots, 600);
+        // Sorted by (node_id, client_id) — secondary key is irrelevant
+        // here since all three node_ids differ.
+        assert!(computed.leaves[0].node_id < computed.leaves[1].node_id);
+        assert!(computed.leaves[1].node_id < computed.leaves[2].node_id);
 
-        assert!(distribution_leaves.leaves[0].node_id < distribution_leaves.leaves[1].node_id);
-        assert!(distribution_leaves.leaves[1].node_id < distribution_leaves.leaves[2].node_id);
-
-        for (i, proof) in distribution_leaves.proofs.iter().enumerate() {
-            let reconstructed = proof.root_from_pod_leaf(
-                &distribution_leaves.leaves[i],
-                Some(ValidatorRewardsLeaf::LEAF_PREFIX),
-            );
-            assert_eq!(reconstructed, distribution_leaves.root);
+        for (leaf_index, leaf) in computed.leaves.iter().enumerate() {
+            let proof = compute_proof_for_leaf(&computed.leaves, leaf_index).unwrap();
+            let reconstructed =
+                proof.root_from_pod_leaf(leaf, Some(ValidatorRewardsLeaf::LEAF_PREFIX));
+            assert_eq!(reconstructed, computed.root, "leaf_index {leaf_index}");
         }
     }
 }

--- a/crates/solana-sdk/src/shred_subscription/instruction/account.rs
+++ b/crates/solana-sdk/src/shred_subscription/instruction/account.rs
@@ -601,6 +601,161 @@ impl From<ConfigureValidatorPublisherRewardsAccounts> for Vec<AccountMeta> {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DistributeValidatorRewardsAccounts {
+    pub program_config_key: Pubkey,
+    pub shred_distribution_key: Pubkey,
+    pub parent_distribution_key: Pubkey,
+    pub validator_publisher_rewards_key: Pubkey,
+    pub validator_client_rewards_key: Pubkey,
+    pub validator_publisher_journal_key: Pubkey,
+    // Omitted when the publisher journal IS the client journal (omit-rule
+    // fires when `client_mint_key` equals `publisher_mint_key`). The publisher
+    // journal then plays both roles, mirroring accumulate.
+    pub validator_client_journal_key: Option<Pubkey>,
+    pub destination_ata_key: Pubkey,
+    pub shred_distribution_publisher_ata_key: Pubkey,
+    pub shred_distribution_client_ata_key: Pubkey,
+    pub client_claim_holding_key: Pubkey,
+}
+
+#[derive(Debug)]
+pub struct DistributeValidatorRewardsAccountsInitializer<'a> {
+    pub subscription_epoch: u64,
+    pub associated_dz_epoch: u64,
+    pub node_id: &'a Pubkey,
+    pub client_id: u16,
+    pub rewards_token_owner_key: &'a Pubkey,
+    pub publisher_mint_key: &'a Pubkey,
+    pub publisher_reward_mint_key: &'a Pubkey,
+    // 2Z mint for the standard configuration; `None` when the publisher
+    // journal also plays the client role (omit-rule).
+    pub client_mint_key: Option<&'a Pubkey>,
+}
+
+impl DistributeValidatorRewardsAccounts {
+    pub fn new(initializer: DistributeValidatorRewardsAccountsInitializer<'_>) -> Self {
+        let DistributeValidatorRewardsAccountsInitializer {
+            subscription_epoch,
+            associated_dz_epoch,
+            node_id,
+            client_id,
+            rewards_token_owner_key,
+            publisher_mint_key,
+            publisher_reward_mint_key,
+            client_mint_key,
+        } = initializer;
+
+        let shred_distribution_key = state::find_shred_distribution_address(subscription_epoch).0;
+        let validator_client_rewards_key =
+            state::find_validator_client_rewards_address(client_id).0;
+
+        let validator_client_journal_key = client_mint_key
+            .filter(|client_mint| *client_mint != publisher_mint_key)
+            .map(|client_mint| {
+                state::find_shred_distribution_journal_address(subscription_epoch, client_mint).0
+            });
+
+        let client_addresses_mint_key = client_mint_key
+            .filter(|client_mint| *client_mint != publisher_mint_key)
+            .unwrap_or(publisher_reward_mint_key);
+
+        Self {
+            program_config_key: state::find_program_config_address().0,
+            shred_distribution_key,
+            parent_distribution_key:
+                crate::revenue_distribution::state::Distribution::find_address(
+                    crate::revenue_distribution::types::DoubleZeroEpoch::new(associated_dz_epoch),
+                )
+                .0,
+            validator_publisher_rewards_key: state::find_validator_publisher_rewards_address(
+                node_id,
+            )
+            .0,
+            validator_client_rewards_key,
+            validator_publisher_journal_key: state::find_shred_distribution_journal_address(
+                subscription_epoch,
+                publisher_mint_key,
+            )
+            .0,
+            validator_client_journal_key,
+            destination_ata_key: get_associated_token_address(
+                rewards_token_owner_key,
+                publisher_reward_mint_key,
+            ),
+            shred_distribution_publisher_ata_key: get_associated_token_address(
+                &shred_distribution_key,
+                publisher_reward_mint_key,
+            ),
+            shred_distribution_client_ata_key: get_associated_token_address(
+                &shred_distribution_key,
+                client_addresses_mint_key,
+            ),
+            client_claim_holding_key: state::find_claim_holding_address(
+                &validator_client_rewards_key,
+                subscription_epoch,
+                client_addresses_mint_key,
+            )
+            .0,
+        }
+    }
+}
+
+impl From<DistributeValidatorRewardsAccountsInitializer<'_>>
+    for DistributeValidatorRewardsAccounts
+{
+    fn from(initializer: DistributeValidatorRewardsAccountsInitializer<'_>) -> Self {
+        Self::new(initializer)
+    }
+}
+
+impl From<DistributeValidatorRewardsAccountsInitializer<'_>> for Vec<AccountMeta> {
+    fn from(initializer: DistributeValidatorRewardsAccountsInitializer<'_>) -> Self {
+        DistributeValidatorRewardsAccounts::new(initializer).into()
+    }
+}
+
+impl From<DistributeValidatorRewardsAccounts> for Vec<AccountMeta> {
+    fn from(accounts: DistributeValidatorRewardsAccounts) -> Self {
+        let DistributeValidatorRewardsAccounts {
+            program_config_key,
+            shred_distribution_key,
+            parent_distribution_key,
+            validator_publisher_rewards_key,
+            validator_client_rewards_key,
+            validator_publisher_journal_key,
+            validator_client_journal_key,
+            destination_ata_key,
+            shred_distribution_publisher_ata_key,
+            shred_distribution_client_ata_key,
+            client_claim_holding_key,
+        } = accounts;
+
+        let mut account_metas = vec![
+            AccountMeta::new_readonly(program_config_key, false),
+            AccountMeta::new_readonly(shred_distribution_key, false),
+            AccountMeta::new_readonly(parent_distribution_key, false),
+            AccountMeta::new_readonly(validator_publisher_rewards_key, false),
+            AccountMeta::new_readonly(validator_client_rewards_key, false),
+            AccountMeta::new(validator_publisher_journal_key, false),
+        ];
+
+        if let Some(validator_client_journal_key) = validator_client_journal_key {
+            account_metas.push(AccountMeta::new(validator_client_journal_key, false));
+        }
+
+        account_metas.extend([
+            AccountMeta::new(destination_ata_key, false),
+            AccountMeta::new(shred_distribution_publisher_ata_key, false),
+            AccountMeta::new(shred_distribution_client_ata_key, false),
+            AccountMeta::new(client_claim_holding_key, false),
+            AccountMeta::new_readonly(spl_token_interface::ID, false),
+        ]);
+
+        account_metas
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/solana-sdk/src/shred_subscription/instruction/account.rs
+++ b/crates/solana-sdk/src/shred_subscription/instruction/account.rs
@@ -628,9 +628,13 @@ pub struct DistributeValidatorRewardsAccountsInitializer<'a> {
     pub rewards_token_owner_key: &'a Pubkey,
     pub publisher_mint_key: &'a Pubkey,
     pub publisher_reward_mint_key: &'a Pubkey,
-    // 2Z mint for the standard configuration; `None` when the publisher
-    // journal also plays the client role (omit-rule).
-    pub client_mint_key: Option<&'a Pubkey>,
+    /// Mint that identifies the client-side journal. In the current
+    /// protocol this is always the 2Z mint (client rewards are routed
+    /// exclusively to the 2Z journal), so every caller today passes the
+    /// 2Z mint — but the field is a generic `&Pubkey` so a future
+    /// protocol version that routes client rewards to a different mint
+    /// works without an API change.
+    pub client_mint_key: &'a Pubkey,
 }
 
 impl DistributeValidatorRewardsAccounts {
@@ -650,15 +654,20 @@ impl DistributeValidatorRewardsAccounts {
         let validator_client_rewards_key =
             state::find_validator_client_rewards_address(client_id).0;
 
-        let validator_client_journal_key = client_mint_key
-            .filter(|client_mint| *client_mint != publisher_mint_key)
-            .map(|client_mint| {
-                state::find_shred_distribution_journal_address(subscription_epoch, client_mint).0
-            });
-
-        let client_addresses_mint_key = client_mint_key
-            .filter(|client_mint| *client_mint != publisher_mint_key)
-            .unwrap_or(publisher_reward_mint_key);
+        // Omit-rule: when the publisher journal IS the client journal
+        // (their mints match), the publisher journal plays both roles and
+        // the client-side journal account drops out of the meta list.
+        // Otherwise the client side has its own journal at the 2Z mint,
+        // and the client-side ATA / claim_holding use the 2Z mint too.
+        let client_side_present = client_mint_key != publisher_mint_key;
+        let validator_client_journal_key = client_side_present.then(|| {
+            state::find_shred_distribution_journal_address(subscription_epoch, client_mint_key).0
+        });
+        let client_addresses_mint_key = if client_side_present {
+            client_mint_key
+        } else {
+            publisher_reward_mint_key
+        };
 
         Self {
             program_config_key: state::find_program_config_address().0,

--- a/crates/solana-sdk/src/shred_subscription/instruction/mod.rs
+++ b/crates/solana-sdk/src/shred_subscription/instruction/mod.rs
@@ -223,6 +223,14 @@ impl BorshDeserialize for ShredSubscriptionInstructionData {
                     offchain_authorization,
                 })
             }
+            Self::DISTRIBUTE_VALIDATOR_REWARDS => {
+                let leader_slots = u32::deserialize_reader(reader)?;
+                let proof = MerkleProof::deserialize_reader(reader)?;
+                Ok(Self::DistributeValidatorRewards {
+                    leader_slots,
+                    proof,
+                })
+            }
             Self::CHECK_CLI_VERSION => {
                 let major = u32::deserialize_reader(reader)?;
                 let minor = u32::deserialize_reader(reader)?;
@@ -368,6 +376,18 @@ mod tests {
                     deadline_slot: 999_888,
                     signature: [7u8; 64],
                 }),
+            },
+        );
+    }
+
+    #[test]
+    fn round_trip_distribute_validator_rewards() {
+        let leaves: [&[u8]; 2] = [b"leaf_a", b"leaf_b"];
+        let proof = MerkleProof::from_leaves(&leaves, 0, None).expect("two-leaf proof at index 0");
+        round_trip(
+            &ShredSubscriptionInstructionData::DistributeValidatorRewards {
+                leader_slots: 1_234,
+                proof,
             },
         );
     }

--- a/crates/solana-sdk/src/shred_subscription/instruction/mod.rs
+++ b/crates/solana-sdk/src/shred_subscription/instruction/mod.rs
@@ -5,6 +5,7 @@ use std::io;
 use borsh::{BorshDeserialize, BorshSerialize};
 use doublezero_program_tools::{DISCRIMINATOR_LEN, Discriminator};
 use solana_sdk::pubkey::Pubkey;
+use svm_hash::merkle::MerkleProof;
 
 /// Envelope for an offchain authorization produced by a validator operator
 /// via `solana sign-offchain-message`. Carries the ed25519 signature plus the
@@ -67,6 +68,15 @@ pub enum ShredSubscriptionInstructionData {
         rewards_token_owner_key: Pubkey,
         offchain_authorization: Option<ValidatorOffchainAuthorization>,
     },
+    /// Permissionless. Distribute a single validator's accumulated rewards
+    /// for one (subscription_epoch, journal) pair: transfers the publisher
+    /// share to the validator's destination ATA and the client share into
+    /// the per-epoch claim-holding account. Authenticates the leaf via the
+    /// merkle proof against the journal's root.
+    DistributeValidatorRewards {
+        leader_slots: u32,
+        proof: MerkleProof,
+    },
     /// Validates the provided CLI version against the onchain minimum.
     CheckCliVersion { major: u32, minor: u32, patch: u32 },
 }
@@ -96,6 +106,8 @@ impl ShredSubscriptionInstructionData {
         Discriminator::new_sha2(b"dz::ix::initialize_validator_publisher_rewards");
     pub const CONFIGURE_VALIDATOR_PUBLISHER_REWARDS: Discriminator<DISCRIMINATOR_LEN> =
         Discriminator::new_sha2(b"dz::ix::configure_validator_publisher_rewards");
+    pub const DISTRIBUTE_VALIDATOR_REWARDS: Discriminator<DISCRIMINATOR_LEN> =
+        Discriminator::new_sha2(b"dz::ix::distribute_validator_rewards");
     pub const CHECK_CLI_VERSION: Discriminator<DISCRIMINATOR_LEN> =
         Discriminator::new_sha2(b"dz::ix::check_cli_version");
 }
@@ -145,6 +157,14 @@ impl BorshSerialize for ShredSubscriptionInstructionData {
                 Self::CONFIGURE_VALIDATOR_PUBLISHER_REWARDS.serialize(writer)?;
                 rewards_token_owner_key.serialize(writer)?;
                 offchain_authorization.serialize(writer)
+            }
+            Self::DistributeValidatorRewards {
+                leader_slots,
+                proof,
+            } => {
+                Self::DISTRIBUTE_VALIDATOR_REWARDS.serialize(writer)?;
+                leader_slots.serialize(writer)?;
+                proof.serialize(writer)
             }
             Self::CheckCliVersion {
                 major,

--- a/crates/solana-sdk/src/shred_subscription/state.rs
+++ b/crates/solana-sdk/src/shred_subscription/state.rs
@@ -191,6 +191,7 @@ pub const PROGRAM_CONFIG_FLAGS_OFFSET: usize = DISCRIMINATOR_LEN;
 pub const PROGRAM_CONFIG_SHRED_ORACLE_KEY_OFFSET: usize = DISCRIMINATOR_LEN + 48;
 
 const PROGRAM_CONFIG_FLAG_IS_PRORATED_SERVICE_ENABLED_BIT: u64 = 1 << 2;
+const PROGRAM_CONFIG_FLAG_DISTRIBUTE_VALIDATOR_REWARDS_ENABLED_BIT: u64 = 1 << 5;
 
 /// Returns `true` if the `is_prorated_service_enabled` bit is set on the
 /// raw `ProgramConfig` account data. Returns `false` for accounts that are
@@ -207,6 +208,26 @@ pub fn is_prorated_service_enabled(data: &[u8]) -> bool {
     };
     let flags = u64::from_le_bytes(flags_bytes);
     flags & PROGRAM_CONFIG_FLAG_IS_PRORATED_SERVICE_ENABLED_BIT != 0
+}
+
+/// Returns `true` if the `distribute_validator_rewards_enabled` bit is set
+/// on the raw `ProgramConfig` account data. Mirrors the on-chain
+/// `ProgramConfig::FLAG_DISTRIBUTE_VALIDATOR_REWARDS_ENABLED_BIT` (bit 5).
+/// Returns `false` when the account is too short or the flag is unset —
+/// the on-chain `DistributeValidatorRewards` handler rejects with
+/// "Distribute validator rewards is disabled" in that state, so callers
+/// should skip distribute attempts when this returns `false`.
+pub fn is_distribute_validator_rewards_enabled(data: &[u8]) -> bool {
+    if data.len() < PROGRAM_CONFIG_FLAGS_OFFSET + 8 {
+        return false;
+    }
+    let Ok(flags_bytes) =
+        <[u8; 8]>::try_from(&data[PROGRAM_CONFIG_FLAGS_OFFSET..PROGRAM_CONFIG_FLAGS_OFFSET + 8])
+    else {
+        return false;
+    };
+    let flags = u64::from_le_bytes(flags_bytes);
+    flags & PROGRAM_CONFIG_FLAG_DISTRIBUTE_VALIDATOR_REWARDS_ENABLED_BIT != 0
 }
 
 /// Parse the `shred_oracle_key` from a `ProgramConfig` account. Returns
@@ -943,6 +964,28 @@ mod tests {
     #[test]
     fn prorated_enabled_empty_buffer_returns_false() {
         assert!(!is_prorated_service_enabled(&[]));
+    }
+
+    #[test]
+    fn distribute_validator_rewards_enabled_bit_set() {
+        let data = program_config_data_with_flags(
+            PROGRAM_CONFIG_FLAG_DISTRIBUTE_VALIDATOR_REWARDS_ENABLED_BIT,
+        );
+        assert!(is_distribute_validator_rewards_enabled(&data));
+    }
+
+    #[test]
+    fn distribute_validator_rewards_disabled_when_unset() {
+        // All lower bits set (paused, prorated, accumulate, jupiter) but
+        // not bit 5 — must not be mistaken for distribute-enabled.
+        let data = program_config_data_with_flags(0b01_1111);
+        assert!(!is_distribute_validator_rewards_enabled(&data));
+    }
+
+    #[test]
+    fn distribute_validator_rewards_enabled_short_buffer_returns_false() {
+        let data = vec![0u8; PROGRAM_CONFIG_FLAGS_OFFSET + 4];
+        assert!(!is_distribute_validator_rewards_enabled(&data));
     }
 
     fn client_seat_data_with_last_price(price_dollars: u16) -> Vec<u8> {

--- a/crates/solana-sdk/src/shred_subscription/state.rs
+++ b/crates/solana-sdk/src/shred_subscription/state.rs
@@ -1,12 +1,13 @@
-use std::net::Ipv4Addr;
+use std::{net::Ipv4Addr, ops::Range};
 
 use bytemuck::{Pod, Zeroable};
 use doublezero_program_tools::{
     DISCRIMINATOR_LEN, Discriminator, PrecomputedDiscriminator,
     types::{Flags, StorageGap},
 };
-use doublezero_revenue_distribution::types::UnitShare16;
+use doublezero_revenue_distribution::types::{DoubleZeroEpoch, UnitShare16};
 use solana_sdk::pubkey::Pubkey;
+use svm_hash::sha2::Hash;
 
 pub const PROGRAM_CONFIG_SEED_PREFIX: &[u8] = b"program_config";
 pub const EXECUTION_CONTROLLER_SEED_PREFIX: &[u8] = b"execution_controller";
@@ -21,6 +22,7 @@ pub const SHRED_REWARD_TOKEN_SEED_PREFIX: &[u8] = b"shred_reward_token";
 pub const INSTANT_ALLOCATION_REQUEST_SEED_PREFIX: &[u8] = b"instant_seat_allocation_request";
 pub const WITHDRAW_SEAT_REQUEST_SEED_PREFIX: &[u8] = b"withdraw_seat_request";
 pub const SHRED_DISTRIBUTION_SEED_PREFIX: &[u8] = b"shred_distribution";
+pub const SHRED_DISTRIBUTION_JOURNAL_SEED_PREFIX: &[u8] = b"shred_distribution_journal";
 pub const CLAIM_HOLDING_SEED_PREFIX: &[u8] = b"claim";
 
 pub fn find_program_config_address() -> (Pubkey, u8) {
@@ -137,6 +139,20 @@ pub fn find_shred_distribution_address(subscription_epoch: u64) -> (Pubkey, u8) 
         &[
             SHRED_DISTRIBUTION_SEED_PREFIX,
             &subscription_epoch.to_le_bytes(),
+        ],
+        &crate::shred_subscription::ID,
+    )
+}
+
+pub fn find_shred_distribution_journal_address(
+    subscription_epoch: u64,
+    mint_key: &Pubkey,
+) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[
+            SHRED_DISTRIBUTION_JOURNAL_SEED_PREFIX,
+            &subscription_epoch.to_le_bytes(),
+            mint_key.as_ref(),
         ],
         &crate::shred_subscription::ID,
     )
@@ -681,6 +697,181 @@ pub struct ValidatorPublisherRewards {
 impl PrecomputedDiscriminator for ValidatorPublisherRewards {
     const DISCRIMINATOR: Discriminator<8> =
         Discriminator::new_sha2(b"dz::account::validator_publisher_rewards");
+}
+
+// ---------------------------------------------------------------------------
+// ShredDistribution + ShredDistributionJournal + the
+// ValidatorClientRewardsConfig field they nest. Layouts mirrored from
+// `malbeclabs/doublezero-shreds` (program crate). Vendored here so the
+// offchain CLI can `bytemuck::from_bytes` these accounts without depending
+// on the shreds program crate. Remove once the shreds repo is merged into
+// the monorepo. If the on-chain layout changes, update both sides together.
+// ---------------------------------------------------------------------------
+
+pub const MAX_VALIDATOR_CLIENT_REWARDS_PROPORTIONS: usize = 32;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Pod, Zeroable)]
+#[repr(C, align(4))]
+pub struct ValidatorClientRewardsProportion {
+    pub id: u16,
+    pub rewards_proportion: UnitShare16,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Pod, Zeroable)]
+#[repr(C, align(4))]
+pub struct ValidatorClientRewardProportions {
+    pub set_bitmap: u32,
+    pub proportions: [ValidatorClientRewardsProportion; MAX_VALIDATOR_CLIENT_REWARDS_PROPORTIONS],
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Pod, Zeroable)]
+#[repr(C, align(8))]
+pub struct ValidatorClientRewardsConfig {
+    pub default_proportion: UnitShare16,
+    _padding_0: [u8; 2],
+    pub proportions: ValidatorClientRewardProportions,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Pod, Zeroable)]
+#[repr(C, align(8))]
+pub struct ShredDistribution {
+    pub subscription_epoch: u64,
+    pub flags: Flags,
+    pub associated_dz_epoch: DoubleZeroEpoch,
+    pub bump_seed: u8,
+    pub ata_usdc_bump_seed: u8,
+    pub ata_2z_bump_seed: u8,
+    _padding_0: [u8; 1],
+    pub device_count: u16,
+    pub client_seat_count: u16,
+    pub journal_count: u16,
+    pub validator_rewards_proportion: UnitShare16,
+    pub total_publishing_validators: u32,
+    pub validator_rewards_merkle_root: Hash,
+    pub collected_usdc_payments: u64,
+    pub contributor_collected_2z_converted_from_usdc: u64,
+    pub contributor_usdc_swapped: u64,
+    pub validator_client_rewards_config: ValidatorClientRewardsConfig,
+    pub accumulated_validator_rewards_count: u32,
+    _padding_1: [u8; 28],
+    pub total_published_leader_slots: u32,
+    _padding_2: [u8; 28],
+    _gap: StorageGap<3>,
+}
+
+impl PrecomputedDiscriminator for ShredDistribution {
+    const DISCRIMINATOR: Discriminator<8> =
+        Discriminator::new_sha2(b"dz::account::shred_distribution");
+}
+
+impl ShredDistribution {
+    pub const FLAG_VALIDATOR_REWARDS_CALCULATION_FINALIZED_BIT: usize = 1;
+    pub const FLAG_VALIDATOR_REWARDS_ACCUMULATED_BIT: usize = 2;
+    pub const FLAG_INTEGRATION_FUNDED_BIT: usize = 3;
+
+    #[inline]
+    pub fn is_validator_rewards_calculation_finalized(&self) -> bool {
+        self.flags
+            .bit(Self::FLAG_VALIDATOR_REWARDS_CALCULATION_FINALIZED_BIT)
+    }
+
+    #[inline]
+    pub fn is_validator_rewards_accumulated(&self) -> bool {
+        self.flags.bit(Self::FLAG_VALIDATOR_REWARDS_ACCUMULATED_BIT)
+    }
+
+    #[inline]
+    pub fn is_integration_funded(&self) -> bool {
+        self.flags.bit(Self::FLAG_INTEGRATION_FUNDED_BIT)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+#[repr(C, align(8))]
+pub struct ShredDistributionJournal {
+    pub subscription_epoch: u64,
+    pub mint_key: Pubkey,
+    pub reward_mint_key: Pubkey,
+    flags: Flags,
+    pub usdc_swapped_amount: u64,
+    pub tokens_received_amount: u64,
+    pub publisher_accumulation_bitmap_start_index: u32,
+    pub publisher_accumulation_bitmap_end_index: u32,
+    pub client_accumulation_bitmap_start_index: u32,
+    pub client_accumulation_bitmap_end_index: u32,
+    pub validator_pool: u64,
+    pub total_leader_slots: u32,
+    _padding_0: [u8; 4],
+    pub accumulated_publisher_slots_scaled: u64,
+    pub accumulated_client_slots_scaled: u64,
+    pub accumulated_publisher_leaf_count: u32,
+    pub distributed_publisher_leaf_count: u32,
+    pub distributed_amount: u64,
+    pub accumulated_client_leaf_count: u32,
+    pub distributed_client_leaf_count: u32,
+    _padding_1: [u8; 16],
+    pub first_distribute_timestamp: i64,
+    _gap: StorageGap<3>,
+}
+
+impl PrecomputedDiscriminator for ShredDistributionJournal {
+    const DISCRIMINATOR: Discriminator<8> =
+        Discriminator::new_sha2(b"dz::account::shred_distribution_journal");
+}
+
+impl ShredDistributionJournal {
+    pub const FLAG_SWAP_BYPASSED_BIT: usize = 0;
+    pub const FLAG_SWEPT_BIT: usize = 1;
+
+    #[inline]
+    pub fn is_swap_bypassed(&self) -> bool {
+        self.flags.bit(Self::FLAG_SWAP_BYPASSED_BIT)
+    }
+
+    #[inline]
+    pub fn is_swept(&self) -> bool {
+        self.flags.bit(Self::FLAG_SWEPT_BIT)
+    }
+
+    #[inline]
+    pub fn checked_publisher_accumulation_bitmap_range(&self) -> Option<Range<usize>> {
+        let has_end_index = self.publisher_accumulation_bitmap_end_index != 0;
+        let range = self.publisher_accumulation_bitmap_start_index as usize
+            ..self.publisher_accumulation_bitmap_end_index as usize;
+        has_end_index.then_some(range)
+    }
+
+    #[inline]
+    pub fn checked_client_accumulation_bitmap_range(&self) -> Option<Range<usize>> {
+        let has_end_index = self.client_accumulation_bitmap_end_index != 0;
+        let range = self.client_accumulation_bitmap_start_index as usize
+            ..self.client_accumulation_bitmap_end_index as usize;
+        has_end_index.then_some(range)
+    }
+
+    #[inline]
+    pub fn checked_usdc_swap_budget(&self) -> Option<u64> {
+        if self.total_leader_slots == 0 {
+            return None;
+        }
+        let accumulated_slots_scaled =
+            self.accumulated_publisher_slots_scaled + self.accumulated_client_slots_scaled;
+        let total_slots_scaled = u64::from(self.total_leader_slots) * u64::from(UnitShare16::MAX);
+        let budget = u128::from(self.validator_pool) * u128::from(accumulated_slots_scaled)
+            / u128::from(total_slots_scaled);
+        Some(budget as u64)
+    }
+
+    #[inline]
+    pub fn is_swap_complete(&self) -> bool {
+        if self.is_swap_bypassed() {
+            return true;
+        }
+        match self.checked_usdc_swap_budget() {
+            Some(budget) => self.usdc_swapped_amount == budget,
+            None => true,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/solana-sdk/src/shred_subscription/state.rs
+++ b/crates/solana-sdk/src/shred_subscription/state.rs
@@ -705,7 +705,19 @@ impl PrecomputedDiscriminator for ValidatorPublisherRewards {
 // `malbeclabs/doublezero-shreds` (program crate). Vendored here so the
 // offchain CLI can `bytemuck::from_bytes` these accounts without depending
 // on the shreds program crate. Remove once the shreds repo is merged into
-// the monorepo. If the on-chain layout changes, update both sides together.
+// the monorepo.
+//
+// The compile-time `const _: () = assert!(...)` lines at the bottom of this
+// block mirror the on-chain `assert!(zero_copy::data_end::<T>() == N)` for
+// each Pod struct (`data_end::<T>() == DISCRIMINATOR_LEN + size_of::<T>()`).
+// Without them, a silent upstream drift in any field — or in
+// `Flags`/`StorageGap<N>`'s size against a different `program-tools` pin —
+// would shift `remaining_data`'s start by some number of bytes. Bitmap
+// reads via `publisher_accumulation_bitmap_{start,end}_index` would then
+// land on the wrong bytes and `bitmap_bit_set` would return garbage,
+// silently undercounting or duplicating distribute work. If on-chain
+// changes any of these layouts, update both sides together (offchain
+// struct + the expected size below + the on-chain `assert!`).
 // ---------------------------------------------------------------------------
 
 pub const MAX_VALIDATOR_CLIENT_REWARDS_PROPORTIONS: usize = 32;
@@ -873,6 +885,21 @@ impl ShredDistributionJournal {
         }
     }
 }
+
+// Mirror the on-chain
+// `assert!(zero_copy::data_end::<T>() == N)` lines in
+// `programs/shred-subscription/src/processor/mod.rs`. `data_end` is
+// `DISCRIMINATOR_LEN + size_of::<T>()`, so the offchain size assert is
+// `size_of::<T>() == N - DISCRIMINATOR_LEN`. If on-chain bumps either
+// value, update both sides together.
+const _: () = assert!(std::mem::size_of::<ShredDistribution>() == 400 - DISCRIMINATOR_LEN);
+const _: () = assert!(std::mem::size_of::<ShredDistributionJournal>() == 296 - DISCRIMINATOR_LEN);
+// `ValidatorClientRewardsConfig` is a field inside `ShredDistribution`,
+// not a top-level account, so the on-chain code has no separate
+// `data_end::<T>()` assert for it. Pin its size here directly so any
+// upstream layout shift breaks the build instead of silently relocating
+// later fields of `ShredDistribution`.
+const _: () = assert!(std::mem::size_of::<ValidatorClientRewardsConfig>() == 136);
 
 #[cfg(test)]
 mod tests {

--- a/crates/solana-sdk/src/shred_subscription/types/mod.rs
+++ b/crates/solana-sdk/src/shred_subscription/types/mod.rs
@@ -1,3 +1,5 @@
 pub mod configure_validator_publisher_rewards_auth_message;
+pub mod validator_rewards_leaf;
 
 pub use configure_validator_publisher_rewards_auth_message::ConfigureValidatorPublisherRewardsAuthMessage;
+pub use validator_rewards_leaf::ValidatorRewardsLeaf;

--- a/crates/solana-sdk/src/shred_subscription/types/validator_rewards_leaf.rs
+++ b/crates/solana-sdk/src/shred_subscription/types/validator_rewards_leaf.rs
@@ -1,0 +1,31 @@
+// VENDORED from `malbeclabs/doublezero-shreds`:
+// `programs/shred-subscription/src/types/validator_rewards_leaf.rs`.
+// Kept byte-for-byte compatible with the canonical impl so merkle leaves
+// hash identically on both sides. Remove once the shreds program crate is
+// merged into the monorepo and can be depended on directly.
+
+use bytemuck::{Pod, Zeroable};
+use solana_sdk::pubkey::Pubkey;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Pod, Zeroable)]
+#[repr(C)]
+pub struct ValidatorRewardsLeaf {
+    pub node_id: Pubkey,
+    pub leader_slots: u32,
+    pub client_id: u16,
+    _reserved: [u8; 2],
+}
+
+impl ValidatorRewardsLeaf {
+    pub const LEAF_PREFIX: &'static [u8] = b"dz::validator_rewards";
+
+    #[inline]
+    pub fn new(node_id: Pubkey, leader_slots: u32, client_id: u16) -> Self {
+        Self {
+            node_id,
+            leader_slots,
+            client_id,
+            _reserved: [0; 2],
+        }
+    }
+}

--- a/crates/solana-sdk/src/shred_subscription/types/validator_rewards_leaf.rs
+++ b/crates/solana-sdk/src/shred_subscription/types/validator_rewards_leaf.rs
@@ -16,6 +16,12 @@ pub struct ValidatorRewardsLeaf {
     _reserved: [u8; 2],
 }
 
+// Mirror the canonical impl's `assert_eq!(size_of::<ValidatorRewardsLeaf>(), 40)`.
+// This leaf is hashed into the merkle tree the on-chain program verifies
+// proofs against, so any field-order or padding drift must break the build
+// here rather than silently produce non-matching proofs.
+const _: () = assert!(std::mem::size_of::<ValidatorRewardsLeaf>() == 40);
+
 impl ValidatorRewardsLeaf {
     pub const LEAF_PREFIX: &'static [u8] = b"dz::validator_rewards";
 


### PR DESCRIPTION
Note: this PR carries some vendored snippets from `doublezero-shreds` that will be deleted once shreds merges into the monorepo — each vendored file carries a header tagging "remove when shreds merges into monorepo" so the duplication is greppable and bounded in time.

## Summary of changes

- After a successful `configure`, the CLI scans the last **100** subscription epochs and, for each `(epoch, mint)` pair where this validator's leaf bit is still set in the publisher accumulation bitmap, submits a `DistributeValidatorRewards` ix. Probes all three mint candidates (2Z, USDC, WSOL) per epoch to cover rewards routed historically against a different mint than the validator's current VPR config. Per-`(epoch, mint)` soft-fail; skipped under dry-run.

- Multi-client-id-aware: a validator that legitimately appears under multiple `client_id`s in one epoch (the leaf schema's dedup key is `(node_id, client_id)`, not `node_id` alone) emits one candidate per match, each with its own merkle proof and bitmap slot. The `InitializeClaimHolding` dedup is keyed by `(epoch, client_id)` so each per-client_id claim holding gets its own init.

- **Five batched upfront RPCs + one parallel fan-out** for the whole pass regardless of window size: `ShredDistribution`, journals across the three mints, parent `Distribution` (deduped by DZ epoch), claim holdings, candidate destination ATAs. S3 leaf fetches use `futures::buffer_unordered(8)` so a 100-epoch lookback costs ~1-3 s of S3 wall-time instead of 5-20 s sequential.

- **Per-tx hygiene**: each `(epoch, mint)` tx skips the redundant `CheckCliVersion` ix (configure already enforced it for the session), skips `create_associated_token_account_idempotent` when the destination ATA is known to exist (pre-checked + tracked across the pass), and reuses one cached blockhash instead of fetching per tx.

- The pass is fault-tolerant of its own RPC churn: if the distribute pass fails after `configure` has already landed, the CLI prints the error to stderr but returns `Ok` — operators don't see a misleading "configure failed" exit code over a downstream transient.

- Current Solana epoch is resolved via a Solana RPC (`getEpochInfo`), not the DZ-Ledger one that hosts the shred-subscription program — on testnet/localnet those are distinct chains with independent epoch numbers, and the pass needs the Solana epoch to match S3 file names and on-chain `subscription_epoch` PDAs.

- **Counter rename + new summary**: the pass exposes three counters with explicit units (`submits_succeeded` / `submits_failed` per `(epoch, mint)` submission; `epochs_unsettled` per-epoch where no submit landed for this leaf). The end-of-pass summary, printed at the configure call site:

  ```
  Distribute pass complete:
    submits: N succeeded, M failed
    epochs:  K still unsettled for this leaf
  ```

## SDK additions

- `DistributeValidatorRewards` ix variant + account builder. The builder's `client_mint_key` is always-required `&Pubkey`; the omit-rule (when client journal == publisher journal, drop the redundant client journal account) is decided once inside the builder instead of overloaded onto an `Option`. Borsh `Serialize` + `Deserialize` round-trip with a frozen-bytes test.
- Zero-copy mirrors for `ShredDistribution`, `ShredDistributionJournal`, `ValidatorClientRewardsConfig`, each with a compile-time `const _: () = assert!(size_of::<T>() == ...)` matching the on-chain `data_end::<T>()` assert. Any silent upstream layout drift breaks the offchain build instead of producing garbage bitmap reads at runtime.
- Journal PDA finder, `ValidatorRewardsLeaf` Pod struct.

## Vendored snippets

- S3 fetch + merkle helper from `doublezero-shreds` (~190 LOC). Parity-critical: the canonical oracle uses the same silent `filter_map(...).ok()?` for unparseable `node_identity` entries, and the merkle root must match exactly or every proof fails on-chain verification. Pinned with a `compute_leaves_drops_unparseable_pubkeys_silently` test + load-bearing-parity doc block. `tracing::warn!` added (offchain-only) so operators see when an entry is silently dropped.
- `ValidatorRewardsLeaf` Pod struct, byte-for-byte compatible with on-chain.
- The vendored `compute_leaves_with_proofs` (O(N log N) all-proofs builder) is intentionally NOT carried over — offchain uses a `compute_proof_for_leaf` helper that runs O(log N) work per matched leaf. A `compute_proof_for_leaf_reconstructs_root` test pins equivalence with the on-chain root.

## Bitmap convention parity

The accumulation-bitmap read (`bitmap[leaf_index / 8] & (1 << (leaf_index % 8))`) mirrors what on-chain `try_process_remaining_data_leaf_index` writes (LSB-first via `ByteFlags::set_bit`). Pinned with a `bitmap_bit_set_matches_onchain_accumulate_convention` test that builds a bitmap by calling an on-chain-style write helper and asserts the offchain reader returns the expected value across byte boundaries.

## Testing verification

- 138 CLI unit tests + 35 SDK unit tests pass.
- New tests added for: bitmap-convention parity, the `compute_leaves` silent-drop parity pin, single-leaf merkle proof equivalence, the `DistributeValidatorRewards` ix Borsh round-trip, and the layout-size asserts (which run at compile time).
- `cargo fmt --check` clean, `cargo clippy --all-targets` clean across workspace.
- No devnet smoke yet — last step before merge is running `publisher-rewards configure` against a real validator with pending epochs on devnet to confirm the end-to-end flow lands.