### PR TITLE
contributor-rewards: bump doublezero crate pins to client/v0.25.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,13 +2350,13 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "doublezero-cli-core"
-version = "0.25.0"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.0#c53e54a2306dd9f05421a927bd97d2add9f32ea7"
+version = "0.25.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
 dependencies = [
  "bitflags",
  "clap",
- "doublezero-config 0.25.0",
- "doublezero-program-common 0.25.0",
+ "doublezero-config",
+ "doublezero-program-common",
  "eyre",
  "serde",
  "serde_json",
@@ -2369,18 +2369,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-config"
-version = "0.20.0"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
-dependencies = [
- "eyre",
- "serde",
- "solana-sdk",
-]
-
-[[package]]
-name = "doublezero-config"
-version = "0.25.0"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.0#c53e54a2306dd9f05421a927bd97d2add9f32ea7"
+version = "0.25.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
 dependencies = [
  "eyre",
  "serde",
@@ -2405,7 +2395,7 @@ dependencies = [
  "config",
  "csv",
  "dotenvy",
- "doublezero-program-common 0.20.0",
+ "doublezero-program-common",
  "doublezero-program-tools",
  "doublezero-record",
  "doublezero-revenue-distribution",
@@ -2443,13 +2433,13 @@ dependencies = [
 
 [[package]]
 name = "doublezero-geolocation"
-version = "0.20.0"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
+version = "0.25.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
 dependencies = [
  "borsh 1.5.7",
  "borsh-incremental",
- "doublezero-config 0.20.0",
- "doublezero-program-common 0.20.0",
+ "doublezero-config",
+ "doublezero-program-common",
  "doublezero-serviceability",
  "solana-bincode",
  "solana-loader-v3-interface 3.0.0",
@@ -2470,7 +2460,7 @@ dependencies = [
  "clap",
  "config",
  "doublezero-passport",
- "doublezero-program-common 0.20.0",
+ "doublezero-program-common",
  "doublezero-program-tools",
  "doublezero-record",
  "doublezero-revenue-distribution",
@@ -2554,21 +2544,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-program-common"
-version = "0.20.0"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
-dependencies = [
- "borsh 1.5.7",
- "byteorder",
- "ipnetwork",
- "serde",
- "solana-program",
- "solana-system-interface",
-]
-
-[[package]]
-name = "doublezero-program-common"
-version = "0.25.0"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.0#c53e54a2306dd9f05421a927bd97d2add9f32ea7"
+version = "0.25.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
 dependencies = [
  "borsh 1.5.7",
  "byteorder",
@@ -2603,8 +2580,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-record"
-version = "0.20.0"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
+version = "0.25.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -2663,14 +2640,14 @@ dependencies = [
 
 [[package]]
 name = "doublezero-serviceability"
-version = "0.20.0"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
+version = "0.25.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
 dependencies = [
  "bitflags",
  "borsh 1.5.7",
  "borsh-incremental",
  "bytemuck",
- "doublezero-program-common 0.20.0",
+ "doublezero-program-common",
  "ipnetwork",
  "serde",
  "serde_bytes",
@@ -2722,7 +2699,7 @@ dependencies = [
  "clap",
  "csv",
  "doublezero-cli-core",
- "doublezero-config 0.25.0",
+ "doublezero-config",
  "doublezero-contributor-rewards",
  "doublezero-ledger-sentinel",
  "doublezero-passport-cli",
@@ -2879,13 +2856,13 @@ dependencies = [
 
 [[package]]
 name = "doublezero-telemetry"
-version = "0.20.0"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
+version = "0.25.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
 dependencies = [
  "borsh 1.5.7",
  "borsh-incremental",
- "doublezero-config 0.20.0",
- "doublezero-program-common 0.20.0",
+ "doublezero-config",
+ "doublezero-program-common",
  "doublezero-serviceability",
  "serde",
  "serde_bytes",
@@ -2894,8 +2871,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero_sdk"
-version = "0.20.0"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.20.0#5a37494c8fb32a15f1ee60a431696b2c7d3b16d0"
+version = "0.25.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
 dependencies = [
  "async-trait",
  "backon",
@@ -2906,9 +2883,9 @@ dependencies = [
  "chrono",
  "directories-next",
  "dirs-next",
- "doublezero-config 0.20.0",
+ "doublezero-config",
  "doublezero-geolocation",
- "doublezero-program-common 0.20.0",
+ "doublezero-program-common",
  "doublezero-record",
  "doublezero-serviceability",
  "doublezero-telemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,37 +117,37 @@ tag = "revenue-distribution/v0.3.6"
 # that introduced doublezero-cli-core (client/v0.25.0 == geolocation-cli/v0.24.0).
 [workspace.dependencies.doublezero-cli-core]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.25.0"
+tag = "client/v0.25.1"
 
 # Source of the RFC-20 `Environment` enum consumed by `CliContext`. MUST be
 # pinned to the same tag as doublezero-cli-core so the `Environment` type
 # unifies across the boundary.
 [workspace.dependencies.doublezero-config]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.25.0"
+tag = "client/v0.25.1"
 
 [workspace.dependencies.doublezero-program-common]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.20.0"
+tag = "client/v0.25.1"
 
 [workspace.dependencies.doublezero-record]
 features = ["no-entrypoint"]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.20.0"
+tag = "client/v0.25.1"
 
 [workspace.dependencies.doublezero_sdk]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.20.0"
+tag = "client/v0.25.1"
 
 [workspace.dependencies.doublezero-serviceability]
 features = ["no-entrypoint", "serde"]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.20.0"
+tag = "client/v0.25.1"
 
 [workspace.dependencies.doublezero-telemetry]
 features = ["no-entrypoint", "serde"]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.20.0"
+tag = "client/v0.25.1"
 
 ### Other git dependencies
 

--- a/crates/contributor-rewards/src/calculator/shapley/handler.rs
+++ b/crates/contributor-rewards/src/calculator/shapley/handler.rs
@@ -140,7 +140,6 @@ pub fn build_devices(fetch_data: &FetchData, network: &Network) -> Result<(Devic
         let interface_bandwidth_bps: u64 = device
             .interfaces
             .iter()
-            .map(|iface| iface.into_current_version())
             .filter(|iface| {
                 iface.interface_type
                     == doublezero_serviceability::state::interface::InterfaceType::Physical

--- a/crates/contributor-rewards/src/ingestor/demand.rs
+++ b/crates/contributor-rewards/src/ingestor/demand.rs
@@ -204,7 +204,7 @@ pub fn build_city_stats(
     for user in fetch_data.dz_serviceability.users.values() {
         let is_live = !matches!(
             user.status,
-            UserStatus::Rejected | UserStatus::Banned | UserStatus::PendingBan
+            UserStatus::RejectedDeprecated | UserStatus::Banned | UserStatus::PendingBanDeprecated
         );
         if user.user_type != UserType::Multicast || !is_live || user.is_publisher() {
             continue;

--- a/crates/contributor-rewards/src/ingestor/types.rs
+++ b/crates/contributor-rewards/src/ingestor/types.rs
@@ -189,7 +189,7 @@ fn apply_serviceability_json_compat_migrations(serviceability: &mut Value) {
                             // V1 fields absent from V2; default them.
                             obj.entry("bandwidth").or_insert(Value::Number(0.into()));
                             obj.entry("cir").or_insert(Value::Number(0.into()));
-                            obj.entry("mtu").or_insert(Value::Number(0.into()));
+                            obj.entry("mtu").or_insert(Value::Number(9000.into()));
                             obj.entry("interface_cyoa")
                                 .or_insert(Value::String("None".to_string()));
                             obj.entry("interface_dia")

--- a/crates/contributor-rewards/src/ingestor/types.rs
+++ b/crates/contributor-rewards/src/ingestor/types.rs
@@ -139,6 +139,99 @@ fn apply_serviceability_json_compat_migrations(serviceability: &mut Value) {
                 .or_insert_with(|| Value::Number(0.into()));
             user.entry("last_bgp_reported_at")
                 .or_insert_with(|| Value::Number(0.into()));
+            user.entry("bgp_rtt_ns")
+                .or_insert_with(|| Value::Number(0.into()));
+        }
+    }
+
+    // doublezero-serviceability v0.25.1 split Device.interfaces:
+    //   old: `interfaces: Vec<Interface>` (enum with V1/V2 variants)
+    //   new: `deprecated_interfaces: Vec<InterfaceDeprecated>` + `interfaces: Vec<Interface>` (struct)
+    // Snapshots from before the split have `interfaces` in enum format; move those
+    // to `deprecated_interfaces` and build new-format `interfaces` from the V1/V2 bodies.
+    if let Some(devices) = serviceability
+        .get_mut("devices")
+        .and_then(|devices| devices.as_object_mut())
+    {
+        for device in devices.values_mut().filter_map(|d| d.as_object_mut()) {
+            // Detect old enum format: array elements are objects with "V1" or "V2" keys.
+            let is_old_format = device
+                .get("interfaces")
+                .and_then(|v| v.as_array())
+                .is_some_and(|arr| {
+                    arr.first()
+                        .is_some_and(|el| el.get("V1").is_some() || el.get("V2").is_some())
+                });
+
+            if is_old_format {
+                let old_interfaces = device.get("interfaces").cloned().unwrap_or_default();
+                device
+                    .entry("deprecated_interfaces")
+                    .or_insert(old_interfaces.clone());
+
+                // Convert each V1/V2 body into the new Interface struct format.
+                let new_interfaces: Vec<Value> = old_interfaces
+                    .as_array()
+                    .unwrap_or(&Vec::new())
+                    .iter()
+                    .filter_map(|el| {
+                        let (version, body) = if let Some(v1) = el.get("V1") {
+                            (1u8, v1)
+                        } else if let Some(v2) = el.get("V2") {
+                            (2u8, v2)
+                        } else {
+                            return None;
+                        };
+                        let mut iface = body.clone();
+                        if let Some(obj) = iface.as_object_mut() {
+                            obj.insert("size".to_string(), Value::Number(0.into()));
+                            obj.insert("version".to_string(), Value::Number(version.into()));
+                            // V1 fields absent from V2; default them.
+                            obj.entry("bandwidth").or_insert(Value::Number(0.into()));
+                            obj.entry("cir").or_insert(Value::Number(0.into()));
+                            obj.entry("mtu").or_insert(Value::Number(0.into()));
+                            obj.entry("interface_cyoa")
+                                .or_insert(Value::String("None".to_string()));
+                            obj.entry("interface_dia")
+                                .or_insert(Value::String("None".to_string()));
+                            obj.entry("routing_mode")
+                                .or_insert(Value::String("Static".to_string()));
+                            obj.entry("flex_algo_node_segments")
+                                .or_insert(Value::Array(Vec::new()));
+                        }
+                        Some(iface)
+                    })
+                    .collect();
+
+                device.insert("interfaces".to_string(), Value::Array(new_interfaces));
+            } else {
+                device
+                    .entry("deprecated_interfaces")
+                    .or_insert(Value::Array(Vec::new()));
+            }
+
+            // New Device fields added between v0.20 and v0.25.1.
+            device
+                .entry("device_health")
+                .or_insert(Value::String("Unknown".to_string()));
+            device
+                .entry("desired_status")
+                .or_insert(Value::String("Activated".to_string()));
+            device
+                .entry("unicast_users_count")
+                .or_insert(Value::Number(0.into()));
+            device
+                .entry("multicast_subscribers_count")
+                .or_insert(Value::Number(0.into()));
+            device
+                .entry("max_unicast_users")
+                .or_insert(Value::Number(0.into()));
+            device
+                .entry("max_multicast_subscribers")
+                .or_insert(Value::Number(0.into()));
+            device
+                .entry("reserved_seats")
+                .or_insert(Value::Number(0.into()));
         }
     }
 }

--- a/crates/contributor-rewards/tests/test_demand.rs
+++ b/crates/contributor-rewards/tests/test_demand.rs
@@ -172,7 +172,9 @@ mod tests {
         for user in fetch_data.dz_serviceability.users.values() {
             let is_live = !matches!(
                 user.status,
-                UserStatus::Rejected | UserStatus::Banned | UserStatus::PendingBan
+                UserStatus::RejectedDeprecated
+                    | UserStatus::Banned
+                    | UserStatus::PendingBanDeprecated
             );
             if user.user_type != UserType::Multicast || !is_live || user.is_publisher() {
                 continue;


### PR DESCRIPTION
In preparation for merging `doublezero-solana` cli into `doublezero` cli, unifying `doublezero` crate pins.

## Summary of Changes
* Bump all 7 `malbeclabs/doublezero` git pins from stale tags (`client/v0.20.0` and `client/v0.25.0`) to `client/v0.25.1`, unifying the workspace on a single monorepo revision
* Fix API drift: remove `into_current_version()` call in shapley handler (new `Interface` struct exposes fields directly), rename deprecated `UserStatus` variants
* Add JSON compat migration for the `Device.interfaces` split (old enum format → `deprecated_interfaces` + new struct format) and new `User.bgp_rtt_ns` field, keeping historical snapshots deserializable
* Fixes #1516

## Testing Verification
* Full test suite passes (400+ tests across the workspace, 0 failures)
* Snapshot-based demand tests (`test_demand_generation_from_json`, `test_subscriber_counts_come_from_users_not_device_counters`) verify the JSON compat migration correctly transforms old-format interface data
* Clippy clean, fmt clean
