### PR TITLE
contributor-rewards: backfill User.feed_pk in snapshot compat migration

### DIFF
--- a/crates/contributor-rewards/CHANGELOG.md
+++ b/crates/contributor-rewards/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - release artifact now builds as a static `x86_64-unknown-linux-musl` binary (malbeclabs/infra#1853)
 - TLS for HTTP clients moves from openssl to rustls; trust roots are the bundled webpki Mozilla set plus the host OS certificate store, so OS-installed private CAs remain trusted (malbeclabs/infra#1853)
 - refactor(contributor-rewards): use the shared `Wallet` memo helpers from `solana-client-tools` in place of the local `RELAY_MEMO_CU` constant
+- fix(contributor-rewards): backfill `User.feed_pk` (zero pubkey) in the snapshot compat migration so snapshots captured before doublezero#4030 still deserialize (malbeclabs/infra#1853)
 
 ## [0.6.1](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/contributor-rewards%2Fv0.6.1) - 2026-06-13
 

--- a/crates/contributor-rewards/src/ingestor/types.rs
+++ b/crates/contributor-rewards/src/ingestor/types.rs
@@ -129,8 +129,9 @@ fn apply_serviceability_json_compat_migrations(serviceability: &mut Value) {
     }
 
     // doublezero-serviceability v0.20 added durable tunnel/BGP state to User;
-    // client/v0.25.0 then appended `bgp_rtt_ns`. Both default to the same values
-    // onchain/Borsh deserialization uses for absent tails.
+    // client/v0.25.0 then appended `bgp_rtt_ns`, and #4030 (per-feed EdgeSeat
+    // billing) appended `feed_pk`. All default to the same values onchain/Borsh
+    // deserialization uses for absent tails.
     if let Some(users) = serviceability
         .get_mut("users")
         .and_then(|users| users.as_object_mut())
@@ -148,6 +149,8 @@ fn apply_serviceability_json_compat_migrations(serviceability: &mut Value) {
                 .or_insert_with(|| Value::Number(0.into()));
             user.entry("bgp_rtt_ns")
                 .or_insert_with(|| Value::Number(0.into()));
+            user.entry("feed_pk")
+                .or_insert_with(|| Value::String(Pubkey::default().to_string()));
         }
     }
 


### PR DESCRIPTION
## Summary
- #4030 appended `feed_pk` to the serviceability `User`. The Borsh path defaults it for absent tails, but the JSON snapshot path (serde) has no default, so pre-#4030 snapshots fail with `missing field feed_pk` — this turned `main` red after #399.
- Backfill `feed_pk` (zero pubkey) in `apply_serviceability_json_compat_migrations`, alongside the existing `tunnel_*`/`bgp_*` tail defaults.

## Testing
- `cargo test -p doublezero-contributor-rewards --test test_demand --test test_pub_links` — 6/6 pass (the 4 previously-failing `feed_pk` tests plus 2 siblings).
