### PR TITLE
solana-client-tools: add a shared create-ATA compute-unit helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,6 +2777,8 @@ dependencies = [
  "solana-rpc-client-types",
  "solana-sdk",
  "solana-transaction-status-client-types",
+ "spl-associated-token-account-interface",
+ "spl-token-interface",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",

--- a/crates/contributor-rewards/CHANGELOG.md
+++ b/crates/contributor-rewards/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- refactor(contributor-rewards): use the shared create-ATA compute-unit helper from `solana-client-tools`
 - fix(contributor-rewards): bump network shapley ([#377](https://github.com/doublezerofoundation/doublezero-offchain/pull/377))
 
 ## [0.5.5](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/contributor-rewards%2Fv0.5.5) - 2026-05-20

--- a/crates/contributor-rewards/CHANGELOG.md
+++ b/crates/contributor-rewards/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- refactor(contributor-rewards): use the shared create-ATA compute-unit helper from `solana-client-tools`
+- refactor(contributor-rewards): use the shared create-ATA compute-unit helper from `solana-client-tools` ([#386](https://github.com/doublezerofoundation/doublezero-offchain/pull/386))
 - fix(contributor-rewards): bump network shapley ([#377](https://github.com/doublezerofoundation/doublezero-offchain/pull/377))
 
 ## [0.5.5](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/contributor-rewards%2Fv0.5.5) - 2026-05-20

--- a/crates/contributor-rewards/src/calculator/distribute.rs
+++ b/crates/contributor-rewards/src/calculator/distribute.rs
@@ -19,10 +19,7 @@ use doublezero_solana_sdk::{
     try_build_instruction,
 };
 use solana_sdk::{compute_budget::ComputeBudgetInstruction, pubkey::Pubkey};
-use spl_associated_token_account_interface::{
-    address::get_associated_token_address_and_bump_seed,
-    instruction::create_associated_token_account_idempotent,
-};
+use spl_associated_token_account_interface::instruction::create_associated_token_account_idempotent;
 use tracing::{debug, info, warn};
 
 use crate::calculator::{ledger_operations::try_fetch_shapley_output, proof::ShapleyOutputStorage};
@@ -254,7 +251,6 @@ async fn try_distribute_contributor_rewards(
     reward_share: &RewardShare,
 ) -> Result<bool> {
     const DISTRIBUTE_REWARDS_CU_BASE: u32 = 30_000;
-    const CREATE_ATA_CU_BASE: u32 = 25_000;
     const PER_RECIPIENT_CU: u32 = 12_500;
 
     let wallet_key = wallet.pubkey();
@@ -317,17 +313,13 @@ async fn try_distribute_contributor_rewards(
         },
     )?;
 
-    // Derive ATA keys and bumps. We will need these bumps to set the CU
-    // precisely.
-    let (ata_keys, ata_bumps) = recipient_keys
+    // Derive ATA addresses together with their create-ATA compute-unit
+    // estimates. The address is needed for the existence check below. The CU is
+    // carried through to the recipients whose ATA must be created.
+    let (ata_keys, recipient_create_compute_units) = recipient_keys
         .iter()
         .map(|recipient_key| {
-            get_associated_token_address_and_bump_seed(
-                recipient_key,
-                dz_mint_key,
-                &spl_associated_token_account_interface::program::ID,
-                &spl_token_interface::ID,
-            )
+            Wallet::ata_address_and_create_compute_units(recipient_key, dz_mint_key)
         })
         .unzip::<_, _, Vec<_>, Vec<_>>();
 
@@ -339,15 +331,17 @@ async fn try_distribute_contributor_rewards(
         .await?
         .into_iter()
         .zip(recipient_keys.iter())
-        .zip(ata_bumps)
-        .filter_map(|((account_info, recipient_key), bump)| match account_info {
-            Some(account_info) if account_info.owner == Pubkey::default() => {
-                Some((recipient_key, bump))
-            }
-            None => Some((recipient_key, bump)),
-            _ => None,
-        })
-        .map(|(recipient_key, bump)| {
+        .zip(recipient_create_compute_units)
+        .filter_map(
+            |((account_info, recipient_key), create_compute_units)| match account_info {
+                Some(account_info) if account_info.owner == Pubkey::default() => {
+                    Some((recipient_key, create_compute_units))
+                }
+                None => Some((recipient_key, create_compute_units)),
+                _ => None,
+            },
+        )
+        .map(|(recipient_key, create_compute_units)| {
             let ix = create_associated_token_account_idempotent(
                 &wallet_key,
                 recipient_key,
@@ -355,9 +349,7 @@ async fn try_distribute_contributor_rewards(
                 &spl_token_interface::ID,
             );
 
-            let compute_unit_limit = CREATE_ATA_CU_BASE + Wallet::compute_units_for_bump_seed(bump);
-
-            (ix, compute_unit_limit)
+            (ix, create_compute_units)
         })
         .unzip::<_, _, Vec<_>, Vec<_>>();
 

--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- use the shared create-ATA compute-unit helper from `solana-client-tools`
+
 ## [0.5.7](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.7)
 
 - uptick crate to v0.5.7 (#385)

--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- use the shared create-ATA compute-unit helper from `solana-client-tools`
+- use the shared create-ATA compute-unit helper from `solana-client-tools` (#386)
 
 ## [0.5.7](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.7)
 

--- a/crates/solana-cli/src/command/revenue_distribution/relay/distribute_rewards.rs
+++ b/crates/solana-cli/src/command/revenue_distribution/relay/distribute_rewards.rs
@@ -19,10 +19,7 @@ use doublezero_solana_sdk::{
     try_build_instruction,
 };
 use solana_sdk::{compute_budget::ComputeBudgetInstruction, pubkey::Pubkey};
-use spl_associated_token_account_interface::{
-    address::get_associated_token_address_and_bump_seed,
-    instruction::create_associated_token_account_idempotent,
-};
+use spl_associated_token_account_interface::instruction::create_associated_token_account_idempotent;
 
 use crate::command::revenue_distribution::{
     relay::{
@@ -214,7 +211,6 @@ async fn try_distribute_contributor_rewards(
     reward_share: &RewardShare,
 ) -> Result<()> {
     const DISTRIBUTE_REWARDS_CU_BASE: u32 = 30_000;
-    const CREATE_ATA_CU_BASE: u32 = 25_000;
     const PER_RECIPIENT_CU: u32 = 12_500;
 
     let wallet_key = wallet.pubkey();
@@ -277,17 +273,13 @@ async fn try_distribute_contributor_rewards(
         },
     )?;
 
-    // Derive ATA keys and bumps. We will need these bumps to set the CU
-    // precisely.
-    let (ata_keys, ata_bumps) = recipient_keys
+    // Derive ATA addresses together with their create-ATA compute-unit
+    // estimates. The address is needed for the existence check below. The CU is
+    // carried through to the recipients whose ATA must be created.
+    let (ata_keys, recipient_create_compute_units) = recipient_keys
         .iter()
         .map(|recipient_key| {
-            get_associated_token_address_and_bump_seed(
-                recipient_key,
-                dz_mint_key,
-                &spl_associated_token_account_interface::program::ID,
-                &spl_token_interface::ID,
-            )
+            Wallet::ata_address_and_create_compute_units(recipient_key, dz_mint_key)
         })
         .unzip::<_, _, Vec<_>, Vec<_>>();
 
@@ -299,15 +291,17 @@ async fn try_distribute_contributor_rewards(
         .await?
         .into_iter()
         .zip(recipient_keys.iter())
-        .zip(ata_bumps)
-        .filter_map(|((account_info, recipient_key), bump)| match account_info {
-            Some(account_info) if account_info.owner == Pubkey::default() => {
-                Some((recipient_key, bump))
-            }
-            None => Some((recipient_key, bump)),
-            _ => None,
-        })
-        .map(|(recipient_key, bump)| {
+        .zip(recipient_create_compute_units)
+        .filter_map(
+            |((account_info, recipient_key), create_compute_units)| match account_info {
+                Some(account_info) if account_info.owner == Pubkey::default() => {
+                    Some((recipient_key, create_compute_units))
+                }
+                None => Some((recipient_key, create_compute_units)),
+                _ => None,
+            },
+        )
+        .map(|(recipient_key, create_compute_units)| {
             let ix = create_associated_token_account_idempotent(
                 &wallet_key,
                 recipient_key,
@@ -315,9 +309,7 @@ async fn try_distribute_contributor_rewards(
                 &spl_token_interface::ID,
             );
 
-            let compute_unit_limit = CREATE_ATA_CU_BASE + Wallet::compute_units_for_bump_seed(bump);
-
-            (ix, compute_unit_limit)
+            (ix, create_compute_units)
         })
         .unzip::<_, _, Vec<_>, Vec<_>>();
 

--- a/crates/solana-cli/src/command/shreds/publisher_rewards/configure.rs
+++ b/crates/solana-cli/src/command/shreds/publisher_rewards/configure.rs
@@ -22,10 +22,7 @@ use doublezero_solana_sdk::{
     try_build_instruction,
 };
 use solana_sdk::{compute_budget::ComputeBudgetInstruction, signature::Signature, signer::Signer};
-use spl_associated_token_account_interface::{
-    address::get_associated_token_address_and_bump_seed,
-    instruction::create_associated_token_account_idempotent,
-};
+use spl_associated_token_account_interface::instruction::create_associated_token_account_idempotent;
 
 use super::rewards_mint_arg::RewardsMintArg;
 
@@ -185,12 +182,11 @@ impl ConfigureCommand {
         // of each PDA derivation rather than a single conservative ceiling.
         let (srt_pda, srt_bump) = find_shred_reward_token_address(&rewards_token_mint);
         let (vpr_pda, vpr_bump) = find_validator_publisher_rewards_address(&self.node_id);
-        let (rewards_token_ata, ata_bump) = get_associated_token_address_and_bump_seed(
-            &self.rewards_token_owner,
-            &rewards_token_mint,
-            &spl_associated_token_account_interface::program::ID,
-            &spl_token_interface::ID,
-        );
+        let (rewards_token_ata, ata_create_compute_units) =
+            Wallet::ata_address_and_create_compute_units(
+                &self.rewards_token_owner,
+                &rewards_token_mint,
+            );
 
         println!("Shred subscription - Configure Validator Publisher Rewards");
         println!("Node ID:           {}", self.node_id);
@@ -224,7 +220,6 @@ impl ConfigureCommand {
         const INIT_VPR_CU_BASE: u32 = 20_000;
         const CONFIGURE_VPR_CU_BASE: u32 = 20_000;
         const ED25519_VERIFY_CU: u32 = 150_000;
-        const CREATE_ATA_CU_BASE: u32 = 25_000;
         const CHECK_CLI_VERSION_CU: u32 = 5_000;
 
         let mut compute_unit_limit: u32 = CHECK_CLI_VERSION_CU;
@@ -286,8 +281,7 @@ impl ConfigureCommand {
                 &rewards_token_mint,
                 &spl_token_interface::ID,
             ));
-            compute_unit_limit +=
-                CREATE_ATA_CU_BASE + Wallet::compute_units_for_bump_seed(ata_bump);
+            compute_unit_limit += ata_create_compute_units;
         }
 
         instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(

--- a/crates/solana-client-tools/CHANGELOG.md
+++ b/crates/solana-client-tools/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- add `Wallet::create_ata_compute_units` and `Wallet::ata_address_and_create_compute_units` helpers for estimating create-ATA compute units
+- add `Wallet::create_ata_compute_units` and `Wallet::ata_address_and_create_compute_units` helpers for estimating create-ATA compute units ([#386](https://github.com/doublezerofoundation/doublezero-offchain/pull/386))
 - add `Devnet` to `NetworkEnvironment`: `-ud`/`devnet` moniker, Solana devnet RPC URL, and genesis-hash detection ([#384](https://github.com/doublezerofoundation/doublezero-offchain/pull/384))
 - tolerate missing and unparseable accounts in try_fetch_multiple_zero_copy_data. Return type is now Result<Vec<Option<_>>> (breaking) ([#374](https://github.com/doublezerofoundation/doublezero-offchain/pull/374))
 - update solana-cli to handle defaults and tighten up error messages ([#373](https://github.com/doublezerofoundation/doublezero-offchain/pull/373))

--- a/crates/solana-client-tools/CHANGELOG.md
+++ b/crates/solana-client-tools/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- add `Wallet::create_ata_compute_units` and `Wallet::ata_address_and_create_compute_units` helpers for estimating create-ATA compute units
 - add `Devnet` to `NetworkEnvironment`: `-ud`/`devnet` moniker, Solana devnet RPC URL, and genesis-hash detection ([#384](https://github.com/doublezerofoundation/doublezero-offchain/pull/384))
 - tolerate missing and unparseable accounts in try_fetch_multiple_zero_copy_data. Return type is now Result<Vec<Option<_>>> (breaking) ([#374](https://github.com/doublezerofoundation/doublezero-offchain/pull/374))
 - update solana-cli to handle defaults and tighten up error messages ([#373](https://github.com/doublezerofoundation/doublezero-offchain/pull/373))

--- a/crates/solana-client-tools/Cargo.toml
+++ b/crates/solana-client-tools/Cargo.toml
@@ -20,6 +20,8 @@ solana-client.workspace = true
 solana-commitment-config.workspace = true
 solana-sdk.workspace = true
 solana-transaction-status-client-types.workspace = true
+spl-associated-token-account-interface.workspace = true
+spl-token-interface.workspace = true
 thiserror.workspace = true
 url.workspace = true
 

--- a/crates/solana-client-tools/src/payer.rs
+++ b/crates/solana-client-tools/src/payer.rs
@@ -18,6 +18,7 @@ use solana_sdk::{
     transaction::{TransactionError, VersionedTransaction},
 };
 use solana_transaction_status_client_types::UiTransactionEncoding;
+use spl_associated_token_account_interface::address::get_associated_token_address_and_bump_seed;
 
 // Re-export for backward compatibility
 pub use crate::keypair::try_load_keypair;
@@ -326,6 +327,24 @@ impl Wallet {
         1_500 * u32::from(255 - bump)
     }
 
+    // Base compute units for create_associated_token_account_idempotent, before
+    // the bump-dependent address re-derivation cost.
+    const CREATE_ATA_CU_BASE: u32 = 25_000;
+
+    pub fn create_ata_compute_units(bump: u8) -> u32 {
+        Self::CREATE_ATA_CU_BASE + Self::compute_units_for_bump_seed(bump)
+    }
+
+    pub fn ata_address_and_create_compute_units(owner: &Pubkey, mint: &Pubkey) -> (Pubkey, u32) {
+        let (address, bump) = get_associated_token_address_and_bump_seed(
+            owner,
+            mint,
+            &spl_associated_token_account_interface::program::ID,
+            &spl_token_interface::ID,
+        );
+        (address, Self::create_ata_compute_units(bump))
+    }
+
     pub fn default_send_transaction_config(&self) -> RpcSendTransactionConfig {
         RpcSendTransactionConfig {
             preflight_commitment: Some(self.connection.commitment().commitment),
@@ -366,4 +385,39 @@ fn try_load_specified_keypair(path: &PathBuf) -> Result<Keypair> {
         .with_context(|| format!("Invalid keypair found at {}", path.display()))?;
 
     Ok(default_keypair)
+}
+
+#[cfg(test)]
+mod tests {
+    use spl_associated_token_account_interface::address::get_associated_token_address_and_bump_seed;
+
+    use super::*;
+
+    #[test]
+    fn test_create_ata_compute_units_adds_base_to_bump_cost() {
+        // Bump 255 has zero re-derivation cost, so the result is just the base.
+        assert_eq!(Wallet::create_ata_compute_units(255), 25_000);
+        // Each bump candidate below 255 adds 1_500 CU.
+        assert_eq!(Wallet::create_ata_compute_units(254), 26_500);
+    }
+
+    #[test]
+    fn test_ata_address_and_create_compute_units_uses_classic_spl_token() {
+        let owner = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+
+        let (address, compute_units) = Wallet::ata_address_and_create_compute_units(&owner, &mint);
+
+        let (expected_address, expected_bump) = get_associated_token_address_and_bump_seed(
+            &owner,
+            &mint,
+            &spl_associated_token_account_interface::program::ID,
+            &spl_token_interface::ID,
+        );
+        assert_eq!(address, expected_address);
+        assert_eq!(
+            compute_units,
+            Wallet::create_ata_compute_units(expected_bump)
+        );
+    }
 }


### PR DESCRIPTION
Closes https://github.com/malbeclabs/doublezero/issues/3873

## Summary
- solana-client-tools: add `Wallet::create_ata_compute_units(bump)` (owning the single `CREATE_ATA_CU_BASE = 25_000`) and `Wallet::ata_address_and_create_compute_units(owner, mint)` for create-ATA compute-unit estimation
- contributor-rewards, solana-cli: replace the duplicated local `CREATE_ATA_CU_BASE` constants and inline formula with the shared combo helper (identical CU values)