### PR TITLE
solana-cli: remove invalid written-off debt sanity check from fetch validator-debts

### DIFF
--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `revenue-distribution fetch validator-debts`: remove the written-off debt sanity check that aborted the command. It compared a windowed sum (the last 100 epochs of debt records) against the deposit's lifetime cumulative `written_off_sol_debt`, so it fired whenever a validator had a write-off older than the window
+
 ## [0.5.6](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.6)
 
 - uptick crate to v0.5.6 (#376)

--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- `revenue-distribution fetch validator-debts`: remove the written-off debt sanity check that aborted the command. It compared a windowed sum (the last 100 epochs of debt records) against the deposit's lifetime cumulative `written_off_sol_debt`, so it fired whenever a validator had a write-off older than the window
+- `revenue-distribution fetch validator-debts`: remove the written-off debt sanity check that aborted the command. It compared a windowed sum (the last 100 epochs of debt records) against the deposit's lifetime cumulative `written_off_sol_debt`, so it fired whenever a validator had a write-off older than the window (#380)
 
 ## [0.5.6](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.6)
 

--- a/crates/solana-cli/src/command/revenue_distribution/fetch/validator_debts.rs
+++ b/crates/solana-cli/src/command/revenue_distribution/fetch/validator_debts.rs
@@ -134,21 +134,10 @@ async fn try_print_validator_debts_outstanding_table(
         })
         .collect::<Vec<_>>();
 
-    let deposit_accounts = deposit_account_infos
-        .into_iter()
-        .map(ZeroCopyAccountOwnedData::<SolanaValidatorDeposit>::try_from)
-        .collect::<Result<Vec<_>>>()?;
-
     let mut outputs = Vec::with_capacity(debt_records.len());
 
-    for ((node_id, deposit_balance), deposit_account) in node_ids
-        .into_iter()
-        .zip(deposit_balances)
-        .zip(deposit_accounts)
-    {
+    for (node_id, deposit_balance) in node_ids.into_iter().zip(deposit_balances) {
         let mut total_debt = 0;
-
-        let mut recorded_written_off_debt = 0;
 
         for (debt_record, distribution) in debt_records.iter().zip(distributions) {
             if debt_record.debts.is_empty() {
@@ -174,10 +163,6 @@ async fn try_print_validator_debts_outstanding_table(
                     false
                 };
 
-                if is_written_off {
-                    recorded_written_off_debt += debt_record.data.debts[index].amount;
-                }
-
                 // If the debt is not processed or if it is processed but
                 // written off, we should include it in the total debt.
                 if !try_is_processed_leaf(processed_leaf_data, index).unwrap() || is_written_off {
@@ -185,14 +170,6 @@ async fn try_print_validator_debts_outstanding_table(
                 }
             }
         }
-
-        // Out of paranoia, make sure the debt written in the records equals the
-        // written-off debt amount in the deposit account.
-        anyhow::ensure!(
-            recorded_written_off_debt == deposit_account.written_off_sol_debt,
-            "Recorded written off debt {recorded_written_off_debt} is not equal to deposit balance {}",
-            deposit_account.written_off_sol_debt
-        );
 
         if excess_mode {
             if total_debt >= deposit_balance {


### PR DESCRIPTION
Closes https://github.com/malbeclabs/doublezero/issues/3823

## Summary
`revenue-distribution fetch validator-debts`: removed the "out of paranoia" sanity check that aborted the command. It required `recorded_written_off_debt == deposit.written_off_sol_debt`, comparing a windowed sum (only the last 100 epochs of debt records, per `try_fetch_debt_records_and_distributions`) against the deposit's lifetime cumulative `written_off_sol_debt` (increment-only, merkle-verified onchain). Any write-off older than the window made the two diverge, aborting the command. `recorded_written_off_debt` fed nothing else, so it and the now-unused deposit-account parse were removed with it.

## Testing
Verified against live mainnet-beta: the previously-aborting invocation for node `12i8gndWWWMTRzJBFhnYkobNgZB3XMUUJq75HeUrshrk` (whose epoch-60 write-off had aged out of the 61..=161 window) now exits 0 and prints the outstanding table. `--view excess-balance` also returns cleanly.
