### PR TITLE
chore(contributor-rewards): bump dz client to v0.27.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,8 +2350,8 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "doublezero-cli-core"
-version = "0.25.1"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
+version = "0.27.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.27.1#9669b0eebf4e33432b5100c56c99b64aced2effb"
 dependencies = [
  "bitflags",
  "clap",
@@ -2369,8 +2369,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-config"
-version = "0.25.1"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
+version = "0.27.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.27.1#9669b0eebf4e33432b5100c56c99b64aced2effb"
 dependencies = [
  "eyre",
  "serde",
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-contributor-rewards"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2433,8 +2433,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-geolocation"
-version = "0.25.1"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
+version = "0.27.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.27.1#9669b0eebf4e33432b5100c56c99b64aced2effb"
 dependencies = [
  "borsh 1.5.7",
  "borsh-incremental",
@@ -2544,8 +2544,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-program-common"
-version = "0.25.1"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
+version = "0.27.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.27.1#9669b0eebf4e33432b5100c56c99b64aced2effb"
 dependencies = [
  "borsh 1.5.7",
  "byteorder",
@@ -2580,8 +2580,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-record"
-version = "0.25.1"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
+version = "0.27.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.27.1#9669b0eebf4e33432b5100c56c99b64aced2effb"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -2640,8 +2640,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-serviceability"
-version = "0.25.1"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
+version = "0.27.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.27.1#9669b0eebf4e33432b5100c56c99b64aced2effb"
 dependencies = [
  "bitflags",
  "borsh 1.5.7",
@@ -2858,8 +2858,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-telemetry"
-version = "0.25.1"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
+version = "0.27.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.27.1#9669b0eebf4e33432b5100c56c99b64aced2effb"
 dependencies = [
  "borsh 1.5.7",
  "borsh-incremental",
@@ -2873,8 +2873,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero_sdk"
-version = "0.25.1"
-source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.25.1#b0b686e22d0ecf08e45c6404e96b86fe6286dfe4"
+version = "0.27.1"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.27.1#9669b0eebf4e33432b5100c56c99b64aced2effb"
 dependencies = [
  "async-trait",
  "backon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,40 +115,40 @@ tag = "revenue-distribution/v0.3.7"
 # RFC-20 CLI core: provides CliContext, OutputFormat, RequirementCheck, the
 # render_* output helpers, and the eyre-based error type. doublezero-cli-core
 # was introduced at client/v0.25.0; the whole SDK family is pinned to a single
-# monorepo revision (client/v0.25.1) so shared types unify across the boundary.
+# monorepo revision (client/v0.27.1) so shared types unify across the boundary.
 [workspace.dependencies.doublezero-cli-core]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.25.1"
+tag = "client/v0.27.1"
 
 # Source of the RFC-20 `Environment` enum consumed by `CliContext`. MUST be
 # pinned to the same tag as doublezero-cli-core so the `Environment` type
 # unifies across the boundary.
 [workspace.dependencies.doublezero-config]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.25.1"
+tag = "client/v0.27.1"
 
 [workspace.dependencies.doublezero-program-common]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.25.1"
+tag = "client/v0.27.1"
 
 [workspace.dependencies.doublezero-record]
 features = ["no-entrypoint"]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.25.1"
+tag = "client/v0.27.1"
 
 [workspace.dependencies.doublezero_sdk]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.25.1"
+tag = "client/v0.27.1"
 
 [workspace.dependencies.doublezero-serviceability]
 features = ["no-entrypoint", "serde"]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.25.1"
+tag = "client/v0.27.1"
 
 [workspace.dependencies.doublezero-telemetry]
 features = ["no-entrypoint", "serde"]
 git = "https://github.com/malbeclabs/doublezero"
-tag = "client/v0.25.1"
+tag = "client/v0.27.1"
 
 ### Other git dependencies
 

--- a/crates/contributor-rewards/CHANGELOG.md
+++ b/crates/contributor-rewards/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/contributor-rewards%2Fv0.6.1) - 2026-06-13
+
+- chore(contributor-rewards): bump doublezero client to `v0.27.1` ([#388](https://github.com/doublezerofoundation/doublezero-offchain/pull/388))
 - chore(contributor-rewards): converge the doublezero SDK family on `client/v0.25.1`, dropping the duplicate v0.20 lockfile entries; adapt to the v0.25 serviceability layout (flat `Device.interfaces`, renamed `UserStatus::*Deprecated` variants) and extend the snapshot compat migrations to backfill `Device.deprecated_interfaces`, the flat `Interface` projection, and `User.bgp_rtt_ns` ([#379](https://github.com/doublezerofoundation/doublezero-offchain/pull/379))
 - refactor(contributor-rewards): use the shared create-ATA compute-unit helper from `solana-client-tools` ([#386](https://github.com/doublezerofoundation/doublezero-offchain/pull/386))
+
+## [0.6.0](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/contributor-rewards%2Fv0.6.0) - 2026-05-31
+
 - fix(contributor-rewards): bump network shapley ([#377](https://github.com/doublezerofoundation/doublezero-offchain/pull/377))
 
 ## [0.5.5](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/contributor-rewards%2Fv0.5.5) - 2026-05-20

--- a/crates/contributor-rewards/Cargo.toml
+++ b/crates/contributor-rewards/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "doublezero-contributor-rewards"
 readme = "README.md"
-version = "0.6.0"
+version = "0.6.1"
 
 # Workspace inherited keys
 edition.workspace = true

--- a/crates/contributor-rewards/src/ingestor/types.rs
+++ b/crates/contributor-rewards/src/ingestor/types.rs
@@ -151,6 +151,33 @@ fn apply_serviceability_json_compat_migrations(serviceability: &mut Value) {
         }
     }
 
+    // doublezero-serviceability client/v0.27.1 appended per-pass EdgeSeat
+    // user counters/limits to AccessPass. Historical snapshots serialized
+    // before that bump do not contain them; default them to the same values used
+    // by onchain/Borsh deserialization for absent tails.
+    if let Some(access_passes) = serviceability
+        .get_mut("access_passes")
+        .and_then(|access_passes| access_passes.as_object_mut())
+    {
+        for access_pass in access_passes
+            .values_mut()
+            .filter_map(|access_pass| access_pass.as_object_mut())
+        {
+            access_pass
+                .entry("unicast_user_count")
+                .or_insert_with(|| Value::Number(0.into()));
+            access_pass
+                .entry("max_unicast_users")
+                .or_insert_with(|| Value::Number(1.into()));
+            access_pass
+                .entry("multicast_user_count")
+                .or_insert_with(|| Value::Number(0.into()));
+            access_pass
+                .entry("max_multicast_users")
+                .or_insert_with(|| Value::Number(1.into()));
+        }
+    }
+
     // doublezero-serviceability client/v0.25.0 split a Device's single
     // `interfaces` vec into two: a flat `interfaces: Vec<Interface>` written at
     // the end of the on-disk layout, plus a legacy

--- a/crates/sentinel/CHANGELOG.md
+++ b/crates/sentinel/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- chore(contributor-rewards): bump doublezero client to `v0.27.1` ([#388](https://github.com/doublezerofoundation/doublezero-offchain/pull/388))
 - fix(sentinel): adapt to SetAccessPassArgs API change after doublezero dep bump
 - refactor(sentinel): replace `multicast_group_codes` setting with `multicast_group_pubkeys` ([#315](https://github.com/doublezerofoundation/doublezero-offchain/pull/315))
 - fix(sentinel): associate access passes with solana tenant PDA ([#283](https://github.com/doublezerofoundation/doublezero-offchain/pull/283))

--- a/crates/sentinel/src/client/doublezero_ledger.rs
+++ b/crates/sentinel/src/client/doublezero_ledger.rs
@@ -177,6 +177,9 @@ impl DzRpcClient {
             last_access_epoch: u64::MAX,
             // NOTE: Setting this to false by default
             allow_multiple_ip: false,
+            // NOTE: Setting both to max allowed values
+            max_unicast_users: u16::MAX,
+            max_multicast_users: u16::MAX,
         });
         let accounts = vec![
             AccountMeta::new(pass_pk, false),


### PR DESCRIPTION
# Summary

- bump contributor-rewards to v0.6.1
- update changelog
- fix missing args for SetAccessPassArgs struct