### PR TITLE
chore(deps): converge SDK family on client/v0.25.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,7 +1371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.4",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -2350,13 +2350,13 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "doublezero-cli-core"
-version = "0.25.0"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.0#c53e54a2306dd9f05421a927bd97d2add9f32ea7"
+version = "0.25.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
 dependencies = [
  "bitflags",
  "clap",
- "doublezero-config 0.25.0",
- "doublezero-program-common 0.25.0",
+ "doublezero-config",
+ "doublezero-program-common",
  "eyre",
  "serde",
  "serde_json",
@@ -2369,18 +2369,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-config"
-version = "0.20.0"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
-dependencies = [
- "eyre",
- "serde",
- "solana-sdk",
-]
-
-[[package]]
-name = "doublezero-config"
-version = "0.25.0"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.0#c53e54a2306dd9f05421a927bd97d2add9f32ea7"
+version = "0.25.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
 dependencies = [
  "eyre",
  "serde",
@@ -2405,7 +2395,7 @@ dependencies = [
  "config",
  "csv",
  "dotenvy",
- "doublezero-program-common 0.20.0",
+ "doublezero-program-common",
  "doublezero-program-tools",
  "doublezero-record",
  "doublezero-revenue-distribution",
@@ -2443,13 +2433,13 @@ dependencies = [
 
 [[package]]
 name = "doublezero-geolocation"
-version = "0.20.0"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
+version = "0.25.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
 dependencies = [
  "borsh 1.5.7",
  "borsh-incremental",
- "doublezero-config 0.20.0",
- "doublezero-program-common 0.20.0",
+ "doublezero-config",
+ "doublezero-program-common",
  "doublezero-serviceability",
  "solana-bincode",
  "solana-loader-v3-interface 3.0.0",
@@ -2470,7 +2460,7 @@ dependencies = [
  "clap",
  "config",
  "doublezero-passport",
- "doublezero-program-common 0.20.0",
+ "doublezero-program-common",
  "doublezero-program-tools",
  "doublezero-record",
  "doublezero-revenue-distribution",
@@ -2554,21 +2544,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-program-common"
-version = "0.20.0"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
-dependencies = [
- "borsh 1.5.7",
- "byteorder",
- "ipnetwork",
- "serde",
- "solana-program",
- "solana-system-interface",
-]
-
-[[package]]
-name = "doublezero-program-common"
-version = "0.25.0"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.0#c53e54a2306dd9f05421a927bd97d2add9f32ea7"
+version = "0.25.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
 dependencies = [
  "borsh 1.5.7",
  "byteorder",
@@ -2603,8 +2580,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-record"
-version = "0.20.0"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
+version = "0.25.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -2663,14 +2640,14 @@ dependencies = [
 
 [[package]]
 name = "doublezero-serviceability"
-version = "0.20.0"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
+version = "0.25.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
 dependencies = [
  "bitflags",
  "borsh 1.5.7",
  "borsh-incremental",
  "bytemuck",
- "doublezero-program-common 0.20.0",
+ "doublezero-program-common",
  "ipnetwork",
  "serde",
  "serde_bytes",
@@ -2722,7 +2699,7 @@ dependencies = [
  "clap",
  "csv",
  "doublezero-cli-core",
- "doublezero-config 0.25.0",
+ "doublezero-config",
  "doublezero-contributor-rewards",
  "doublezero-ledger-sentinel",
  "doublezero-passport-cli",
@@ -2879,13 +2856,13 @@ dependencies = [
 
 [[package]]
 name = "doublezero-telemetry"
-version = "0.20.0"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
+version = "0.25.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
 dependencies = [
  "borsh 1.5.7",
  "borsh-incremental",
- "doublezero-config 0.20.0",
- "doublezero-program-common 0.20.0",
+ "doublezero-config",
+ "doublezero-program-common",
  "doublezero-serviceability",
  "serde",
  "serde_bytes",
@@ -2894,8 +2871,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero_sdk"
-version = "0.20.0"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
+version = "0.25.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
 dependencies = [
  "async-trait",
  "backon",
@@ -2906,9 +2883,9 @@ dependencies = [
  "chrono",
  "directories-next",
  "dirs-next",
- "doublezero-config 0.20.0",
+ "doublezero-config",
  "doublezero-geolocation",
- "doublezero-program-common 0.20.0",
+ "doublezero-program-common",
  "doublezero-record",
  "doublezero-serviceability",
  "doublezero-telemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,41 +113,42 @@ tag = "revenue-distribution/v0.3.6"
 ### Dependencies found in github.com/malbeclabs/doublezero
 
 # RFC-20 CLI core: provides CliContext, OutputFormat, RequirementCheck, the
-# render_* output helpers, and the eyre-based error type. Pinned to the tag
-# that introduced doublezero-cli-core (client/v0.25.0 == geolocation-cli/v0.24.0).
+# render_* output helpers, and the eyre-based error type. doublezero-cli-core
+# was introduced at client/v0.25.0; the whole SDK family is pinned to a single
+# monorepo revision (client/v0.25.1) so shared types unify across the boundary.
 [workspace.dependencies.doublezero-cli-core]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.25.0"
+tag = "client/v0.25.1"
 
 # Source of the RFC-20 `Environment` enum consumed by `CliContext`. MUST be
 # pinned to the same tag as doublezero-cli-core so the `Environment` type
 # unifies across the boundary.
 [workspace.dependencies.doublezero-config]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.25.0"
+tag = "client/v0.25.1"
 
 [workspace.dependencies.doublezero-program-common]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.20.0"
+tag = "client/v0.25.1"
 
 [workspace.dependencies.doublezero-record]
 features = ["no-entrypoint"]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.20.0"
+tag = "client/v0.25.1"
 
 [workspace.dependencies.doublezero_sdk]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.20.0"
+tag = "client/v0.25.1"
 
 [workspace.dependencies.doublezero-serviceability]
 features = ["no-entrypoint", "serde"]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.20.0"
+tag = "client/v0.25.1"
 
 [workspace.dependencies.doublezero-telemetry]
 features = ["no-entrypoint", "serde"]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.20.0"
+tag = "client/v0.25.1"
 
 ### Other git dependencies
 

--- a/crates/contributor-rewards/CHANGELOG.md
+++ b/crates/contributor-rewards/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- chore(contributor-rewards): converge the doublezero SDK family on `client/v0.25.1`, dropping the duplicate v0.20 lockfile entries; adapt to the v0.25 serviceability layout (flat `Device.interfaces`, renamed `UserStatus::*Deprecated` variants) and extend the snapshot compat migrations to backfill `Device.deprecated_interfaces`, the flat `Interface` projection, and `User.bgp_rtt_ns` ([#379](https://github.com/doublezerofoundation/doublezero-offchain/pull/379))
 - fix(contributor-rewards): bump network shapley ([#377](https://github.com/doublezerofoundation/doublezero-offchain/pull/377))
 
 ## [0.5.5](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/contributor-rewards%2Fv0.5.5) - 2026-05-20

--- a/crates/contributor-rewards/src/calculator/shapley/handler.rs
+++ b/crates/contributor-rewards/src/calculator/shapley/handler.rs
@@ -140,7 +140,6 @@ pub fn build_devices(fetch_data: &FetchData, network: &Network) -> Result<(Devic
         let interface_bandwidth_bps: u64 = device
             .interfaces
             .iter()
-            .map(|iface| iface.into_current_version())
             .filter(|iface| {
                 iface.interface_type
                     == doublezero_serviceability::state::interface::InterfaceType::Physical

--- a/crates/contributor-rewards/src/ingestor/demand.rs
+++ b/crates/contributor-rewards/src/ingestor/demand.rs
@@ -204,7 +204,7 @@ pub fn build_city_stats(
     for user in fetch_data.dz_serviceability.users.values() {
         let is_live = !matches!(
             user.status,
-            UserStatus::Rejected | UserStatus::Banned | UserStatus::PendingBan
+            UserStatus::RejectedDeprecated | UserStatus::Banned | UserStatus::PendingBanDeprecated
         );
         if user.user_type != UserType::Multicast || !is_live || user.is_publisher() {
             continue;

--- a/crates/contributor-rewards/src/ingestor/types.rs
+++ b/crates/contributor-rewards/src/ingestor/types.rs
@@ -7,9 +7,14 @@ use anyhow::{Result, bail};
 use chrono::{DateTime, Utc};
 use doublezero_program_common::serializer;
 use doublezero_serviceability::state::{
-    accesspass::AccessPass as DZAccessPass, contributor::Contributor as DZContributor,
-    device::Device as DZDevice, exchange::Exchange as DZExchange, link::Link as DZLink,
-    location::Location as DZLocation, multicastgroup::MulticastGroup as DZMulticastGroup,
+    accesspass::AccessPass as DZAccessPass,
+    contributor::Contributor as DZContributor,
+    device::Device as DZDevice,
+    exchange::Exchange as DZExchange,
+    interface::{CURRENT_INTERFACE_SCHEMA_VERSION, INTERFACE_MTU},
+    link::Link as DZLink,
+    location::Location as DZLocation,
+    multicastgroup::MulticastGroup as DZMulticastGroup,
     user::User as DZUser,
 };
 use doublezero_telemetry::state::{
@@ -123,7 +128,9 @@ fn apply_serviceability_json_compat_migrations(serviceability: &mut Value) {
         }
     }
 
-    // doublezero-serviceability v0.20 added durable tunnel/BGP state to User.
+    // doublezero-serviceability v0.20 added durable tunnel/BGP state to User;
+    // client/v0.25.0 then appended `bgp_rtt_ns`. Both default to the same values
+    // onchain/Borsh deserialization uses for absent tails.
     if let Some(users) = serviceability
         .get_mut("users")
         .and_then(|users| users.as_object_mut())
@@ -139,8 +146,109 @@ fn apply_serviceability_json_compat_migrations(serviceability: &mut Value) {
                 .or_insert_with(|| Value::Number(0.into()));
             user.entry("last_bgp_reported_at")
                 .or_insert_with(|| Value::Number(0.into()));
+            user.entry("bgp_rtt_ns")
+                .or_insert_with(|| Value::Number(0.into()));
         }
     }
+
+    // doublezero-serviceability client/v0.25.0 split a Device's single
+    // `interfaces` vec into two: a flat `interfaces: Vec<Interface>` written at
+    // the end of the on-disk layout, plus a legacy
+    // `deprecated_interfaces: Vec<InterfaceDeprecated>` (the `{"V1": {...}}` /
+    // `{"V2": {...}}` enum) kept at the original offset for byte-compatible
+    // readers. Snapshots captured under <=v0.20 carry only the legacy enum vec
+    // under `interfaces`, so seed `deprecated_interfaces` from it verbatim and
+    // then project `interfaces` onto the flat form. The SDK keeps both vecs the
+    // same length, so seeding from the same source preserves that invariant.
+    if let Some(devices) = serviceability
+        .get_mut("devices")
+        .and_then(|devices| devices.as_object_mut())
+    {
+        for device in devices
+            .values_mut()
+            .filter_map(|device| device.as_object_mut())
+        {
+            if !device.contains_key("deprecated_interfaces") {
+                let legacy = device
+                    .get("interfaces")
+                    .cloned()
+                    .unwrap_or_else(|| Value::Array(Vec::new()));
+                device.insert("deprecated_interfaces".to_string(), legacy);
+            }
+
+            if let Some(interfaces) = device
+                .get_mut("interfaces")
+                .and_then(|interfaces| interfaces.as_array_mut())
+            {
+                for interface in interfaces.iter_mut() {
+                    migrate_interface_to_flat(interface);
+                }
+            }
+        }
+    }
+}
+
+/// Project a legacy versioned `Interface` enum element (`{"V1": {...}}` /
+/// `{"V2": {...}}`) onto the flat `Interface` struct introduced in
+/// doublezero-serviceability client/v0.25.0. Mirrors the defaults stamped by the
+/// SDK's `TryFrom<&InterfaceV1>` / `TryFrom<&InterfaceV2> for Interface` impls:
+/// a V1 body fans in through V2, gaining `interface_cyoa`/`interface_dia` =
+/// `None`, `bandwidth`/`cir` = 0, `mtu` = `INTERFACE_MTU`, `routing_mode` =
+/// `Static`; both versions gain `version` = `CURRENT_INTERFACE_SCHEMA_VERSION`
+/// and an empty `flex_algo_node_segments`. `size` is the on-disk byte length,
+/// which offchain consumers never read (only `interface_type`/`bandwidth` are
+/// used), so it is defaulted to 0 rather than recomputed.
+fn migrate_interface_to_flat(interface: &mut Value) {
+    let Some(obj) = interface.as_object() else {
+        return;
+    };
+    // Already in the flat v0.25 form; nothing to do.
+    if obj.contains_key("size") {
+        return;
+    }
+
+    let version_tag = if obj.contains_key("V1") {
+        1u8
+    } else if obj.contains_key("V2") {
+        2u8
+    } else {
+        return;
+    };
+
+    let Some(body) = obj
+        .get(if version_tag == 1 { "V1" } else { "V2" })
+        .and_then(|body| body.as_object())
+    else {
+        return;
+    };
+
+    let mut flat = body.clone();
+
+    // V1 predates the CYOA/DIA/bandwidth/routing fields; backfill them with the
+    // same values the V1 -> V2 conversion uses.
+    if version_tag == 1 {
+        flat.entry("interface_cyoa")
+            .or_insert_with(|| Value::String("None".to_string()));
+        flat.entry("interface_dia")
+            .or_insert_with(|| Value::String("None".to_string()));
+        flat.entry("bandwidth")
+            .or_insert_with(|| Value::Number(0.into()));
+        flat.entry("cir").or_insert_with(|| Value::Number(0.into()));
+        flat.entry("mtu")
+            .or_insert_with(|| Value::Number(INTERFACE_MTU.into()));
+        flat.entry("routing_mode")
+            .or_insert_with(|| Value::String("Static".to_string()));
+    }
+
+    flat.entry("flex_algo_node_segments")
+        .or_insert_with(|| Value::Array(Vec::new()));
+    flat.insert(
+        "version".to_string(),
+        Value::Number(CURRENT_INTERFACE_SCHEMA_VERSION.into()),
+    );
+    flat.insert("size".to_string(), Value::Number(0.into()));
+
+    *interface = Value::Object(flat);
 }
 
 /// Struct for all network data

--- a/crates/contributor-rewards/src/ingestor/types.rs
+++ b/crates/contributor-rewards/src/ingestor/types.rs
@@ -207,18 +207,13 @@ fn migrate_interface_to_flat(interface: &mut Value) {
         return;
     }
 
-    let version_tag = if obj.contains_key("V1") {
-        1u8
-    } else if obj.contains_key("V2") {
-        2u8
+    // Pull out the versioned body and note whether it's V1, which predates the
+    // CYOA/DIA/bandwidth/routing fields and so needs them backfilled.
+    let (is_v1, body) = if let Some(body) = obj.get("V1").and_then(Value::as_object) {
+        (true, body)
+    } else if let Some(body) = obj.get("V2").and_then(Value::as_object) {
+        (false, body)
     } else {
-        return;
-    };
-
-    let Some(body) = obj
-        .get(if version_tag == 1 { "V1" } else { "V2" })
-        .and_then(|body| body.as_object())
-    else {
         return;
     };
 
@@ -226,7 +221,7 @@ fn migrate_interface_to_flat(interface: &mut Value) {
 
     // V1 predates the CYOA/DIA/bandwidth/routing fields; backfill them with the
     // same values the V1 -> V2 conversion uses.
-    if version_tag == 1 {
+    if is_v1 {
         flat.entry("interface_cyoa")
             .or_insert_with(|| Value::String("None".to_string()));
         flat.entry("interface_dia")

--- a/crates/contributor-rewards/tests/test_demand.rs
+++ b/crates/contributor-rewards/tests/test_demand.rs
@@ -172,7 +172,9 @@ mod tests {
         for user in fetch_data.dz_serviceability.users.values() {
             let is_live = !matches!(
                 user.status,
-                UserStatus::Rejected | UserStatus::Banned | UserStatus::PendingBan
+                UserStatus::RejectedDeprecated
+                    | UserStatus::Banned
+                    | UserStatus::PendingBanDeprecated
             );
             if user.user_type != UserType::Multicast || !is_live || user.is_publisher() {
                 continue;


### PR DESCRIPTION
## Why

The `Cargo.lock` carried **both** `v0.20` and `v0.25` of `doublezero-config` and `doublezero-program-common`: `doublezero-cli-core` / `doublezero-config` were pinned to `client/v0.25.1` while `doublezero_sdk` and the rest of the SDK family stayed at `client/v0.20.0` and dragged the `v0.20` copies in transitively. This is the follow-up tracked out of PR #378's "Cargo.lock 0.20/0.25 convergence" note.

## What

Bump the remaining SDK family — `doublezero_sdk`, `-serviceability`, `-record`, `-telemetry`, `-program-common` — from `client/v0.20.0` to `client/v0.25.1` so the whole family resolves to a single version. The duplicate `v0.20` entries drop out of the lockfile (net **-23 lines** in `Cargo.lock`).

The `v0.20 → v0.25` serviceability jump changes a few account layouts; the only crate that broke was `contributor-rewards`. Fixes, all mirroring the SDK 0.25 source:

- **`Device.interfaces`** is now a flat `Vec<Interface>` (the versioned `InterfaceDeprecated` enum moved to `Device.deprecated_interfaces`) → drop the obsolete `Interface::into_current_version()` projection in the Shapley handler.
- **`UserStatus::Rejected`/`PendingBan`** were renamed to `*Deprecated` → update the liveness filter in the demand ingestor (and its mirror in the test), **preserving the exact set of non-live statuses**.
- **`apply_json_compat_migrations`** extended so pre-`v0.25` snapshots still load: seed `Device.deprecated_interfaces` from the legacy enum vec, project `Device.interfaces` onto the flat struct (mirroring `TryFrom<&InterfaceV1/V2> for Interface` defaults), and backfill the new `User.bgp_rtt_ns` field.

## Scope note — `UserStatus::OutOfCredits`

`UserStatus` in 0.25 adds a variant that didn't exist in 0.20: `OutOfCredits`. This PR is deliberately **behavior-neutral** — only the three original statuses (`RejectedDeprecated | Banned | PendingBanDeprecated`) count as non-live, so an `OutOfCredits` multicast subscriber is still counted as active demand. Whether `OutOfCredits` should be treated as non-live is a reward-math/product decision, intentionally left out of this convergence. Flagging for a separate call.

## Testing

- `cargo test --workspace` — 43 test binaries pass
- `cargo clippy --workspace --all-targets` — clean
