### PR TITLE
client-tools: add Solana devnet (-ud) network environment

### DIFF
--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `revenue-distribution fetch validator-debts`: remove the written-off debt sanity check that aborted the command. It compared a windowed sum (the last 100 epochs of debt records) against the deposit's lifetime cumulative `written_off_sol_debt`, so it fired whenever a validator had a write-off older than the window (#380)
 - `passport`: route verbs through a typed `PassportCliError` (no more `"{e:#}"` cause-chain flattening), remove the remaining `.expect()`/`.unwrap()` panics, add golden-output tests for `fetch --config` and the find-validator gossip warnings, and emit a single combined JSON object when `fetch` is given both `--config` and `--access-request` (#378)
+- support the `-ud`/`devnet` network environment ([#384](https://github.com/doublezerofoundation/doublezero-offchain/pull/384))
 
 ## [0.5.6](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.6)
 

--- a/crates/solana-cli/src/command/passport.rs
+++ b/crates/solana-cli/src/command/passport.rs
@@ -150,7 +150,7 @@ fn build_ctx(
     json: bool,
     json_compact: bool,
 ) -> Result<CliContext> {
-    let env = map_env(conn.moniker_env());
+    let env = try_map_env(conn.moniker_env())?;
     let solana_l1_rpc_url = SolanaConnection::from(conn).url();
 
     let mut builder = CliContextBuilder::new()
@@ -163,10 +163,12 @@ fn build_ctx(
     builder.build().map_err(|e| anyhow::anyhow!("{e:#}"))
 }
 
-fn map_env(n: Option<NetworkEnvironment>) -> Environment {
-    match n {
-        Some(NetworkEnvironment::MainnetBeta) | None => Environment::MainnetBeta,
-        Some(NetworkEnvironment::Testnet) => Environment::Testnet,
-        Some(NetworkEnvironment::Localnet) => Environment::Local,
-    }
+fn try_map_env(n: Option<NetworkEnvironment>) -> Result<Environment> {
+    let env = match n.unwrap_or(NetworkEnvironment::MainnetBeta) {
+        NetworkEnvironment::MainnetBeta => Environment::MainnetBeta,
+        NetworkEnvironment::Testnet => Environment::Testnet,
+        NetworkEnvironment::Devnet => anyhow::bail!("passport is not available on Solana devnet"),
+        NetworkEnvironment::Localnet => Environment::Local,
+    };
+    Ok(env)
 }

--- a/crates/solana-cli/src/command/shreds/mod.rs
+++ b/crates/solana-cli/src/command/shreds/mod.rs
@@ -129,6 +129,7 @@ pub(in crate::command::shreds) fn shred_oracle_key(env: NetworkEnvironment) -> O
         NetworkEnvironment::Testnet => Some(solana_sdk::pubkey!(
             "BUtAWK4GaUV42YRp7jSHZhchspsshabn67HnBHnKxzsY"
         )),
+        NetworkEnvironment::Devnet => None,
         NetworkEnvironment::Localnet => None,
     }
 }
@@ -177,6 +178,9 @@ pub(in crate::command::shreds) fn serviceability_program_id(
             Ok(doublezero_serviceability::addresses::mainnet::program_id::id())
         }
         NetworkEnvironment::Testnet => {
+            Ok(doublezero_serviceability::addresses::testnet::program_id::id())
+        }
+        NetworkEnvironment::Devnet => {
             Ok(doublezero_serviceability::addresses::testnet::program_id::id())
         }
         NetworkEnvironment::Localnet => {

--- a/crates/solana-client-tools/CHANGELOG.md
+++ b/crates/solana-client-tools/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- add `Devnet` to `NetworkEnvironment`: `-ud`/`devnet` moniker, Solana devnet RPC URL, and genesis-hash detection ([#384](https://github.com/doublezerofoundation/doublezero-offchain/pull/384))
 - tolerate missing and unparseable accounts in try_fetch_multiple_zero_copy_data. Return type is now Result<Vec<Option<_>>> (breaking) ([#374](https://github.com/doublezerofoundation/doublezero-offchain/pull/374))
 - update solana-cli to handle defaults and tighten up error messages ([#373](https://github.com/doublezerofoundation/doublezero-offchain/pull/373))
 - support env var fallback for all CLI args ([#334](https://github.com/doublezerofoundation/doublezero-offchain/pull/334))

--- a/crates/solana-client-tools/src/rpc.rs
+++ b/crates/solana-client-tools/src/rpc.rs
@@ -34,6 +34,7 @@ pub enum NetworkEnvironment {
     #[default]
     MainnetBeta,
     Testnet,
+    Devnet,
     Localnet,
 }
 
@@ -42,6 +43,7 @@ impl NetworkEnvironment {
 
     pub const PUBLIC_SOLANA_MAINNET_BETA_URL: &str = "https://api.mainnet-beta.solana.com";
     pub const PUBLIC_SOLANA_TESTNET_URL: &str = "https://api.testnet.solana.com";
+    pub const PUBLIC_SOLANA_DEVNET_URL: &str = "https://api.devnet.solana.com";
 
     pub const PUBLIC_DOUBLEZERO_LEDGER_MAINNET_BETA_URL: &str =
         "https://doublezero-mainnet-beta.rpcpool.com/db336024-e7a8-46b1-80e5-352dd77060ab";
@@ -52,6 +54,8 @@ impl NetworkEnvironment {
         match self {
             NetworkEnvironment::MainnetBeta => Self::PUBLIC_DOUBLEZERO_LEDGER_MAINNET_BETA_URL,
             NetworkEnvironment::Testnet => Self::PUBLIC_DOUBLEZERO_LEDGER_TESTNET_URL,
+            // There is no DoubleZero Ledger devnet. Reuse the testnet ledger.
+            NetworkEnvironment::Devnet => Self::PUBLIC_DOUBLEZERO_LEDGER_TESTNET_URL,
             NetworkEnvironment::Localnet => Self::DEFAULT_LOCALNET_URL,
         }
     }
@@ -63,6 +67,7 @@ impl NetworkEnvironment {
         match self {
             NetworkEnvironment::MainnetBeta => Self::PUBLIC_SOLANA_MAINNET_BETA_URL,
             NetworkEnvironment::Testnet => Self::PUBLIC_DOUBLEZERO_LEDGER_TESTNET_URL,
+            NetworkEnvironment::Devnet => Self::PUBLIC_SOLANA_DEVNET_URL,
             NetworkEnvironment::Localnet => Self::DEFAULT_LOCALNET_URL,
         }
     }
@@ -71,6 +76,7 @@ impl NetworkEnvironment {
         match self {
             NetworkEnvironment::MainnetBeta => Self::PUBLIC_SOLANA_MAINNET_BETA_URL,
             NetworkEnvironment::Testnet => Self::PUBLIC_SOLANA_TESTNET_URL,
+            NetworkEnvironment::Devnet => Self::PUBLIC_SOLANA_DEVNET_URL,
             NetworkEnvironment::Localnet => Self::DEFAULT_LOCALNET_URL,
         }
     }
@@ -107,6 +113,7 @@ impl FromStr for NetworkEnvironment {
         match s {
             "m" | "mainnet-beta" => Ok(NetworkEnvironment::MainnetBeta),
             "t" | "testnet" => Ok(NetworkEnvironment::Testnet),
+            "d" | "devnet" => Ok(NetworkEnvironment::Devnet),
             "l" | "localhost" => Ok(NetworkEnvironment::Localnet),
             _ => bail!("Cannot convert moniker '{s}' to network environment"),
         }
@@ -116,7 +123,7 @@ impl FromStr for NetworkEnvironment {
 #[derive(Debug, Args, Clone, Default)]
 pub struct SolanaConnectionOptions {
     /// URL for Solana's JSON RPC or moniker (or their first letter):
-    /// [mainnet-beta, testnet, localhost].
+    /// [mainnet-beta, testnet, devnet, localhost].
     #[arg(long = "url", short = 'u', value_name = "URL_OR_MONIKER", env)]
     pub solana_url_or_moniker: Option<String>,
 }
@@ -124,7 +131,7 @@ pub struct SolanaConnectionOptions {
 impl SolanaConnectionOptions {
     const DEFAULT_MONIKER: &str = "m";
 
-    /// If the URL is a known moniker (m/t/l), return the corresponding network
+    /// If the URL is a known moniker (m/t/d/l), return the corresponding network
     /// environment. Returns `None` when a raw URL was provided.
     pub fn moniker_env(&self) -> Option<NetworkEnvironment> {
         let url_or_moniker = self
@@ -161,6 +168,8 @@ impl SolanaConnection {
         pubkey!("4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY");
     pub const DZ_LEDGER_TESTNET_GENESIS_HASH: Pubkey =
         pubkey!("GG2A8FHDoSH3cbQrTsxmMYZ6iy2yyRh7NY1yP7sXSH3v");
+    pub const SOLANA_DEVNET_GENESIS_HASH: Pubkey =
+        pubkey!("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG");
 
     pub fn new(url: String) -> Self {
         Self::new_with_commitment(url, CommitmentConfig::confirmed())
@@ -178,6 +187,7 @@ impl SolanaConnection {
             Self::SOLANA_TESTNET_GENESIS_HASH | Self::DZ_LEDGER_TESTNET_GENESIS_HASH => {
                 Ok(NetworkEnvironment::Testnet)
             }
+            Self::SOLANA_DEVNET_GENESIS_HASH => Ok(NetworkEnvironment::Devnet),
             _ => Ok(NetworkEnvironment::Localnet),
         }
     }
@@ -378,6 +388,8 @@ mod tests {
             ("mainnet-beta", NetworkEnvironment::MainnetBeta),
             ("t", NetworkEnvironment::Testnet),
             ("testnet", NetworkEnvironment::Testnet),
+            ("d", NetworkEnvironment::Devnet),
+            ("devnet", NetworkEnvironment::Devnet),
             ("l", NetworkEnvironment::Localnet),
             ("localhost", NetworkEnvironment::Localnet),
         ] {

--- a/crates/solana-sdk/src/lib.rs
+++ b/crates/solana-sdk/src/lib.rs
@@ -22,7 +22,9 @@ pub const fn compute_units_for_bump_seed(bump: u8) -> u32 {
 
 pub fn environment_2z_token_mint_key(network_env: NetworkEnvironment) -> Pubkey {
     match network_env {
-        NetworkEnvironment::Testnet => revenue_distribution::env::development::DOUBLEZERO_MINT_KEY,
+        NetworkEnvironment::Testnet | NetworkEnvironment::Devnet => {
+            revenue_distribution::env::development::DOUBLEZERO_MINT_KEY
+        }
         _ => revenue_distribution::env::mainnet::DOUBLEZERO_MINT_KEY,
     }
 }
@@ -30,6 +32,7 @@ pub fn environment_2z_token_mint_key(network_env: NetworkEnvironment) -> Pubkey 
 pub fn environment_usdc_token_mint_key(network_env: NetworkEnvironment) -> Pubkey {
     match network_env {
         NetworkEnvironment::Testnet => shred_subscription::env::development::USDC_MINT_KEY,
+        NetworkEnvironment::Devnet => shred_subscription::env::solana_devnet::USDC_MINT_KEY,
         _ => shred_subscription::env::mainnet::USDC_MINT_KEY,
     }
 }

--- a/crates/solana-sdk/src/shred_subscription/env.rs
+++ b/crates/solana-sdk/src/shred_subscription/env.rs
@@ -7,3 +7,9 @@ pub mod development {
     pub const USDC_MINT_KEY: solana_sdk::pubkey::Pubkey =
         solana_sdk::pubkey!("uSDZq2RMuxrEf7gqgDjR8wJCtCyaDAQk2e5jLAaoeeM");
 }
+
+pub mod solana_devnet {
+    // Circle's USDC mint on Solana devnet, Crossmint uses this one.
+    pub const USDC_MINT_KEY: solana_sdk::pubkey::Pubkey =
+        solana_sdk::pubkey!("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU");
+}


### PR DESCRIPTION
Closes https://github.com/malbeclabs/infra/issues/1564

## Summary
- client-tools: add a `Devnet` variant to `NetworkEnvironment` (moniker `d`/`devnet`, RPC URL `https://api.devnet.solana.com`, and genesis-hash detection), so the offchain CLIs can target Solana devnet via `-ud` instead of failing with "relative URL without a base"
- client-tools: the DoubleZero Ledger URL for devnet reuses the testnet ledger, since there is no DoubleZero Ledger devnet. The shred-subscription and Solana URLs point at Solana devnet
- solana-sdk: resolve devnet mints. 2Z uses the development mint, USDC uses the new `shred_subscription::env::solana_devnet::USDC_MINT_KEY` (the Solana devnet USDC, matching malbeclabs/doublezero-shreds#447)
- solana-cli: handle the new variant in `serviceability_program_id` (reuses the testnet program id), `shred_oracle_key`, and `passport`'s env mapping (`try_map_env`), which now errors on devnet since passport is not deployed there

## Testing
- Extended the `moniker_env_recognizes_monikers` unit test with `d`/`devnet` cases.

## Notes
- `NetworkEnvironment` is consumed by `doublezero-shreds` via git dependency. Bumping the pin there will require a `Devnet` arm in any exhaustive matches.
