### PR TITLE
solana-cli: shreds list --all returns only active seats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2832,7 +2832,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-solana-cli"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.8](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.8)
+
+- uptick crate to v0.5.8 (#392)
 - use the shared `Wallet` memo helpers from `solana-client-tools` in place of the local `RELAY_MEMO_CU` constant and the inline 5,000/15,000 memo estimates in `validator-deposit`
 - use the shared create-ATA compute-unit helper from `solana-client-tools` (#386)
+- `shreds list --all`: restrict to seats active in the latest subscription epoch (`active_epoch == max` across the queried seats) and print that epoch, so the result reflects current subscriptions instead of every seat that still has an on-chain escrow (lapsed seats whose accounts persist are excluded) (#392)
 
 ## [0.5.7](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.7)
 

--- a/crates/solana-cli/Cargo.toml
+++ b/crates/solana-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "doublezero-solana-cli"
 description = "Command line to interact with DoubleZero Solana programs"
-version = "0.5.7"
+version = "0.5.8"
 
 # Workspace inherited keys
 edition.workspace = true

--- a/crates/solana-cli/src/command/shreds/list.rs
+++ b/crates/solana-cli/src/command/shreds/list.rs
@@ -38,16 +38,18 @@ pub struct ListCommand {
     #[arg(long)]
     client_ip: Option<Ipv4Addr>,
 
-    /// Show seats regardless of funder, restricted to those active in the latest
-    /// subscription epoch (whose `active_epoch` equals the maximum across the
-    /// queried seats). Lapsed seats, whose accounts persist on-chain, are
-    /// excluded.
+    /// Show seats regardless of funder, restricted to those active in the
+    /// current subscription epoch (whose `active_epoch >= current_epoch`).
+    /// Lapsed seats, whose accounts persist on-chain, are excluded.
     #[arg(long)]
     all: bool,
 
     #[command(flatten)]
     connection_options: SolanaConnectionOptions,
 }
+
+/// A parsed client seat: `(seat_key, device_key, client_ip, tenure)`.
+type ParsedSeat = (Pubkey, Pubkey, Ipv4Addr, u16);
 
 #[derive(Debug, Tabled)]
 struct SeatRow {
@@ -118,15 +120,17 @@ impl ListCommand {
             return Ok(());
         }
 
-        // Parse all seats, recording each seat's active_epoch for the --active
-        // filter below.
+        // Parse all seats. When `--all` is set, also record each seat's
+        // active_epoch for the active-seat filter below.
         let mut active_epoch_by_seat: HashMap<Pubkey, u64> = HashMap::new();
-        let parsed_seats: Vec<_> = accounts
+        let parsed_seats: Vec<ParsedSeat> = accounts
             .iter()
             .filter_map(|(seat_key, account)| {
                 let (device_key, client_ip, tenure, _, active_epoch) =
                     state::parse_client_seat(&account.data)?;
-                active_epoch_by_seat.insert(*seat_key, active_epoch);
+                if self.all {
+                    active_epoch_by_seat.insert(*seat_key, active_epoch);
+                }
                 Some((*seat_key, device_key, client_ip, tenure))
             })
             .collect();
@@ -196,18 +200,9 @@ impl ListCommand {
         };
 
         let filtered_seats = if self.all {
-            match active_epoch_by_seat.values().copied().max() {
-                Some(current_epoch) => {
-                    println!("Active subscription epoch: {current_epoch}\n");
-                    filtered_seats
-                        .into_iter()
-                        .filter(|(seat_key, _, _, _)| {
-                            active_epoch_by_seat.get(seat_key) == Some(&current_epoch)
-                        })
-                        .collect()
-                }
-                None => filtered_seats,
-            }
+            let current_epoch = connection.get_epoch_info().await?.epoch;
+            println!("Active subscription epoch: {current_epoch}\n");
+            active_seats(filtered_seats, &active_epoch_by_seat, current_epoch)
         } else {
             filtered_seats
         };
@@ -288,6 +283,23 @@ impl ListCommand {
     }
 }
 
+/// Filter `seats` to those active in the current subscription epoch. A seat is
+/// active when its `active_epoch >= current_epoch`.
+fn active_seats(
+    seats: Vec<ParsedSeat>,
+    active_epoch_by_seat: &HashMap<Pubkey, u64>,
+    current_epoch: u64,
+) -> Vec<ParsedSeat> {
+    seats
+        .into_iter()
+        .filter(|(seat_key, _, _, _)| {
+            active_epoch_by_seat
+                .get(seat_key)
+                .is_some_and(|&active_epoch| active_epoch >= current_epoch)
+        })
+        .collect()
+}
+
 /// Fetch the current epoch price (base + premium, in whole USDC) for each device.
 async fn fetch_device_prices(
     connection: &SolanaConnection,
@@ -339,4 +351,58 @@ async fn fetch_device_prices(
     }
 
     Ok(prices)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a seat with the given active_epoch, returning the seat tuple and
+    /// its `(seat_key, active_epoch)` entry for the lookup map.
+    fn make_seat(active_epoch: u64) -> (ParsedSeat, (Pubkey, u64)) {
+        let seat_key = Pubkey::new_unique();
+        let seat = (
+            seat_key,
+            Pubkey::new_unique(),
+            Ipv4Addr::new(10, 0, 0, 1),
+            1,
+        );
+        (seat, (seat_key, active_epoch))
+    }
+
+    #[test]
+    fn active_seats_keeps_current_and_future_epochs() {
+        let (lapsed, lapsed_e) = make_seat(4);
+        let (current, current_e) = make_seat(5);
+        let (ahead, ahead_e) = make_seat(6);
+        let seats = vec![lapsed, current, ahead];
+        let map = HashMap::from([lapsed_e, current_e, ahead_e]);
+
+        let result = active_seats(seats, &map, 5);
+
+        let keys: Vec<Pubkey> = result.iter().map(|(k, ..)| *k).collect();
+        assert_eq!(keys, vec![current.0, ahead.0]);
+    }
+
+    #[test]
+    fn active_seats_excludes_all_when_subset_is_lapsed() {
+        // Regression: a --device subset where every seat has lapsed must not
+        // report stale seats as active. The old max()/== logic treated the
+        // most-recent lapsed seat as "active" against a stale derived epoch.
+        let (s1, e1) = make_seat(3);
+        let (s2, e2) = make_seat(4);
+        let seats = vec![s1, s2];
+        let map = HashMap::from([e1, e2]);
+
+        let result = active_seats(seats, &map, 5);
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn active_seats_excludes_seat_missing_from_map() {
+        let (seat, _) = make_seat(5);
+        let result = active_seats(vec![seat], &HashMap::new(), 5);
+        assert!(result.is_empty());
+    }
 }

--- a/crates/solana-cli/src/command/shreds/list.rs
+++ b/crates/solana-cli/src/command/shreds/list.rs
@@ -195,9 +195,6 @@ impl ListCommand {
             (balances, matching_seats)
         };
 
-        // With --all, restrict to seats active in the latest subscription epoch
-        // (the most recent epoch that settled seats); seats that lapsed in
-        // earlier epochs, whose accounts persist on-chain, are dropped.
         let filtered_seats = if self.all {
             match active_epoch_by_seat.values().copied().max() {
                 Some(current_epoch) => {

--- a/crates/solana-cli/src/command/shreds/list.rs
+++ b/crates/solana-cli/src/command/shreds/list.rs
@@ -283,8 +283,6 @@ impl ListCommand {
     }
 }
 
-/// Filter `seats` to those active in the current subscription epoch. A seat is
-/// active when its `active_epoch >= current_epoch`.
 fn active_seats(
     seats: Vec<ParsedSeat>,
     active_epoch_by_seat: &HashMap<Pubkey, u64>,

--- a/crates/solana-cli/src/command/shreds/list.rs
+++ b/crates/solana-cli/src/command/shreds/list.rs
@@ -38,7 +38,10 @@ pub struct ListCommand {
     #[arg(long)]
     client_ip: Option<Ipv4Addr>,
 
-    /// Show all seats regardless of funder.
+    /// Show seats regardless of funder, restricted to those active in the latest
+    /// subscription epoch (whose `active_epoch` equals the maximum across the
+    /// queried seats). Lapsed seats, whose accounts persist on-chain, are
+    /// excluded.
     #[arg(long)]
     all: bool,
 
@@ -115,12 +118,15 @@ impl ListCommand {
             return Ok(());
         }
 
-        // Parse all seats.
+        // Parse all seats, recording each seat's active_epoch for the --active
+        // filter below.
+        let mut active_epoch_by_seat: HashMap<Pubkey, u64> = HashMap::new();
         let parsed_seats: Vec<_> = accounts
             .iter()
             .filter_map(|(seat_key, account)| {
-                let (device_key, client_ip, tenure, _, _) =
+                let (device_key, client_ip, tenure, _, active_epoch) =
                     state::parse_client_seat(&account.data)?;
+                active_epoch_by_seat.insert(*seat_key, active_epoch);
                 Some((*seat_key, device_key, client_ip, tenure))
             })
             .collect();
@@ -187,6 +193,26 @@ impl ListCommand {
                 .filter(|(seat_key, _, _, _)| balances.contains_key(seat_key))
                 .collect();
             (balances, matching_seats)
+        };
+
+        // With --all, restrict to seats active in the latest subscription epoch
+        // (the most recent epoch that settled seats); seats that lapsed in
+        // earlier epochs, whose accounts persist on-chain, are dropped.
+        let filtered_seats = if self.all {
+            match active_epoch_by_seat.values().copied().max() {
+                Some(current_epoch) => {
+                    println!("Active subscription epoch: {current_epoch}\n");
+                    filtered_seats
+                        .into_iter()
+                        .filter(|(seat_key, _, _, _)| {
+                            active_epoch_by_seat.get(seat_key) == Some(&current_epoch)
+                        })
+                        .collect()
+                }
+                None => filtered_seats,
+            }
+        } else {
+            filtered_seats
         };
 
         if filtered_seats.is_empty() {


### PR DESCRIPTION
## Summary

- `shreds list --all` now returns only seats active in the latest subscription epoch (`active_epoch == max` across the queried seats) and prints that epoch, instead of every seat that has an escrow. `ClientSeat`/escrow accounts persist on-chain after a seat lapses, so the old `--all` count included long-dead seats.

## Testing

- Against mainnet: `shreds list --all` → `Active subscription epoch: 993`, 93 active seats (vs 349 unfiltered before).