### PR TITLE
deps: bump malbeclabs/doublezero pins to #4030 (8b795a3c)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,7 +2656,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 [[package]]
 name = "doublezero-cli-core"
 version = "0.29.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=d282439115945aae84128c6baa63cb1d967b1201#d282439115945aae84128c6baa63cb1d967b1201"
+source = "git+https://github.com/malbeclabs/doublezero?rev=8b795a3c876c96d6427d4e0e47dc81ec05199f4a#8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
 dependencies = [
  "bitflags 2.13.0",
  "clap",
@@ -2666,7 +2666,7 @@ dependencies = [
  "serde",
  "serde_json",
  "solana-sdk",
- "tabled 0.21.0",
+ "tabled 0.20.0",
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
@@ -2675,7 +2675,7 @@ dependencies = [
 [[package]]
 name = "doublezero-config"
 version = "0.29.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=d282439115945aae84128c6baa63cb1d967b1201#d282439115945aae84128c6baa63cb1d967b1201"
+source = "git+https://github.com/malbeclabs/doublezero?rev=8b795a3c876c96d6427d4e0e47dc81ec05199f4a#8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
 dependencies = [
  "eyre",
  "serde",
@@ -2741,7 +2741,7 @@ dependencies = [
 [[package]]
 name = "doublezero-geolocation"
 version = "0.29.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=d282439115945aae84128c6baa63cb1d967b1201#d282439115945aae84128c6baa63cb1d967b1201"
+source = "git+https://github.com/malbeclabs/doublezero?rev=8b795a3c876c96d6427d4e0e47dc81ec05199f4a#8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
 dependencies = [
  "borsh",
  "borsh-incremental",
@@ -2752,7 +2752,7 @@ dependencies = [
  "solana-loader-v3-interface",
  "solana-program",
  "solana-sdk-ids",
- "solana-system-interface 3.2.0",
+ "solana-system-interface 2.0.0",
  "thiserror 2.0.18",
 ]
 
@@ -2858,14 +2858,14 @@ dependencies = [
 [[package]]
 name = "doublezero-program-common"
 version = "0.29.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=d282439115945aae84128c6baa63cb1d967b1201#d282439115945aae84128c6baa63cb1d967b1201"
+source = "git+https://github.com/malbeclabs/doublezero?rev=8b795a3c876c96d6427d4e0e47dc81ec05199f4a#8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
 dependencies = [
  "borsh",
  "byteorder",
  "ipnetwork",
  "serde",
  "solana-program",
- "solana-system-interface 3.2.0",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -2894,11 +2894,11 @@ dependencies = [
 [[package]]
 name = "doublezero-record"
 version = "0.29.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=d282439115945aae84128c6baa63cb1d967b1201#d282439115945aae84128c6baa63cb1d967b1201"
+source = "git+https://github.com/malbeclabs/doublezero?rev=8b795a3c876c96d6427d4e0e47dc81ec05199f4a#8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
 dependencies = [
  "bytemuck",
  "solana-program",
- "solana-system-interface 3.2.0",
+ "solana-system-interface 2.0.0",
  "thiserror 2.0.18",
 ]
 
@@ -2955,7 +2955,7 @@ dependencies = [
 [[package]]
 name = "doublezero-serviceability"
 version = "0.29.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=d282439115945aae84128c6baa63cb1d967b1201#d282439115945aae84128c6baa63cb1d967b1201"
+source = "git+https://github.com/malbeclabs/doublezero?rev=8b795a3c876c96d6427d4e0e47dc81ec05199f4a#8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
 dependencies = [
  "bitflags 2.13.0",
  "borsh",
@@ -2966,7 +2966,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "solana-program",
- "solana-system-interface 3.2.0",
+ "solana-system-interface 2.0.0",
  "thiserror 2.0.18",
 ]
 
@@ -3183,7 +3183,7 @@ dependencies = [
 [[package]]
 name = "doublezero-telemetry"
 version = "0.29.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=d282439115945aae84128c6baa63cb1d967b1201#d282439115945aae84128c6baa63cb1d967b1201"
+source = "git+https://github.com/malbeclabs/doublezero?rev=8b795a3c876c96d6427d4e0e47dc81ec05199f4a#8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
 dependencies = [
  "borsh",
  "borsh-incremental",
@@ -3198,7 +3198,7 @@ dependencies = [
 [[package]]
 name = "doublezero_sdk"
 version = "0.29.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=d282439115945aae84128c6baa63cb1d967b1201#d282439115945aae84128c6baa63cb1d967b1201"
+source = "git+https://github.com/malbeclabs/doublezero?rev=8b795a3c876c96d6427d4e0e47dc81ec05199f4a#8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
 dependencies = [
  "async-trait",
  "backon",
@@ -3232,7 +3232,7 @@ dependencies = [
  "solana-pubsub-client",
  "solana-rpc-client-api",
  "solana-sdk",
- "solana-system-interface 3.2.0",
+ "solana-system-interface 2.0.0",
  "solana-transaction-status",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,41 +125,43 @@ tag = "revenue-distribution/v0.3.7"
 # RFC-20 CLI core: provides CliContext, OutputFormat, RequirementCheck, the
 # render_* output helpers, and the eyre-based error type. The whole SDK family
 # is pinned to a single monorepo revision so shared types unify across the
-# boundary. The pin is the malbeclabs/doublezero#3830 merge commit (Solana 3.0
-# migration); swap for the next v3-containing client/* tag once one is cut.
+# boundary. The pin is the malbeclabs/doublezero#4030 merge commit (per-feed
+# EdgeSeat FeedSeat billing state + SetAccessPassFeeds), 42 commits past the
+# #3830 Solana 3.0 boundary on the same v3 line; swap for the next
+# v3-containing client/* tag once one is cut.
 [workspace.dependencies.doublezero-cli-core]
 git = "https://github.com/malbeclabs/doublezero"
-rev = "d282439115945aae84128c6baa63cb1d967b1201"
+rev = "8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
 
 # Source of the RFC-20 `Environment` enum consumed by `CliContext`. MUST be
 # pinned to the same revision as doublezero-cli-core so the `Environment` type
 # unifies across the boundary.
 [workspace.dependencies.doublezero-config]
 git = "https://github.com/malbeclabs/doublezero"
-rev = "d282439115945aae84128c6baa63cb1d967b1201"
+rev = "8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
 
 [workspace.dependencies.doublezero-program-common]
 git = "https://github.com/malbeclabs/doublezero"
-rev = "d282439115945aae84128c6baa63cb1d967b1201"
+rev = "8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
 
 [workspace.dependencies.doublezero-record]
 features = ["no-entrypoint"]
 git = "https://github.com/malbeclabs/doublezero"
-rev = "d282439115945aae84128c6baa63cb1d967b1201"
+rev = "8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
 
 [workspace.dependencies.doublezero_sdk]
 git = "https://github.com/malbeclabs/doublezero"
-rev = "d282439115945aae84128c6baa63cb1d967b1201"
+rev = "8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
 
 [workspace.dependencies.doublezero-serviceability]
 features = ["no-entrypoint", "serde"]
 git = "https://github.com/malbeclabs/doublezero"
-rev = "d282439115945aae84128c6baa63cb1d967b1201"
+rev = "8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
 
 [workspace.dependencies.doublezero-telemetry]
 features = ["no-entrypoint", "serde"]
 git = "https://github.com/malbeclabs/doublezero"
-rev = "d282439115945aae84128c6baa63cb1d967b1201"
+rev = "8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
 
 ### Other git dependencies
 


### PR DESCRIPTION
## Summary
- Bump all seven `malbeclabs/doublezero` crate pins from the #3830 Solana 3.0 boundary (`d2824391`) to the #4030 merge (`8b795a3c`) — 42 commits forward on the same Solana 3.0 line. #4030 widens the EdgeSeat `FeedSeat` with per-feed billing state and adds the `SetAccessPassFeeds` instruction.
- Unblocks downstream repos consuming `doublezero-solana-client-tools` to resolve a single doublezero source at #4030 (cargo treats differing revs of the same repo as distinct sources, so client-tools and the consumer's direct pins must agree). Immediate consumer: the shred-subscription oracle's access-pass-expiry cranker, which needs the `FeedSeat` / `SetAccessPassFeeds` types.
- Same `0.29.0` crate versions as #3830 — no version bump, no offchain source changes.

## Testing
- `cargo build --workspace` clean (2m12s, 0 errors): solana-cli, solana-client-tools, contributor-rewards, scheduler, validator-debt, and passport-cli all compile against #4030 unmodified.
