### PR TITLE
solana-cli: uptick crate to v0.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-solana-cli"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.6](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.6)
+
+- uptick crate to v0.5.6 (#376)
 - `shreds publisher-rewards configure`: after the configure tx lands, scan the last 100 subscription epochs and submit `DistributeValidatorRewards` for any unsettled leaf so the validator's pending rewards land in the same operator session. Skipped under dry-run; per-epoch soft-fail so one bad epoch doesn't tank the rest (#375)
+- `solana-client-tools`: `try_fetch_multiple_zero_copy_data` now returns `Vec<Option<T>>`; a single missing or layout-invalid account surfaces as `None` in its slot instead of failing the whole batch (#374)
+- `shreds publisher-rewards`: ergonomics pass — `configure` / `prepare-offchain-message` direct auth now uses the global `-k` signer (its pubkey must equal `--node-id`) instead of a separate `--validator-identity-keypair`, plus sensible default refinements across the subcommand group (#373)
 
 ## [0.5.5](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.5)
 

--- a/crates/solana-cli/Cargo.toml
+++ b/crates/solana-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "doublezero-solana-cli"
 description = "Command line to interact with DoubleZero Solana programs"
-version = "0.5.5"
+version = "0.5.6"
 
 # Workspace inherited keys
 edition.workspace = true


### PR DESCRIPTION
## Summary of Changes
Uptick `doublezero-solana-cli` crate to v0.5.6.

Includes:
- `shreds publisher-rewards configure`: after the configure tx lands, scan the last 100 subscription epochs and submit `DistributeValidatorRewards` for any unsettled leaf so the validator's pending rewards land in the same operator session (#375)
- `solana-client-tools`: `try_fetch_multiple_zero_copy_data` now returns `Vec<Option<T>>` so a single missing/invalid account no longer fails the whole batch (#374)
- `shreds publisher-rewards`: ergonomics pass — direct auth now uses the global `-k` signer (must equal `--node-id`) instead of `--validator-identity-keypair` (#373)

## Testing Verification
N/A