### PR TITLE
solana-cli: bump version to 0.5.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2832,7 +2832,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-solana-cli"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.9](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.9)
+
+- uptick crate to v0.5.9 (#394)
 - `shreds validator-client-rewards claim`: claim every outstanding holding by default. `--subscription-epoch` is now optional — omit it to discover and drain all holdings for the client and mint (current epoch read from `getEpochInfo`). The 16-epoch cap is replaced by automatic batching into `≤16`-per-tx transactions, and explicit epochs whose holding is missing/wrong-mint/invalid are warned and skipped instead of failing the whole claim (#393)
 
 ## [0.5.8](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.8)

--- a/crates/solana-cli/Cargo.toml
+++ b/crates/solana-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "doublezero-solana-cli"
 description = "Command line to interact with DoubleZero Solana programs"
-version = "0.5.8"
+version = "0.5.9"
 
 # Workspace inherited keys
 edition.workspace = true


### PR DESCRIPTION
## Summary of Changes
* Bump version to 0.5.9 in the solana-cli
