### PR TITLE
solana-cli: claim all validator-client-rewards holdings by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# DoubleZero Offchain
+
+## Code conventions
+
+### Naming and prose
+
+- Always write "onchain", never "on-chain".
+- **No abbreviations for account or variable names — anywhere.** Spell out `validator_client_rewards`, not `vcr`. `validator_publisher_rewards`, not `vpr`. `shred_distribution`, not `sd`. This applies to source variable names, test bindings, code comments, program logs, PR titles, branch names, commit subjects, and any prose in this codebase. Acronyms that are universally known in the Solana/SPL ecosystem are fine — `PDA`, `ATA`, `CPI`, `SPL`, `SVM`, `IDL`. Project-specific shorthand is not — write out the full name even if it appears many times in a single function.
+
+### Type annotations
+
+- **Never** define types anywhere the Rust compiler can infer them. This is non-negotiable and applies everywhere — `let` bindings (source and tests), numeric literals, function-call turbofishes, test helpers, struct field initializers, function arguments. If `let x = ...;` compiles, do not write `let x: Foo = ...;`. If `5_000` compiles, do not write `5_000u16` or `5_000_u32`. If `.collect()` compiles, do not write `.collect::<Vec<_>>()`. **In particular, do not write `let mut x: u64 = 0;` — write `let mut x = 0;` and let the first usage drive inference.** Only add annotations when the compiler genuinely cannot infer. When in doubt, write without the annotation and add one only if the compiler asks.
+- When the compiler does need a type hint, prefer **turbofish on the call site** (`.collect::<Vec<_>>()`, `<u32>::try_from(x)`) over annotating the `let` binding (`let xs: Vec<_> = ...`). Turbofish documents the type at the point it is needed; a let-binding annotation hides that intent and decays as the surrounding code changes.
+
+### Comments and docstrings
+
+- **`///` and `//!` docstrings are reserved for the crate's published API.** For structs, enums, type aliases, and constants that live inside a crate with no published rustdoc consumer, do not write `///` rustdoc on the item or on its fields. Field-level comments that just restate the field name are noise. The type and the field's name should carry the meaning. If a field's behavior or rationale is genuinely non-obvious (cross-variant naming, security-relevant invariants, contract between caller and helper), use a single `//` line comment above the field. Function and method docstrings on internal items are not covered by this rule. Those are fine.
+
+    `///` on a `pub` function or method is allowed only when that item is reachable from the crate root through a `pub` module chain (a `pub` item inside a private submodule is not part of the published surface, so it follows the internal rule). `//!` module-level docs are allowed only on `pub` modules and must be one short line.
+
+### Error handling
+
+- **Prefer the `anyhow::Context` trait over the `anyhow!` macro.** Reach for `.context("...")` / `.with_context(|| ...)` rather than `.ok_or_else(|| anyhow!("..."))` on `Option<T>` or `.map_err(|e| anyhow!(e))` on `Result<T, E>`. For a `Result<T, String>` (or any `Display + Send + Sync + 'static` error), use `.map_err(anyhow::Error::msg)`. `anyhow!` and `bail!` are reserved for cases where you genuinely need to construct a new error from scratch with no Option/Result to attach context to — `ensure!`/`bail!` for invariant violations are fine.
+
+### Abstraction discipline
+
+- **Don't extract a helper function for code that only one caller uses.** Inline it. Helpers earn their keep by deduplicating logic across multiple call sites; a single-call-site helper just hides the work at the cost of an extra hop. The exception is when the helper is itself the unit under test (a parser, math routine, fixture builder being directly verified). Applies to source code, test code, and build/tooling scripts alike.
+- **Do not add a new workspace crate without explicit ask.** New top-level crates change the workspace layout, bring CI surface area, and force a decision about naming, dependencies, and feature flags. Before proposing one, ask. If the work fits inside an existing crate (even if the crate's purpose stretches slightly), prefer extending the existing crate. The same rule applies to splitting a crate into multiple crates or merging existing crates.
+
+### Tests
+
+- **Every test function name starts with `test_`.** Write `#[test] fn test_<what_it_checks>()`, not `#[test] fn <what_it_checks>()`. Applies to `#[test]`, `#[tokio::test]`, unit tests, and integration tests alike.

--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `shreds validator-client-rewards claim`: claim every outstanding holding by default. `--subscription-epoch` is now optional — omit it to discover and drain all holdings for the client and mint (current epoch read from `getEpochInfo`). The 16-epoch cap is replaced by automatic batching into `≤16`-per-tx transactions, and explicit epochs whose holding is missing/wrong-mint/invalid are warned and skipped instead of failing the whole claim (#393)
+
 ## [0.5.8](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.8)
 
 - uptick crate to v0.5.8 (#392)

--- a/crates/solana-cli/src/command/shreds/validator_client_rewards/claim.rs
+++ b/crates/solana-cli/src/command/shreds/validator_client_rewards/claim.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, bail, ensure};
 use clap::Args;
 use doublezero_solana_client_tools::{
     payer::{SolanaPayerOptions, TransactionOutcome, Wallet},
@@ -64,25 +64,27 @@ pub(crate) fn resolve_destination(
     override_destination.unwrap_or_else(|| get_associated_token_address(manager, mint))
 }
 
-pub(crate) fn validate_manager(wallet: &Pubkey, vcr_manager: &Pubkey) -> Result<()> {
-    if wallet != vcr_manager {
-        return Err(anyhow!(
-            "manager mismatch: wallet is {wallet}, VCR manager is {vcr_manager}"
-        ));
-    }
+pub(crate) fn validate_manager(
+    wallet: &Pubkey,
+    validator_client_rewards_manager: &Pubkey,
+) -> Result<()> {
+    ensure!(
+        wallet == validator_client_rewards_manager,
+        "manager mismatch: wallet is {wallet}, validator client rewards manager is {validator_client_rewards_manager}"
+    );
     Ok(())
 }
 
-/// Upper bound on epochs per claim tx. Each `ClaimHoldingId` adds 9 bytes of
-/// instruction data and the holding account adds 32 bytes to the account list,
-/// so beyond ~20 the tx blows past the 1232-byte packet limit. 16 is a
-/// conservative cap that leaves room for the destination/rent/program-config
-/// accounts and the CheckCliVersion ix.
+// Upper bound on epochs per claim tx. Each `ClaimHoldingId` adds 9 bytes of
+// instruction data and the holding account adds 32 bytes to the account list,
+// so beyond ~20 the tx blows past the 1232-byte packet limit. 16 is a
+// conservative cap that leaves room for the destination/rent/program-config
+// accounts and the CheckCliVersion ix.
 pub(crate) const MAX_CLAIM_EPOCHS_PER_TX: usize = 16;
 
-/// How far back (in subscription epochs) auto-discovery probes from the current
-/// epoch. Holdings older than the on-chain abandonment window are swept, so this
-/// covers every holding that can still exist.
+// How far back (in subscription epochs) auto-discovery probes from the current
+// epoch. Holdings older than the on-chain abandonment window are swept, so this
+// covers every holding that can still exist.
 const MAX_DISCOVERY_LOOKBACK: u64 = 90;
 
 struct HoldingToClaim {
@@ -113,37 +115,43 @@ impl ClaimCommand {
         let wallet = Wallet::try_new(self.solana_payer_options, Some(dz_connection))?;
         let wallet_key = wallet.pubkey();
 
-        let vcr_key = find_validator_client_rewards_address(self.client_id).0;
+        let validator_client_rewards_key = find_validator_client_rewards_address(self.client_id).0;
         let program_config_key = find_program_config_address().0;
 
-        // Single fetch: VCR, ProgramConfig.
-        let accounts =
-            try_fetch_multiple_accounts(&wallet.connection, &[vcr_key, program_config_key])
-                .await
-                .with_context(|| "fetching VCR + program config")?;
+        // Single fetch: validator client rewards, program config.
+        let accounts = try_fetch_multiple_accounts(
+            &wallet.connection,
+            &[validator_client_rewards_key, program_config_key],
+        )
+        .await
+        .context("fetching validator client rewards + program config")?;
 
-        let vcr_account = accounts.first().and_then(|a| a.as_ref()).ok_or_else(|| {
-            anyhow!(
-                "validator client rewards not initialized for client-id {} (PDA {})",
-                self.client_id,
-                vcr_key
-            )
+        let validator_client_rewards_account =
+            accounts.first().and_then(|a| a.as_ref()).with_context(|| {
+                format!(
+                    "validator client rewards not initialized for client-id {} (PDA {validator_client_rewards_key})",
+                    self.client_id
+                )
+            })?;
+        let validator_client_rewards_info = parse_validator_client_rewards(
+            &validator_client_rewards_account.data,
+        )
+        .with_context(|| {
+            format!("failed to parse ValidatorClientRewards at {validator_client_rewards_key}")
         })?;
-        let vcr_info = parse_validator_client_rewards(&vcr_account.data)
-            .ok_or_else(|| anyhow!("failed to parse ValidatorClientRewards at {vcr_key}"))?;
-        validate_manager(&wallet_key, &vcr_info.manager_key)?;
+        validate_manager(&wallet_key, &validator_client_rewards_info.manager_key)?;
 
-        let cfg_account = accounts
+        let config_account = accounts
             .get(1)
             .and_then(|a| a.as_ref())
-            .ok_or_else(|| anyhow!("ProgramConfig {program_config_key} not found onchain"))?;
-        let rent_beneficiary = parse_program_config_shred_oracle_key(&cfg_account.data)
-            .ok_or_else(|| anyhow!("failed to parse shred_oracle_key from ProgramConfig"))?;
+            .with_context(|| format!("ProgramConfig {program_config_key} not found onchain"))?;
+        let rent_beneficiary = parse_program_config_shred_oracle_key(&config_account.data)
+            .context("failed to parse shred_oracle_key from ProgramConfig")?;
 
         // Resolve the set of holdings to claim: explicit epochs (validated), or
         // every outstanding holding discovered on chain.
         let holdings = if self.subscription_epochs.is_empty() {
-            let target = vcr_info.claim_holding_count as usize;
+            let target = validator_client_rewards_info.claim_holding_count as usize;
             if target == 0 {
                 println!(
                     "No outstanding claim holdings for client_id {} (claim_holding_count is 0).",
@@ -159,11 +167,15 @@ impl ClaimCommand {
                 .connection
                 .get_epoch_info()
                 .await
-                .with_context(|| "fetching current epoch")?
+                .context("fetching current epoch")?
                 .epoch;
-            let discovered =
-                discover_holdings(&wallet, &vcr_key, &self.rewards_token_mint, current_epoch)
-                    .await?;
+            let discovered = discover_holdings(
+                &wallet,
+                &validator_client_rewards_key,
+                &self.rewards_token_mint,
+                current_epoch,
+            )
+            .await?;
             if discovered.is_empty() {
                 println!(
                     "No claim holdings for client_id {} found for mint {} within the last {MAX_DISCOVERY_LOOKBACK} epochs.",
@@ -190,7 +202,7 @@ impl ClaimCommand {
         } else {
             validate_explicit_holdings(
                 &wallet,
-                &vcr_key,
+                &validator_client_rewards_key,
                 &self.rewards_token_mint,
                 &self.subscription_epochs,
             )
@@ -211,40 +223,41 @@ impl ClaimCommand {
             &self.rewards_token_mint,
             self.destination_token_account,
         );
-        let dest_account = wallet
+        let destination_account = wallet
             .connection
             .get_account_with_commitment(&destination, CommitmentConfig::confirmed())
             .await
             .with_context(|| format!("fetching destination token account {destination}"))?
             .value
-            .ok_or_else(|| {
-                anyhow!(
+            .with_context(|| {
+                format!(
                     "destination token account {destination} does not exist. \
                      Run: `spl-token create-account --owner {wallet_key} {} --fee-payer {wallet_key}`",
                     self.rewards_token_mint
                 )
             })?;
-        if dest_account.owner != spl_token_interface::ID {
+        if destination_account.owner != spl_token_interface::ID {
             bail!(
                 "destination {destination} is not an SPL token account (owner = {})",
-                dest_account.owner
+                destination_account.owner
             );
         }
-        let dest_token = spl_token_interface::state::Account::unpack(&dest_account.data)
-            .with_context(|| format!("unpacking destination token account {destination}"))?;
-        if dest_token.mint != self.rewards_token_mint {
+        let destination_token =
+            spl_token_interface::state::Account::unpack(&destination_account.data)
+                .with_context(|| format!("unpacking destination token account {destination}"))?;
+        if destination_token.mint != self.rewards_token_mint {
             bail!(
                 "destination {destination} mint mismatch: expected {}, found {}",
                 self.rewards_token_mint,
-                dest_token.mint
+                destination_token.mint
             );
         }
 
         let total_holdings = holdings.len();
-        let total_pre_balance = holdings
-            .iter()
-            .fold(0u64, |acc, h| acc.saturating_add(h.pre_balance));
-        let batches: Vec<&[HoldingToClaim]> = holdings.chunks(MAX_CLAIM_EPOCHS_PER_TX).collect();
+        let total_pre_balance = holdings.iter().fold(0u64, |total, holding| {
+            total.saturating_add(holding.pre_balance)
+        });
+        let batches = holdings.chunks(MAX_CLAIM_EPOCHS_PER_TX).collect::<Vec<_>>();
         let batch_count = batches.len();
 
         println!(
@@ -259,17 +272,20 @@ impl ClaimCommand {
         // Submit one transaction per batch of up to MAX_CLAIM_EPOCHS_PER_TX
         // holdings. Batches are independent, so a later failure does not undo an
         // earlier executed batch.
-        let mut executed_holdings = 0usize;
+        let mut executed_holdings = 0;
         let mut last_executed = false;
         for (batch_index, batch) in batches.into_iter().enumerate() {
-            let epochs: Vec<u64> = batch.iter().map(|h| h.epoch).collect();
-            let claim_holding_ids: Vec<ClaimHoldingId> = batch
+            let epochs = batch
                 .iter()
-                .map(|h| ClaimHoldingId {
-                    subscription_epoch: h.epoch,
-                    bump_seed: h.bump_seed,
+                .map(|holding| holding.epoch)
+                .collect::<Vec<_>>();
+            let claim_holding_ids = batch
+                .iter()
+                .map(|holding| ClaimHoldingId {
+                    subscription_epoch: holding.epoch,
+                    bump_seed: holding.bump_seed,
                 })
-                .collect();
+                .collect::<Vec<_>>();
 
             let claim_accounts = ClaimValidatorClientRewardsAccounts::new(
                 self.client_id,
@@ -287,8 +303,12 @@ impl ClaimCommand {
             )?;
 
             let mut instructions = vec![super::super::build_check_cli_version_instruction()?, ix];
-            let cu_limit: u32 = 30_000u32.saturating_mul(epochs.len() as u32 + 1);
-            instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(cu_limit));
+            // ~30k CU per holding (token transfer + close + state decrement),
+            // plus the check-cli-version ix.
+            let compute_unit_limit = 30_000u32.saturating_mul(epochs.len() as u32 + 1);
+            instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(
+                compute_unit_limit,
+            ));
             if let Some(ref compute_unit_price_ix) = wallet.compute_unit_price_ix {
                 instructions.push(compute_unit_price_ix.clone());
             }
@@ -313,10 +333,10 @@ impl ClaimCommand {
                 // between the read and the claim makes the actual drained amount
                 // higher. Diff the destination balance before/after for the
                 // authoritative number.
-                for h in batch {
+                for holding in batch {
                     println!(
                         "  epoch {}: {} from {} (pre-claim)",
-                        h.epoch, h.pre_balance, h.holding_pda,
+                        holding.epoch, holding.pre_balance, holding.holding_pda,
                     );
                 }
                 wallet.print_verbose_output(&[tx_sig]).await?;
@@ -328,17 +348,24 @@ impl ClaimCommand {
                 "\nPre-claim total: {total_pre_balance} ({executed_holdings}/{total_holdings} holding(s) claimed across {batch_count} transaction(s))."
             );
 
-            // Re-fetch the VCR to report the post-tx claim_holding_count.
+            // Re-fetch the validator client rewards account to report the
+            // post-tx claim_holding_count.
             let post_count = match wallet
                 .connection
-                .get_account_with_commitment(&vcr_key, CommitmentConfig::confirmed())
+                .get_account_with_commitment(
+                    &validator_client_rewards_key,
+                    CommitmentConfig::confirmed(),
+                )
                 .await
             {
-                Ok(resp) => resp.value.and_then(|acct| {
-                    parse_validator_client_rewards(&acct.data).map(|i| i.claim_holding_count)
+                Ok(response) => response.value.and_then(|account| {
+                    parse_validator_client_rewards(&account.data)
+                        .map(|info| info.claim_holding_count)
                 }),
                 Err(err) => {
-                    eprintln!("warning: post-claim VCR re-fetch failed: {err}");
+                    eprintln!(
+                        "warning: post-claim validator client rewards re-fetch failed: {err}"
+                    );
                     None
                 }
             };
@@ -352,27 +379,28 @@ impl ClaimCommand {
     }
 }
 
-/// Discover every outstanding claim holding for `vcr_key`/`mint` by probing
-/// every holding PDA in `[ceiling_epoch - MAX_DISCOVERY_LOOKBACK, ceiling_epoch]`.
-/// Returns the holdings that exist, sorted by epoch.
+/// Discover every outstanding claim holding for `validator_client_rewards_key`/`mint`
+/// by probing every holding PDA in
+/// `[ceiling_epoch - MAX_DISCOVERY_LOOKBACK, ceiling_epoch]`. Returns the
+/// holdings that exist, sorted by epoch.
 async fn discover_holdings(
     wallet: &Wallet,
-    vcr_key: &Pubkey,
+    validator_client_rewards_key: &Pubkey,
     mint: &Pubkey,
     ceiling_epoch: u64,
 ) -> Result<Vec<HoldingToClaim>> {
     let floor = ceiling_epoch.saturating_sub(MAX_DISCOVERY_LOOKBACK);
-    let derived: Vec<(u64, Pubkey, u8)> = (floor..=ceiling_epoch)
+    let derived = (floor..=ceiling_epoch)
         .map(|epoch| {
-            let (pda, bump) = find_claim_holding_address(vcr_key, epoch, mint);
+            let (pda, bump) = find_claim_holding_address(validator_client_rewards_key, epoch, mint);
             (epoch, pda, bump)
         })
-        .collect();
-    let keys: Vec<Pubkey> = derived.iter().map(|(_, pda, _)| *pda).collect();
+        .collect::<Vec<_>>();
+    let keys = derived.iter().map(|(_, pda, _)| *pda).collect::<Vec<_>>();
     let probed = try_fetch_multiple_accounts(&wallet.connection, &keys)
         .await
-        .with_context(|| "probing claim holdings")?;
-    let mut found: Vec<HoldingToClaim> = Vec::new();
+        .context("probing claim holdings")?;
+    let mut found = Vec::new();
     for ((epoch, pda, bump), account) in derived.into_iter().zip(probed) {
         if let Some(pre_balance) = holding_balance(account.as_ref(), mint) {
             found.push(HoldingToClaim {
@@ -383,14 +411,14 @@ async fn discover_holdings(
             });
         }
     }
-    found.sort_unstable_by_key(|h| h.epoch);
+    found.sort_unstable_by_key(|holding| holding.epoch);
     Ok(found)
 }
 
 /// Resolve an explicit set of subscription epochs into claimable holdings.
 async fn validate_explicit_holdings(
     wallet: &Wallet,
-    vcr_key: &Pubkey,
+    validator_client_rewards_key: &Pubkey,
     mint: &Pubkey,
     epochs: &[u64],
 ) -> Result<Vec<HoldingToClaim>> {
@@ -398,31 +426,31 @@ async fn validate_explicit_holdings(
     epochs.sort_unstable();
     epochs.dedup();
 
-    let derived: Vec<(u64, Pubkey, u8)> = epochs
+    let derived = epochs
         .iter()
         .map(|&epoch| {
-            let (pda, bump) = find_claim_holding_address(vcr_key, epoch, mint);
+            let (pda, bump) = find_claim_holding_address(validator_client_rewards_key, epoch, mint);
             (epoch, pda, bump)
         })
-        .collect();
+        .collect::<Vec<_>>();
 
-    let keys: Vec<Pubkey> = derived.iter().map(|(_, pda, _)| *pda).collect();
+    let keys = derived.iter().map(|(_, pda, _)| *pda).collect::<Vec<_>>();
     let accounts = try_fetch_multiple_accounts(&wallet.connection, &keys)
         .await
-        .with_context(|| "fetching claim holdings")?;
+        .context("fetching claim holdings")?;
 
-    let mut holdings: Vec<HoldingToClaim> = Vec::new();
-    for ((epoch, pda, bump), maybe_acct) in derived.iter().zip(accounts) {
-        match maybe_acct.as_ref() {
+    let mut holdings = Vec::new();
+    for ((epoch, pda, bump), maybe_account) in derived.iter().zip(accounts) {
+        match maybe_account.as_ref() {
             None => eprintln!(
                 "warning: epoch {epoch} holding {pda} is not initialized; skipping. \
                  Run `shreds validator-client-rewards init-holding ...` to create it."
             ),
-            Some(acct) if acct.owner != spl_token_interface::ID => eprintln!(
+            Some(account) if account.owner != spl_token_interface::ID => eprintln!(
                 "warning: epoch {epoch} holding {pda} is not an SPL token account (owner {}); skipping.",
-                acct.owner
+                account.owner
             ),
-            Some(acct) => match spl_token_interface::state::Account::unpack(&acct.data) {
+            Some(account) => match spl_token_interface::state::Account::unpack(&account.data) {
                 Ok(token) if token.mint != *mint => eprintln!(
                     "warning: epoch {epoch} holding {pda} is for mint {} (expected {mint}); skipping.",
                     token.mint
@@ -462,7 +490,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_required_args_with_implicit_destination() {
+    fn test_parses_required_args_with_implicit_destination() {
         let mint = Pubkey::new_unique();
         let cli = Cli::try_parse_from([
             "test",
@@ -476,14 +504,14 @@ mod tests {
         .unwrap();
         assert_eq!(cli.cmd.client_id, 7);
         assert_eq!(cli.cmd.rewards_token_mint, mint);
-        assert_eq!(cli.cmd.subscription_epochs, vec![100u64]);
+        assert_eq!(cli.cmd.subscription_epochs, vec![100]);
         assert!(cli.cmd.destination_token_account.is_none());
     }
 
     #[test]
-    fn parses_explicit_destination() {
+    fn test_parses_explicit_destination() {
         let mint = Pubkey::new_unique();
-        let dest = Pubkey::new_unique();
+        let destination = Pubkey::new_unique();
         let cli = Cli::try_parse_from([
             "test",
             "--client-id",
@@ -493,25 +521,25 @@ mod tests {
             "--subscription-epoch",
             "100",
             "--destination-token-account",
-            &dest.to_string(),
+            &destination.to_string(),
         ])
         .unwrap();
-        assert_eq!(cli.cmd.destination_token_account, Some(dest));
+        assert_eq!(cli.cmd.destination_token_account, Some(destination));
     }
 
     #[test]
-    fn resolve_destination_uses_override_when_provided() {
+    fn test_resolve_destination_uses_override_when_provided() {
         let manager = Pubkey::new_unique();
         let mint = Pubkey::new_unique();
-        let override_dest = Pubkey::new_unique();
+        let override_destination = Pubkey::new_unique();
         assert_eq!(
-            resolve_destination(&manager, &mint, Some(override_dest)),
-            override_dest
+            resolve_destination(&manager, &mint, Some(override_destination)),
+            override_destination
         );
     }
 
     #[test]
-    fn resolve_destination_defaults_to_ata() {
+    fn test_resolve_destination_defaults_to_ata() {
         let manager = Pubkey::new_unique();
         let mint = Pubkey::new_unique();
         let expected = get_associated_token_address(&manager, &mint);
@@ -519,24 +547,24 @@ mod tests {
     }
 
     #[test]
-    fn validate_manager_matches() {
+    fn test_validate_manager_matches() {
         let wallet = Pubkey::new_unique();
         assert!(validate_manager(&wallet, &wallet).is_ok());
     }
 
     #[test]
-    fn validate_manager_mismatch() {
+    fn test_validate_manager_mismatch() {
         let wallet = Pubkey::new_unique();
         let manager = Pubkey::new_unique();
         let err = validate_manager(&wallet, &manager).unwrap_err();
-        let msg = format!("{err}");
-        assert!(msg.contains("manager mismatch"));
-        assert!(msg.contains(&wallet.to_string()));
-        assert!(msg.contains(&manager.to_string()));
+        let message = format!("{err}");
+        assert!(message.contains("manager mismatch"));
+        assert!(message.contains(&wallet.to_string()));
+        assert!(message.contains(&manager.to_string()));
     }
 
     #[test]
-    fn allows_missing_subscription_epoch() {
+    fn test_allows_missing_subscription_epoch() {
         // Omitting --subscription-epoch is valid: the command discovers and
         // claims every outstanding holding for the client and mint.
         let mint = Pubkey::new_unique();
@@ -549,22 +577,5 @@ mod tests {
         ])
         .unwrap();
         assert!(cli.cmd.subscription_epochs.is_empty());
-    }
-
-    #[test]
-    fn max_claim_epochs_keeps_tx_under_packet_limit() {
-        // Sanity-check the cap: at MAX_CLAIM_EPOCHS_PER_TX, the holding-id
-        // payload + per-holding account metas should stay well under the
-        // 1232-byte Solana packet limit (accounting for the ~256 bytes of
-        // fixed overhead from signature/header/fixed-accounts/blockhash).
-        let payload_per_epoch = 9; // ClaimHoldingId = u64 + u8
-        let account_meta_per_epoch = 32; // one Pubkey per holding
-        let approx_per_epoch = payload_per_epoch + account_meta_per_epoch;
-        let approx_overhead = 256;
-        let total = approx_overhead + approx_per_epoch * MAX_CLAIM_EPOCHS_PER_TX;
-        assert!(
-            total < 1232,
-            "MAX_CLAIM_EPOCHS_PER_TX={MAX_CLAIM_EPOCHS_PER_TX} produces approx tx size {total} >= 1232"
-        );
     }
 }

--- a/crates/solana-cli/src/command/shreds/validator_client_rewards/claim.rs
+++ b/crates/solana-cli/src/command/shreds/validator_client_rewards/claim.rs
@@ -1,6 +1,9 @@
 use anyhow::{Context, Result, anyhow, bail};
 use clap::Args;
-use doublezero_solana_client_tools::payer::{SolanaPayerOptions, TransactionOutcome, Wallet};
+use doublezero_solana_client_tools::{
+    payer::{SolanaPayerOptions, TransactionOutcome, Wallet},
+    rpc::try_fetch_multiple_accounts,
+};
 use doublezero_solana_sdk::{
     shred_subscription::{
         ID,
@@ -77,9 +80,6 @@ pub(crate) fn validate_manager(wallet: &Pubkey, vcr_manager: &Pubkey) -> Result<
 /// accounts and the CheckCliVersion ix.
 pub(crate) const MAX_CLAIM_EPOCHS_PER_TX: usize = 16;
 
-/// getMultipleAccounts caps at 100 keys per request.
-const ACCOUNTS_FETCH_CHUNK: usize = 100;
-
 /// How far back (in subscription epochs) auto-discovery probes from the current
 /// epoch. Holdings older than the on-chain abandonment window are swept, so this
 /// covers every holding that can still exist.
@@ -116,12 +116,11 @@ impl ClaimCommand {
         let vcr_key = find_validator_client_rewards_address(self.client_id).0;
         let program_config_key = find_program_config_address().0;
 
-        // Single getMultipleAccounts call: VCR, ProgramConfig.
-        let accounts = wallet
-            .connection
-            .get_multiple_accounts(&[vcr_key, program_config_key])
-            .await
-            .with_context(|| "fetching VCR + program config")?;
+        // Single fetch: VCR, ProgramConfig.
+        let accounts =
+            try_fetch_multiple_accounts(&wallet.connection, &[vcr_key, program_config_key])
+                .await
+                .with_context(|| "fetching VCR + program config")?;
 
         let vcr_account = accounts.first().and_then(|a| a.as_ref()).ok_or_else(|| {
             anyhow!(
@@ -363,31 +362,25 @@ async fn discover_holdings(
     ceiling_epoch: u64,
 ) -> Result<Vec<HoldingToClaim>> {
     let floor = ceiling_epoch.saturating_sub(MAX_DISCOVERY_LOOKBACK);
-    let candidates: Vec<u64> = (floor..=ceiling_epoch).collect();
+    let derived: Vec<(u64, Pubkey, u8)> = (floor..=ceiling_epoch)
+        .map(|epoch| {
+            let (pda, bump) = find_claim_holding_address(vcr_key, epoch, mint);
+            (epoch, pda, bump)
+        })
+        .collect();
+    let keys: Vec<Pubkey> = derived.iter().map(|(_, pda, _)| *pda).collect();
+    let probed = try_fetch_multiple_accounts(&wallet.connection, &keys)
+        .await
+        .with_context(|| "probing claim holdings")?;
     let mut found: Vec<HoldingToClaim> = Vec::new();
-    for chunk in candidates.chunks(ACCOUNTS_FETCH_CHUNK) {
-        let derived: Vec<(u64, Pubkey, u8)> = chunk
-            .iter()
-            .map(|&epoch| {
-                let (pda, bump) = find_claim_holding_address(vcr_key, epoch, mint);
-                (epoch, pda, bump)
-            })
-            .collect();
-        let keys: Vec<Pubkey> = derived.iter().map(|(_, pda, _)| *pda).collect();
-        let probed = wallet
-            .connection
-            .get_multiple_accounts(&keys)
-            .await
-            .with_context(|| "probing claim holdings")?;
-        for ((epoch, pda, bump), account) in derived.into_iter().zip(probed) {
-            if let Some(pre_balance) = holding_balance(account.as_ref(), mint) {
-                found.push(HoldingToClaim {
-                    epoch,
-                    bump_seed: bump,
-                    holding_pda: pda,
-                    pre_balance,
-                });
-            }
+    for ((epoch, pda, bump), account) in derived.into_iter().zip(probed) {
+        if let Some(pre_balance) = holding_balance(account.as_ref(), mint) {
+            found.push(HoldingToClaim {
+                epoch,
+                bump_seed: bump,
+                holding_pda: pda,
+                pre_balance,
+            });
         }
     }
     found.sort_unstable_by_key(|h| h.epoch);
@@ -413,48 +406,44 @@ async fn validate_explicit_holdings(
         })
         .collect();
 
-    let mut holdings: Vec<HoldingToClaim> = Vec::new();
+    let keys: Vec<Pubkey> = derived.iter().map(|(_, pda, _)| *pda).collect();
+    let accounts = try_fetch_multiple_accounts(&wallet.connection, &keys)
+        .await
+        .with_context(|| "fetching claim holdings")?;
 
-    for chunk in derived.chunks(ACCOUNTS_FETCH_CHUNK) {
-        let keys: Vec<Pubkey> = chunk.iter().map(|(_, pda, _)| *pda).collect();
-        let accounts = wallet
-            .connection
-            .get_multiple_accounts(&keys)
-            .await
-            .with_context(|| "fetching claim holdings")?;
-        for ((epoch, pda, bump), maybe_acct) in chunk.iter().zip(accounts) {
-            match maybe_acct.as_ref() {
-                None => eprintln!(
-                    "warning: epoch {epoch} holding {pda} is not initialized; skipping. \
-                     Run `shreds validator-client-rewards init-holding ...` to create it."
+    let mut holdings: Vec<HoldingToClaim> = Vec::new();
+    for ((epoch, pda, bump), maybe_acct) in derived.iter().zip(accounts) {
+        match maybe_acct.as_ref() {
+            None => eprintln!(
+                "warning: epoch {epoch} holding {pda} is not initialized; skipping. \
+                 Run `shreds validator-client-rewards init-holding ...` to create it."
+            ),
+            Some(acct) if acct.owner != spl_token_interface::ID => eprintln!(
+                "warning: epoch {epoch} holding {pda} is not an SPL token account (owner {}); skipping.",
+                acct.owner
+            ),
+            Some(acct) => match spl_token_interface::state::Account::unpack(&acct.data) {
+                Ok(token) if token.mint != *mint => eprintln!(
+                    "warning: epoch {epoch} holding {pda} is for mint {} (expected {mint}); skipping.",
+                    token.mint
                 ),
-                Some(acct) if acct.owner != spl_token_interface::ID => eprintln!(
-                    "warning: epoch {epoch} holding {pda} is not an SPL token account (owner {}); skipping.",
-                    acct.owner
-                ),
-                Some(acct) => match spl_token_interface::state::Account::unpack(&acct.data) {
-                    Ok(token) if token.mint != *mint => eprintln!(
-                        "warning: epoch {epoch} holding {pda} is for mint {} (expected {mint}); skipping.",
-                        token.mint
-                    ),
-                    Ok(token) => {
-                        if token.amount == 0 {
-                            eprintln!(
-                                "warning: epoch {epoch} holding has 0 balance; will still close and recover rent."
-                            );
-                        }
-                        holdings.push(HoldingToClaim {
-                            epoch: *epoch,
-                            bump_seed: *bump,
-                            holding_pda: *pda,
-                            pre_balance: token.amount,
-                        });
+                Ok(token) => {
+                    if token.amount == 0 {
+                        eprintln!(
+                            "warning: epoch {epoch} holding has 0 balance; will still close and recover rent."
+                        );
                     }
-                    Err(err) => eprintln!(
-                        "warning: epoch {epoch} holding {pda} failed to unpack ({err}); skipping."
-                    ),
-                },
-            }
+                    holdings.push(HoldingToClaim {
+                        epoch: *epoch,
+                        bump_seed: *bump,
+                        holding_pda: *pda,
+                        pre_balance: token.amount,
+                    });
+                }
+                Err(err) => eprintln!(
+                    "warning: epoch {epoch} holding {pda} failed to unpack ({err}); skipping."
+                ),
+            },
         }
     }
     Ok(holdings)

--- a/crates/solana-cli/src/command/shreds/validator_client_rewards/claim.rs
+++ b/crates/solana-cli/src/command/shreds/validator_client_rewards/claim.rs
@@ -17,16 +17,21 @@ use doublezero_solana_sdk::{
     try_build_instruction,
 };
 use solana_sdk::{
-    commitment_config::CommitmentConfig, compute_budget::ComputeBudgetInstruction,
-    instruction::AccountMeta, program_pack::Pack, pubkey::Pubkey,
+    account::Account, commitment_config::CommitmentConfig,
+    compute_budget::ComputeBudgetInstruction, instruction::AccountMeta, program_pack::Pack,
+    pubkey::Pubkey,
 };
 use spl_associated_token_account_interface::address::get_associated_token_address;
 
 /*
    doublezero-solana shreds validator-client-rewards claim \
        --client-id <ID> --rewards-token-mint <PUBKEY> \
-       --subscription-epoch <EPOCH> [--subscription-epoch <EPOCH> ...] \
+       [--subscription-epoch <EPOCH> ...] \
        [--destination-token-account <PUBKEY>]
+
+   When no --subscription-epoch is given, every outstanding holding for the
+   client and mint is discovered and claimed across as many transactions as
+   needed (up to MAX_CLAIM_EPOCHS_PER_TX holdings per tx).
 */
 
 #[derive(Debug, Args)]
@@ -37,8 +42,9 @@ pub struct ClaimCommand {
     /// Token mint that holdings are denominated in.
     #[arg(long)]
     pub rewards_token_mint: Pubkey,
-    /// One or more subscription epochs to claim.
-    #[arg(long = "subscription-epoch", required = true, num_args = 1..)]
+    /// Subscription epochs to claim. When omitted, every outstanding holding
+    /// for this client and mint is discovered and claimed.
+    #[arg(long = "subscription-epoch", num_args = 1..)]
     pub subscription_epochs: Vec<u64>,
     /// Destination token account. Defaults to ATA(manager, rewards_token_mint).
     #[arg(long)]
@@ -71,16 +77,34 @@ pub(crate) fn validate_manager(wallet: &Pubkey, vcr_manager: &Pubkey) -> Result<
 /// accounts and the CheckCliVersion ix.
 pub(crate) const MAX_CLAIM_EPOCHS_PER_TX: usize = 16;
 
+/// getMultipleAccounts caps at 100 keys per request.
+const ACCOUNTS_FETCH_CHUNK: usize = 100;
+
+/// How far back (in subscription epochs) auto-discovery probes from the current
+/// epoch. Holdings older than the on-chain abandonment window are swept, so this
+/// covers every holding that can still exist.
+const MAX_DISCOVERY_LOOKBACK: u64 = 90;
+
+struct HoldingToClaim {
+    epoch: u64,
+    bump_seed: u8,
+    holding_pda: Pubkey,
+    pre_balance: u64,
+}
+
+/// Decode a fetched account as a claim holding for `mint`, returning its
+/// balance.
+fn holding_balance(account: Option<&Account>, mint: &Pubkey) -> Option<u64> {
+    let account = account?;
+    if account.owner != spl_token_interface::ID {
+        return None;
+    }
+    let token = spl_token_interface::state::Account::unpack(&account.data).ok()?;
+    (token.mint == *mint).then_some(token.amount)
+}
+
 impl ClaimCommand {
     pub async fn try_into_execute(self) -> Result<()> {
-        if self.subscription_epochs.len() > MAX_CLAIM_EPOCHS_PER_TX {
-            bail!(
-                "too many --subscription-epoch values ({}); max {} per tx. Split into multiple `claim` calls.",
-                self.subscription_epochs.len(),
-                MAX_CLAIM_EPOCHS_PER_TX
-            );
-        }
-
         let dz_connection = self
             .solana_payer_options
             .connection_options
@@ -89,23 +113,15 @@ impl ClaimCommand {
         let wallet = Wallet::try_new(self.solana_payer_options, Some(dz_connection))?;
         let wallet_key = wallet.pubkey();
 
-        // Derive every PDA we need.
         let vcr_key = find_validator_client_rewards_address(self.client_id).0;
         let program_config_key = find_program_config_address().0;
-        let holding_keys: Vec<Pubkey> = self
-            .subscription_epochs
-            .iter()
-            .map(|epoch| find_claim_holding_address(&vcr_key, *epoch, &self.rewards_token_mint).0)
-            .collect();
 
-        // Single getMultipleAccounts call: VCR, ProgramConfig, every holding.
-        let mut all_keys = vec![vcr_key, program_config_key];
-        all_keys.extend(holding_keys.iter().copied());
+        // Single getMultipleAccounts call: VCR, ProgramConfig.
         let accounts = wallet
             .connection
-            .get_multiple_accounts(&all_keys)
+            .get_multiple_accounts(&[vcr_key, program_config_key])
             .await
-            .with_context(|| "fetching VCR + program config + holdings")?;
+            .with_context(|| "fetching VCR + program config")?;
 
         let vcr_account = accounts.first().and_then(|a| a.as_ref()).ok_or_else(|| {
             anyhow!(
@@ -125,72 +141,72 @@ impl ClaimCommand {
         let rent_beneficiary = parse_program_config_shred_oracle_key(&cfg_account.data)
             .ok_or_else(|| anyhow!("failed to parse shred_oracle_key from ProgramConfig"))?;
 
-        // Validate every holding. Track per-holding pre-claim balances so the
-        // post-tx output can report what was drained from each.
-        let mut missing: Vec<u64> = Vec::new();
-        let mut wrong_owner: Vec<(u64, Pubkey)> = Vec::new();
-        let mut wrong_mint: Vec<(u64, Pubkey)> = Vec::new();
-        let mut zero_balance: Vec<u64> = Vec::new();
-        let mut total_drained: u64 = 0;
-        // (epoch, holding_pda, pre_claim_balance)
-        let mut pre_claim_balances: Vec<(u64, Pubkey, u64)> = Vec::new();
-        for ((epoch, key), maybe_acct) in self
-            .subscription_epochs
-            .iter()
-            .zip(holding_keys.iter())
-            .zip(accounts.iter().skip(2))
-        {
-            match maybe_acct.as_ref() {
-                None => missing.push(*epoch),
-                Some(acct) => {
-                    if acct.owner != spl_token_interface::ID {
-                        wrong_owner.push((*epoch, acct.owner));
-                        continue;
-                    }
-                    match spl_token_interface::state::Account::unpack(&acct.data) {
-                        Ok(token) => {
-                            if token.mint != self.rewards_token_mint {
-                                wrong_mint.push((*epoch, token.mint));
-                                continue;
-                            }
-                            if token.amount == 0 {
-                                zero_balance.push(*epoch);
-                            }
-                            total_drained = total_drained.saturating_add(token.amount);
-                            pre_claim_balances.push((*epoch, *key, token.amount));
-                        }
-                        Err(err) => bail!("holding {key} (epoch {epoch}) failed to unpack: {err}"),
-                    }
-                }
+        // Resolve the set of holdings to claim: explicit epochs (validated), or
+        // every outstanding holding discovered on chain.
+        let holdings = if self.subscription_epochs.is_empty() {
+            let target = vcr_info.claim_holding_count as usize;
+            if target == 0 {
+                println!(
+                    "No outstanding claim holdings for client_id {} (claim_holding_count is 0).",
+                    self.client_id
+                );
+                return Ok(());
             }
-        }
-        if !missing.is_empty() || !wrong_owner.is_empty() || !wrong_mint.is_empty() {
-            let mut issues: Vec<String> = Vec::new();
-            if !missing.is_empty() {
-                issues.push(format!(
-                    "  - holdings not initialized for epochs: {missing:?}. Run `shreds validator-client-rewards init-holding ...` first."
-                ));
+            // The shred-subscription program stamps `current_subscription_epoch`
+            // from the Clock of the cluster it runs on, which is exactly the
+            // cluster `wallet.connection` talks to, so the live epoch there is
+            // the discovery ceiling.
+            let current_epoch = wallet
+                .connection
+                .get_epoch_info()
+                .await
+                .with_context(|| "fetching current epoch")?
+                .epoch;
+            let discovered =
+                discover_holdings(&wallet, &vcr_key, &self.rewards_token_mint, current_epoch)
+                    .await?;
+            if discovered.is_empty() {
+                println!(
+                    "No claim holdings for client_id {} found for mint {} within the last {MAX_DISCOVERY_LOOKBACK} epochs.",
+                    self.client_id, self.rewards_token_mint,
+                );
+                return Ok(());
             }
-            if !wrong_owner.is_empty() {
-                let epochs: Vec<u64> = wrong_owner.iter().map(|(e, _)| *e).collect();
-                issues.push(format!(
-                    "  - holdings for epochs {epochs:?} are not SPL token accounts (epoch, owner): {wrong_owner:?}"
-                ));
+            if discovered.len() < target {
+                eprintln!(
+                    "warning: found {} holding(s) for mint {} but claim_holding_count is {target}; \
+                     the remainder may be denominated in another mint or older than the \
+                     {MAX_DISCOVERY_LOOKBACK}-epoch discovery window.",
+                    discovered.len(),
+                    self.rewards_token_mint,
+                );
             }
-            if !wrong_mint.is_empty() {
-                issues.push(format!(
-                    "  - holdings for the following epochs are for the wrong mint (epoch, found_mint): {wrong_mint:?}"
-                ));
-            }
-            bail!("claim holdings have issues:\n{}", issues.join("\n"));
-        }
-        for epoch in &zero_balance {
-            eprintln!(
-                "warning: epoch {epoch} holding has 0 balance; will still close and recover rent"
+            println!(
+                "Discovered {} outstanding holding(s) for client_id {} (mint {}).",
+                discovered.len(),
+                self.client_id,
+                self.rewards_token_mint,
             );
+            discovered
+        } else {
+            validate_explicit_holdings(
+                &wallet,
+                &vcr_key,
+                &self.rewards_token_mint,
+                &self.subscription_epochs,
+            )
+            .await?
+        };
+
+        if holdings.is_empty() {
+            println!(
+                "Nothing to claim for client_id {} (mint {}); no valid holdings.",
+                self.client_id, self.rewards_token_mint,
+            );
+            return Ok(());
         }
 
-        // Resolve destination ATA and validate it.
+        // Resolve destination token account and validate it.
         let destination = resolve_destination(
             &wallet_key,
             &self.rewards_token_mint,
@@ -225,74 +241,93 @@ impl ClaimCommand {
             );
         }
 
-        // Build the holding-id payload (re-derive bumps).
-        let claim_holding_ids: Vec<ClaimHoldingId> = self
-            .subscription_epochs
+        let total_holdings = holdings.len();
+        let total_pre_balance = holdings
             .iter()
-            .map(|epoch| {
-                let (_addr, bump) =
-                    find_claim_holding_address(&vcr_key, *epoch, &self.rewards_token_mint);
-                ClaimHoldingId {
-                    subscription_epoch: *epoch,
-                    bump_seed: bump,
-                }
-            })
-            .collect();
+            .fold(0u64, |acc, h| acc.saturating_add(h.pre_balance));
+        let batches: Vec<&[HoldingToClaim]> = holdings.chunks(MAX_CLAIM_EPOCHS_PER_TX).collect();
+        let batch_count = batches.len();
 
         println!(
-            "Shred subscription - Claim Validator Client Rewards (client_id={}, mint={}, epochs={})",
-            self.client_id,
-            self.rewards_token_mint,
-            self.subscription_epochs
-                .iter()
-                .map(u64::to_string)
-                .collect::<Vec<_>>()
-                .join(",")
+            "Shred subscription - Claim Validator Client Rewards \
+             (client_id={}, mint={}, holdings={total_holdings}, transactions={batch_count})",
+            self.client_id, self.rewards_token_mint,
         );
         println!("  manager       : {wallet_key}");
         println!("  destination   : {destination}");
         println!("  rent recovers : {rent_beneficiary}");
 
-        // Build the claim instruction.
-        let claim_accounts = ClaimValidatorClientRewardsAccounts::new(
-            self.client_id,
-            &wallet_key,
-            &destination,
-            &rent_beneficiary,
-            &self.rewards_token_mint,
-            &self.subscription_epochs,
-        );
-        let metas: Vec<AccountMeta> = claim_accounts.into();
-        let ix = try_build_instruction(
-            &ID,
-            metas,
-            &ShredSubscriptionInstructionData::ClaimValidatorClientRewards(claim_holding_ids),
-        )?;
+        // Submit one transaction per batch of up to MAX_CLAIM_EPOCHS_PER_TX
+        // holdings. Batches are independent, so a later failure does not undo an
+        // earlier executed batch.
+        let mut executed_holdings = 0usize;
+        let mut last_executed = false;
+        for (batch_index, batch) in batches.into_iter().enumerate() {
+            let epochs: Vec<u64> = batch.iter().map(|h| h.epoch).collect();
+            let claim_holding_ids: Vec<ClaimHoldingId> = batch
+                .iter()
+                .map(|h| ClaimHoldingId {
+                    subscription_epoch: h.epoch,
+                    bump_seed: h.bump_seed,
+                })
+                .collect();
 
-        let mut instructions = vec![super::super::build_check_cli_version_instruction()?, ix];
+            let claim_accounts = ClaimValidatorClientRewardsAccounts::new(
+                self.client_id,
+                &wallet_key,
+                &destination,
+                &rent_beneficiary,
+                &self.rewards_token_mint,
+                &epochs,
+            );
+            let metas: Vec<AccountMeta> = claim_accounts.into();
+            let ix = try_build_instruction(
+                &ID,
+                metas,
+                &ShredSubscriptionInstructionData::ClaimValidatorClientRewards(claim_holding_ids),
+            )?;
 
-        // ~30k CU per holding (token transfer + close + state decrement), plus
-        // the check-cli-version ix. Bounded by MAX_CLAIM_EPOCHS_PER_TX.
-        let cu_limit: u32 = 30_000u32.saturating_mul(self.subscription_epochs.len() as u32 + 1);
-        instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(cu_limit));
-        if let Some(ref compute_unit_price_ix) = wallet.compute_unit_price_ix {
-            instructions.push(compute_unit_price_ix.clone());
+            let mut instructions = vec![super::super::build_check_cli_version_instruction()?, ix];
+            let cu_limit: u32 = 30_000u32.saturating_mul(epochs.len() as u32 + 1);
+            instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(cu_limit));
+            if let Some(ref compute_unit_price_ix) = wallet.compute_unit_price_ix {
+                instructions.push(compute_unit_price_ix.clone());
+            }
+
+            if batch_count > 1 {
+                println!(
+                    "\nTransaction {}/{batch_count}: {} holding(s), epochs {epochs:?}",
+                    batch_index + 1,
+                    batch.len(),
+                );
+            }
+
+            let transaction = wallet.new_transaction(&instructions).await?;
+            let tx_outcome = wallet.send_or_simulate_transaction(&transaction).await?;
+
+            if let TransactionOutcome::Executed(tx_sig) = tx_outcome {
+                executed_holdings += batch.len();
+                last_executed = true;
+                println!("Claimed: {tx_sig}");
+                // The on-chain handler transfers the full balance of each
+                // holding, but these balances were read pre-tx — a top-up
+                // between the read and the claim makes the actual drained amount
+                // higher. Diff the destination balance before/after for the
+                // authoritative number.
+                for h in batch {
+                    println!(
+                        "  epoch {}: {} from {} (pre-claim)",
+                        h.epoch, h.pre_balance, h.holding_pda,
+                    );
+                }
+                wallet.print_verbose_output(&[tx_sig]).await?;
+            }
         }
 
-        let transaction = wallet.new_transaction(&instructions).await?;
-        let tx_outcome = wallet.send_or_simulate_transaction(&transaction).await?;
-
-        if let TransactionOutcome::Executed(tx_sig) = tx_outcome {
-            println!("Claimed: {tx_sig}");
-            // The on-chain handler transfers the full balance of each holding,
-            // but the balances reported here were read pre-tx — if a top-up
-            // landed between the read and our claim, the actual drained amount
-            // is higher. To get the authoritative number, diff the destination
-            // ATA balance before and after.
-            for (epoch, holding_pda, drained) in &pre_claim_balances {
-                println!("  epoch {epoch}: {drained} from {holding_pda} (pre-claim)");
-            }
-            println!("Pre-claim total: {total_drained}");
+        if last_executed {
+            println!(
+                "\nPre-claim total: {total_pre_balance} ({executed_holdings}/{total_holdings} holding(s) claimed across {batch_count} transaction(s))."
+            );
 
             // Re-fetch the VCR to report the post-tx claim_holding_count.
             let post_count = match wallet
@@ -312,12 +347,117 @@ impl ClaimCommand {
                 Some(count) => println!("Remaining claim holding count: {count}"),
                 None => println!("Remaining claim holding count: (unavailable)"),
             }
-
-            wallet.print_verbose_output(&[tx_sig]).await?;
         }
 
         Ok(())
     }
+}
+
+/// Discover every outstanding claim holding for `vcr_key`/`mint` by probing
+/// every holding PDA in `[ceiling_epoch - MAX_DISCOVERY_LOOKBACK, ceiling_epoch]`.
+/// Returns the holdings that exist, sorted by epoch.
+async fn discover_holdings(
+    wallet: &Wallet,
+    vcr_key: &Pubkey,
+    mint: &Pubkey,
+    ceiling_epoch: u64,
+) -> Result<Vec<HoldingToClaim>> {
+    let floor = ceiling_epoch.saturating_sub(MAX_DISCOVERY_LOOKBACK);
+    let candidates: Vec<u64> = (floor..=ceiling_epoch).collect();
+    let mut found: Vec<HoldingToClaim> = Vec::new();
+    for chunk in candidates.chunks(ACCOUNTS_FETCH_CHUNK) {
+        let derived: Vec<(u64, Pubkey, u8)> = chunk
+            .iter()
+            .map(|&epoch| {
+                let (pda, bump) = find_claim_holding_address(vcr_key, epoch, mint);
+                (epoch, pda, bump)
+            })
+            .collect();
+        let keys: Vec<Pubkey> = derived.iter().map(|(_, pda, _)| *pda).collect();
+        let probed = wallet
+            .connection
+            .get_multiple_accounts(&keys)
+            .await
+            .with_context(|| "probing claim holdings")?;
+        for ((epoch, pda, bump), account) in derived.into_iter().zip(probed) {
+            if let Some(pre_balance) = holding_balance(account.as_ref(), mint) {
+                found.push(HoldingToClaim {
+                    epoch,
+                    bump_seed: bump,
+                    holding_pda: pda,
+                    pre_balance,
+                });
+            }
+        }
+    }
+    found.sort_unstable_by_key(|h| h.epoch);
+    Ok(found)
+}
+
+/// Resolve an explicit set of subscription epochs into claimable holdings.
+async fn validate_explicit_holdings(
+    wallet: &Wallet,
+    vcr_key: &Pubkey,
+    mint: &Pubkey,
+    epochs: &[u64],
+) -> Result<Vec<HoldingToClaim>> {
+    let mut epochs = epochs.to_vec();
+    epochs.sort_unstable();
+    epochs.dedup();
+
+    let derived: Vec<(u64, Pubkey, u8)> = epochs
+        .iter()
+        .map(|&epoch| {
+            let (pda, bump) = find_claim_holding_address(vcr_key, epoch, mint);
+            (epoch, pda, bump)
+        })
+        .collect();
+
+    let mut holdings: Vec<HoldingToClaim> = Vec::new();
+
+    for chunk in derived.chunks(ACCOUNTS_FETCH_CHUNK) {
+        let keys: Vec<Pubkey> = chunk.iter().map(|(_, pda, _)| *pda).collect();
+        let accounts = wallet
+            .connection
+            .get_multiple_accounts(&keys)
+            .await
+            .with_context(|| "fetching claim holdings")?;
+        for ((epoch, pda, bump), maybe_acct) in chunk.iter().zip(accounts) {
+            match maybe_acct.as_ref() {
+                None => eprintln!(
+                    "warning: epoch {epoch} holding {pda} is not initialized; skipping. \
+                     Run `shreds validator-client-rewards init-holding ...` to create it."
+                ),
+                Some(acct) if acct.owner != spl_token_interface::ID => eprintln!(
+                    "warning: epoch {epoch} holding {pda} is not an SPL token account (owner {}); skipping.",
+                    acct.owner
+                ),
+                Some(acct) => match spl_token_interface::state::Account::unpack(&acct.data) {
+                    Ok(token) if token.mint != *mint => eprintln!(
+                        "warning: epoch {epoch} holding {pda} is for mint {} (expected {mint}); skipping.",
+                        token.mint
+                    ),
+                    Ok(token) => {
+                        if token.amount == 0 {
+                            eprintln!(
+                                "warning: epoch {epoch} holding has 0 balance; will still close and recover rent."
+                            );
+                        }
+                        holdings.push(HoldingToClaim {
+                            epoch: *epoch,
+                            bump_seed: *bump,
+                            holding_pda: *pda,
+                            pre_balance: token.amount,
+                        });
+                    }
+                    Err(err) => eprintln!(
+                        "warning: epoch {epoch} holding {pda} failed to unpack ({err}); skipping."
+                    ),
+                },
+            }
+        }
+    }
+    Ok(holdings)
 }
 
 #[cfg(test)]
@@ -407,16 +547,19 @@ mod tests {
     }
 
     #[test]
-    fn rejects_missing_subscription_epoch() {
+    fn allows_missing_subscription_epoch() {
+        // Omitting --subscription-epoch is valid: the command discovers and
+        // claims every outstanding holding for the client and mint.
         let mint = Pubkey::new_unique();
-        let result = Cli::try_parse_from([
+        let cli = Cli::try_parse_from([
             "test",
             "--client-id",
             "7",
             "--rewards-token-mint",
             &mint.to_string(),
-        ]);
-        assert!(result.is_err());
+        ])
+        .unwrap();
+        assert!(cli.cmd.subscription_epochs.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
`shreds validator-client-rewards claim` now drains every outstanding holding by default.

- `--subscription-epoch` is optional. When omitted, all holdings for the client and mint are discovered (current epoch from `getEpochInfo`) and claimed.
- Removes the 16-epoch hard cap: holdings are split into ≤16-per-tx transactions submitted sequentially.
- Explicit epochs whose holding is missing, wrong-mint, or otherwise invalid are warned and skipped instead of failing the whole claim; it only sends nothing when no valid holdings remain.