### PR TITLE
solana-cli: shreds withdraw compares active_epoch against last_settled_epoch (0.5.10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2832,7 +2832,7 @@ dependencies = [
 
 [[package]]
 name = "doublezero-solana-cli"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.10](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.10)
+
+- uptick crate to v0.5.10 (#395)
+- `shreds withdraw`: compare the seat's shred-subscription `active_epoch` against the program's `last_settled_epoch` (from the `ExecutionController`), mirroring the on-chain withdrawal guard (reject when `active_epoch < last_settled_epoch`), instead of the Solana cluster epoch (`getEpochInfo`). On clusters where the cluster epoch exceeds the subscription epoch (e.g. Solana devnet) the previous comparison was always false, so the instant seat withdrawal was silently skipped and the command only closed the payment escrow — leaving the seat active and its multicast subscription up (#395)
+
 ## [0.5.9](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.9)
 
 - uptick crate to v0.5.9 (#394)

--- a/crates/solana-cli/Cargo.toml
+++ b/crates/solana-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "doublezero-solana-cli"
 description = "Command line to interact with DoubleZero Solana programs"
-version = "0.5.9"
+version = "0.5.10"
 
 # Workspace inherited keys
 edition.workspace = true

--- a/crates/solana-cli/src/command/shreds/withdraw.rs
+++ b/crates/solana-cli/src/command/shreds/withdraw.rs
@@ -82,8 +82,11 @@ impl WithdrawCommand {
         let (allocation_request_key, _) =
             state::find_instant_allocation_request_address(&device, client_ip_bits);
 
-        // Fetch client seat, payment escrow, program config, and any in-flight
-        // instant seat allocation request in a single RPC.
+        let (execution_controller_key, _) = state::find_execution_controller_address();
+
+        // Fetch client seat, payment escrow, program config, any in-flight
+        // instant seat allocation request, and the execution controller in a
+        // single RPC.
         let mut accounts = wallet
             .connection
             .get_multiple_accounts(&[
@@ -91,10 +94,19 @@ impl WithdrawCommand {
                 escrow_key,
                 program_config_key,
                 allocation_request_key,
+                execution_controller_key,
             ])
             .await?;
 
-        // Pop in reverse order: allocation_request (3), program_config (2), escrow (1), seat (0).
+        // Pop in reverse order: execution_controller (4), allocation_request (3),
+        // program_config (2), escrow (1), seat (0).
+        let last_settled_epoch = accounts
+            .pop()
+            .flatten()
+            .and_then(|a| state::parse_execution_controller_last_settled_epoch(&a.data))
+            .with_context(|| {
+                format!("Execution controller {execution_controller_key} missing or unparseable")
+            })?;
         let allocation_request_in_flight = accounts.pop().flatten().is_some();
         let prorated_service_enabled = accounts
             .pop()
@@ -122,8 +134,17 @@ impl WithdrawCommand {
         let seat_has_recorded_price =
             state::parse_client_seat_last_usdc_price_dollars(&seat_data.data)
                 .is_some_and(|price| price > 0);
-        let current_epoch = wallet.connection.get_epoch_info().await?.epoch;
-        let has_active_service = active_epoch >= current_epoch;
+        // Mirror the on-chain withdrawal guard exactly: a seat is withdrawable
+        // iff `active_epoch >= last_settled_epoch` (the on-chain
+        // request_(prorated_)instant_seat_withdrawal handlers reject when
+        // `active_epoch < last_settled_epoch`). A fresh instant allocation sets
+        // `active_epoch = last_settled_epoch`, so the seat is withdrawable
+        // immediately. Comparing against `current_subscription_epoch` (always
+        // `last_settled_epoch + 1` — the *next* epoch) is off by one and skips
+        // the withdrawal for every just-allocated seat; comparing against the
+        // Solana cluster epoch (pre-0.5.10) is also wrong whenever the cluster
+        // epoch exceeds the subscription epoch.
+        let has_active_service = active_epoch >= last_settled_epoch;
 
         // Only request instant withdrawal when the seat is active. Stale seats
         // (or --funds-only) skip the request and just close the payment escrow.

--- a/crates/solana-sdk/src/shred_subscription/state.rs
+++ b/crates/solana-sdk/src/shred_subscription/state.rs
@@ -210,6 +210,28 @@ pub fn is_prorated_service_enabled(data: &[u8]) -> bool {
     flags & PROGRAM_CONFIG_FLAG_IS_PRORATED_SERVICE_ENABLED_BIT != 0
 }
 
+/// Offset of `ExecutionController::last_settled_epoch` within the raw account
+/// data (after the discriminator). On-chain field layout preceding it:
+/// phase_field(u8) + bump_seed(u8) + pad(2) + total_metros(u16) +
+/// total_enabled_devices(u16) + total_client_seats(u32) +
+/// oracle_instant_request_count(u16) + validator_client_ids_count(u8) + pad(1)
+/// + flags(8) = 24 bytes to `current_subscription_epoch`, then 120 more:
+/// current_subscription_epoch(u64) +
+/// updated_device_prices_count(u16) + settled_devices_count(u16) +
+/// settled_client_seats_count(u16) + total_devices(u16) + last_settled_slot(u64)
+/// + last_updating_prices_slot(u64) + last_open_for_requests_slot(u64) +
+/// last_closed_for_requests_slot(u64) + epoch_round_commitment(32) +
+/// epoch_round_reveal(32) + next_seat_funding_index(u64) = 120 → 24 + 120 = 144.
+pub const EXECUTION_CONTROLLER_LAST_SETTLED_EPOCH_OFFSET: usize = DISCRIMINATOR_LEN + 144;
+
+/// Reads `last_settled_epoch` from raw `ExecutionController` account data.
+/// Returns `None` if the account is too short to contain the field.
+pub fn parse_execution_controller_last_settled_epoch(data: &[u8]) -> Option<u64> {
+    let start = EXECUTION_CONTROLLER_LAST_SETTLED_EPOCH_OFFSET;
+    let bytes = data.get(start..start + 8)?;
+    Some(u64::from_le_bytes(<[u8; 8]>::try_from(bytes).ok()?))
+}
+
 /// Returns `true` if the `distribute_validator_rewards_enabled` bit is set
 /// on the raw `ProgramConfig` account data. Mirrors the on-chain
 /// `ProgramConfig::FLAG_DISTRIBUTE_VALIDATOR_REWARDS_ENABLED_BIT` (bit 5).

--- a/crates/solana-sdk/src/shred_subscription/state.rs
+++ b/crates/solana-sdk/src/shred_subscription/state.rs
@@ -212,16 +212,19 @@ pub fn is_prorated_service_enabled(data: &[u8]) -> bool {
 
 /// Offset of `ExecutionController::last_settled_epoch` within the raw account
 /// data (after the discriminator). On-chain field layout preceding it:
+///
+/// ```text
 /// phase_field(u8) + bump_seed(u8) + pad(2) + total_metros(u16) +
 /// total_enabled_devices(u16) + total_client_seats(u32) +
 /// oracle_instant_request_count(u16) + validator_client_ids_count(u8) + pad(1)
-/// + flags(8) = 24 bytes to `current_subscription_epoch`, then 120 more:
+/// + flags(8) = 24 bytes to current_subscription_epoch, then 120 more:
 /// current_subscription_epoch(u64) +
 /// updated_device_prices_count(u16) + settled_devices_count(u16) +
 /// settled_client_seats_count(u16) + total_devices(u16) + last_settled_slot(u64)
 /// + last_updating_prices_slot(u64) + last_open_for_requests_slot(u64) +
 /// last_closed_for_requests_slot(u64) + epoch_round_commitment(32) +
 /// epoch_round_reveal(32) + next_seat_funding_index(u64) = 120 → 24 + 120 = 144.
+/// ```
 pub const EXECUTION_CONTROLLER_LAST_SETTLED_EPOCH_OFFSET: usize = DISCRIMINATOR_LEN + 144;
 
 /// Reads `last_settled_epoch` from raw `ExecutionController` account data.


### PR DESCRIPTION
## Summary

`doublezero-solana shreds withdraw` decided whether a client seat still has active service — and thus whether to issue the instant seat withdrawal vs. just close the payment escrow — by comparing the seat's shred-subscription `active_epoch` against the **Solana cluster epoch** (`getEpochInfo`):

```rust
let current_epoch = wallet.connection.get_epoch_info().await?.epoch; // Solana CLUSTER epoch
let has_active_service = active_epoch >= current_epoch;
```

On clusters where the cluster epoch exceeds the subscription epoch (e.g. Solana devnet, where the two are decoupled), this is always false, so `withdraw` fell back to `ClosePaymentEscrow` and never submitted a withdrawal-request instruction. Consequences:

- The **on-chain program never deactivated the seat** — the withdrawal-request instruction is what zeroes `client_seat.active_epoch`, decrements the granted-seat counters, and creates the `WithdrawSeatRequest` PDA. (`ClosePaymentEscrow` only closes the escrow and clears `funding_authority`; it leaves `active_epoch` set.)
- With no `WithdrawSeatRequest` PDA, the **oracle never tore down the multicast subscription** (the oracle reacts to that PDA; it does not deactivate the seat itself).

Net: the tunnel stayed up and `TestQA_MulticastSettlement/validate_tunnel_down` timed out (malbeclabs/infra#1832).

## Fix

Compare `active_epoch` against the program's **`last_settled_epoch`** (read from the `ExecutionController`), mirroring the on-chain withdrawal guard exactly (the on-chain handlers reject when `active_epoch < last_settled_epoch`). A fresh instant allocation sets `active_epoch = last_settled_epoch`, so the seat is withdrawable immediately.

Note: `current_subscription_epoch` must **not** be used here — the program keeps it one ahead of `last_settled_epoch` (it's the *next* epoch), so comparing against it is off by one and skips the withdrawal for every freshly-allocated seat.

Adds `parse_execution_controller_last_settled_epoch` to the SDK and reads the `ExecutionController` in the existing batched `get_multiple_accounts`. Bumps `doublezero-solana-cli` 0.5.9 → 0.5.10.

## Testing

- `cargo check -p doublezero-solana-cli` clean.
- Deployed a 0.5.10 snapshot to a testnet QA host: `TestQA_MulticastSettlement` now passes end-to-end — `withdraw_seat` issues the real instant withdrawal, the on-chain seat is deactivated, the oracle tears down the subscription, and both `validate_tunnel_down` and `validate_balance_after_withdraw` pass (previously `validate_tunnel_down` timed out at the escrow-close fallback). See malbeclabs/infra#1832.
