### PR TITLE
Revert shreds pay --operator-key (operator-key split buyer CLI)

### DIFF
--- a/crates/solana-cli/CHANGELOG.md
+++ b/crates/solana-cli/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - migrate to Solana 3.0: workspace `solana-*` crates and `solana-sdk` move to the 3.0 line, `solana-program-test` to 3.0.12, and the doublezero SDK git-deps repin from `client/v0.27.1` to the malbeclabs/doublezero#3830 merge revision (malbeclabs/infra#1853)
 - release artifact now builds as a static `x86_64-unknown-linux-musl` binary so it runs on older glibc hosts (malbeclabs/infra#1853)
 - TLS for HTTP clients moves from openssl to rustls; trust roots are the bundled webpki Mozilla set plus the host OS certificate store, so OS-installed private CAs remain trusted (malbeclabs/infra#1853)
-- `shreds pay`: add `--operator-key` to set the DoubleZero operational identity (`user.owner` / access-pass `user_payer`) on escrow initialization; defaults to the payer wallet, preserving today's behavior (owner = withdraw authority). The pre-existing-multicast-user guard now also accepts a user owned by the operator key, so a re-subscribe/top-up with a distinct `--operator-key` is not rejected as another wallet's subscription
 
 ## [0.5.10](https://github.com/doublezerofoundation/doublezero-offchain/releases/tag/doublezero-solana/v0.5.10)
 

--- a/crates/solana-cli/src/command/shreds/pay.rs
+++ b/crates/solana-cli/src/command/shreds/pay.rs
@@ -117,19 +117,9 @@ fn user_owner_is_acceptable(
     user_owner: Option<Pubkey>,
     oracle_key: Option<Pubkey>,
     wallet_key: Pubkey,
-    operator_key: Pubkey,
-    wallet_owns_escrow: bool,
 ) -> bool {
     let is_shred_oracle_user = oracle_key.zip(user_owner).is_some_and(|(o, u)| o == u);
-    // Under the operator-key split the oracle provisions the user owned by the
-    // operator key, which may be distinct from the wallet (withdraw authority);
-    // a re-subscribe/top-up must accept either as self-owned. When this wallet
-    // already owns the seat's payment escrow, the user at this IP was
-    // provisioned from that escrow under an operator key chosen at init (not
-    // re-supplied on top-ups), so whatever owner it carries is ours too — the
-    // cross-device case is caught separately by the other-device seat guard.
-    let is_self_owned =
-        user_owner == Some(wallet_key) || user_owner == Some(operator_key) || wallet_owns_escrow;
+    let is_self_owned = user_owner == Some(wallet_key);
     is_shred_oracle_user || is_self_owned
 }
 
@@ -181,11 +171,6 @@ pub struct PayCommand {
     /// Serviceability program ID for the multicast user guard (auto-detected; override for e2e)
     #[arg(long, hide = true)]
     serviceability_program_id: Option<Pubkey>,
-    /// Operator key that becomes the DoubleZero operational identity
-    /// (user.owner / access-pass user_payer). Defaults to the payer wallet,
-    /// reproducing today's behavior (owner = the withdraw authority).
-    #[arg(long)]
-    operator_key: Option<Pubkey>,
 
     #[command(flatten)]
     write_opts: crate::command::WriteVerbOptions,
@@ -201,7 +186,6 @@ impl PayCommand {
         let moniker_env = self.write_opts.connection_options.moniker_env();
         let wallet = crate::command::build_wallet(ctx, self.write_opts)?;
         let wallet_key = wallet.pubkey();
-        let operator_key = self.operator_key.unwrap_or(wallet_key);
 
         writeln!(out, "Shred subscription - Pay")?;
 
@@ -215,33 +199,11 @@ impl PayCommand {
             .await?;
         let client_ip_bits = u32::from(self.client_ip);
 
-        // Derive PDAs and check which accounts already exist on-chain up front:
-        // the multicast-user guard below needs escrow_exists to distinguish an
-        // operator-keyed seat this wallet already owns from a genuinely foreign
-        // user, and the escrow-init path needs the existing owner to reconcile
-        // --operator-key.
-        let (client_seat_key, seat_bump) = state::find_client_seat_address(&device, client_ip_bits);
-        let (escrow_key, escrow_bump) =
-            state::find_payment_escrow_address(&client_seat_key, &wallet_key);
-        let (program_config_key, _) = state::find_program_config_address();
-        let accounts = wallet
-            .connection
-            .get_multiple_accounts(&[client_seat_key, escrow_key, program_config_key])
-            .await?;
-        let seat_exists = accounts[0].is_some();
-        let escrow_exists = accounts[1].is_some();
-        let prorated_service_enabled = accounts[2]
-            .as_ref()
-            .is_some_and(|a| state::is_prorated_service_enabled(&a.data));
-
         // Best-effort check: if this client IP already has a Multicast user on
         // serviceability owned by neither the shred oracle nor the wallet
         // running this command, the shred oracle's CreateSubscribeUser would
         // collide on the User PDA. Both oracle-owned (legacy top-up / re-sub)
-        // and self-owned (validator-owned per the new design) are benign. We
-        // also remember the existing owner so the escrow-init path can reconcile
-        // --operator-key against it.
-        let mut existing_user_owner = None;
+        // and self-owned (validator-owned per the new design) are benign.
         let svc_program_id_result = match self.serviceability_program_id {
             Some(id) => Ok(id),
             None => serviceability_program_id(network_env),
@@ -258,19 +220,13 @@ impl PayCommand {
                 .await
                 .map(|r| r.value)
             {
-                existing_user_owner = if user_account.data.len() >= 33 {
+                let user_owner = if user_account.data.len() >= 33 {
                     Pubkey::try_from(&user_account.data[1..33]).ok()
                 } else {
                     None
                 };
 
-                if !user_owner_is_acceptable(
-                    existing_user_owner,
-                    oracle_key,
-                    wallet.pubkey(),
-                    operator_key,
-                    escrow_exists,
-                ) {
+                if !user_owner_is_acceptable(user_owner, oracle_key, wallet.pubkey()) {
                     bail!(
                         "Client IP {} already has a multicast user on serviceability \
                          owned by neither the shred oracle nor your wallet. This IP \
@@ -282,6 +238,23 @@ impl PayCommand {
                 }
             }
         }
+
+        // Derive PDAs.
+        let (client_seat_key, seat_bump) = state::find_client_seat_address(&device, client_ip_bits);
+        let (escrow_key, escrow_bump) =
+            state::find_payment_escrow_address(&client_seat_key, &wallet_key);
+        let (program_config_key, _) = state::find_program_config_address();
+
+        // Check which accounts already exist on-chain.
+        let accounts = wallet
+            .connection
+            .get_multiple_accounts(&[client_seat_key, escrow_key, program_config_key])
+            .await?;
+        let seat_exists = accounts[0].is_some();
+        let escrow_exists = accounts[1].is_some();
+        let prorated_service_enabled = accounts[2]
+            .as_ref()
+            .is_some_and(|a| state::is_prorated_service_enabled(&a.data));
 
         // Block if this client IP already has a seat on a DIFFERENT device.
         // The serviceability User PDA is keyed by (IP, user_type) with no
@@ -438,33 +411,13 @@ impl PayCommand {
             compute_unit_limit += 50_000 + Wallet::compute_units_for_bump_seed(seat_bump);
         }
 
-        // The operator key is only carried by InitializePaymentEscrow and is
-        // immutable once the escrow exists — there is no set-operator-key
-        // instruction, and the escrow stores no key the CLI could read back.
-        // The provisioned user's owner is the source of truth. A top-up that
-        // re-states the same key (or omits the flag) proceeds normally; only a
-        // flag that would *change* an already-set operator key is refused, so
-        // we don't mislead the caller into thinking the change took effect.
-        if escrow_exists && self.operator_key.is_some() && existing_user_owner != self.operator_key
-        {
-            bail!(
-                "This seat's payment escrow already exists; its operator key was set when the \
-                 escrow was created and cannot be changed. Omit --operator-key to top up the \
-                 existing seat."
-            );
-        }
-
         if !escrow_exists {
             let escrow_ix = try_build_instruction(
                 &ID,
                 InitializePaymentEscrowAccounts::new(&client_seat_key, &wallet_key),
-                &ShredSubscriptionInstructionData::InitializePaymentEscrow(operator_key),
+                &ShredSubscriptionInstructionData::InitializePaymentEscrow,
             )?;
             instructions.push(escrow_ix);
-            writeln!(
-                out,
-                "Initializing payment escrow with operator key: {operator_key}"
-            )?;
             compute_unit_limit += 50_000 + Wallet::compute_units_for_bump_seed(escrow_bump);
         }
 
@@ -1042,13 +995,7 @@ mod tests {
     fn user_acceptable_when_owned_by_shred_oracle() {
         let oracle = Pubkey::new_unique();
         let wallet = Pubkey::new_unique();
-        assert!(user_owner_is_acceptable(
-            Some(oracle),
-            Some(oracle),
-            wallet,
-            wallet,
-            false,
-        ));
+        assert!(user_owner_is_acceptable(Some(oracle), Some(oracle), wallet,));
     }
 
     #[test]
@@ -1056,43 +1003,14 @@ mod tests {
         // New behavior: validator-owned (self-owned) Users are benign.
         let oracle = Pubkey::new_unique();
         let wallet = Pubkey::new_unique();
-        assert!(user_owner_is_acceptable(
-            Some(wallet),
-            Some(oracle),
-            wallet,
-            wallet,
-            false,
-        ));
-    }
-
-    #[test]
-    fn user_acceptable_when_owned_by_operator_key() {
-        // Operator-key split: the oracle provisions the user owned by the
-        // operator key, distinct from the wallet (withdraw authority). A
-        // re-subscribe/top-up must treat that as self-owned.
-        let oracle = Pubkey::new_unique();
-        let wallet = Pubkey::new_unique();
-        let operator = Pubkey::new_unique();
-        assert!(user_owner_is_acceptable(
-            Some(operator),
-            Some(oracle),
-            wallet,
-            operator,
-            false,
-        ));
+        assert!(user_owner_is_acceptable(Some(wallet), Some(oracle), wallet,));
     }
 
     #[test]
     fn user_acceptable_self_owned_even_when_oracle_key_unknown() {
         // If we can't resolve the oracle pubkey, self-ownership still passes.
         let wallet = Pubkey::new_unique();
-        assert!(user_owner_is_acceptable(
-            Some(wallet),
-            None,
-            wallet,
-            wallet,
-            false,
-        ));
+        assert!(user_owner_is_acceptable(Some(wallet), None, wallet));
     }
 
     #[test]
@@ -1104,8 +1022,6 @@ mod tests {
             Some(third_party),
             Some(oracle),
             wallet,
-            wallet,
-            false,
         ));
     }
 
@@ -1114,58 +1030,13 @@ mod tests {
         // Malformed account data → user_owner is None → bail (safe default).
         let oracle = Pubkey::new_unique();
         let wallet = Pubkey::new_unique();
-        assert!(!user_owner_is_acceptable(
-            None,
-            Some(oracle),
-            wallet,
-            wallet,
-            false,
-        ));
+        assert!(!user_owner_is_acceptable(None, Some(oracle), wallet));
     }
 
     #[test]
     fn user_rejected_when_third_party_and_oracle_unknown() {
         let wallet = Pubkey::new_unique();
         let third_party = Pubkey::new_unique();
-        assert!(!user_owner_is_acceptable(
-            Some(third_party),
-            None,
-            wallet,
-            wallet,
-            false,
-        ));
-    }
-
-    #[test]
-    fn test_user_acceptable_when_wallet_owns_escrow() {
-        // Top-up of an operator-keyed seat: the user is owned by the operator
-        // key (neither oracle nor wallet), but this wallet already owns the
-        // seat's escrow, so the user was provisioned from it and is benign.
-        let oracle = Pubkey::new_unique();
-        let wallet = Pubkey::new_unique();
-        let operator = Pubkey::new_unique();
-        assert!(user_owner_is_acceptable(
-            Some(operator),
-            Some(oracle),
-            wallet,
-            wallet,
-            true,
-        ));
-    }
-
-    #[test]
-    fn test_user_rejected_when_third_party_and_no_escrow() {
-        // Same foreign owner, but without an escrow this wallet owns, the guard
-        // must still reject — this is the collision case it exists to catch.
-        let oracle = Pubkey::new_unique();
-        let wallet = Pubkey::new_unique();
-        let operator = Pubkey::new_unique();
-        assert!(!user_owner_is_acceptable(
-            Some(operator),
-            Some(oracle),
-            wallet,
-            wallet,
-            false,
-        ));
+        assert!(!user_owner_is_acceptable(Some(third_party), None, wallet));
     }
 }

--- a/crates/solana-cli/src/command/shreds/pay.rs
+++ b/crates/solana-cli/src/command/shreds/pay.rs
@@ -246,14 +246,17 @@ impl PayCommand {
         let (program_config_key, _) = state::find_program_config_address();
 
         // Check which accounts already exist on-chain.
-        let accounts = wallet
+        let mut accounts = wallet
             .connection
             .get_multiple_accounts(&[client_seat_key, escrow_key, program_config_key])
-            .await?;
-        let seat_exists = accounts[0].is_some();
-        let escrow_exists = accounts[1].is_some();
-        let prorated_service_enabled = accounts[2]
-            .as_ref()
+            .await?
+            .into_iter();
+        let seat_account = accounts.next().flatten();
+        let seat_exists = seat_account.is_some();
+        let escrow_exists = accounts.next().flatten().is_some();
+        let prorated_service_enabled = accounts
+            .next()
+            .flatten()
             .is_some_and(|a| state::is_prorated_service_enabled(&a.data));
 
         // Block if this client IP already has a seat on a DIFFERENT device.
@@ -300,7 +303,7 @@ impl PayCommand {
         }
 
         let seat_already_active =
-            is_seat_already_active(accounts[0].as_ref().map(|a| a.data.as_slice()));
+            is_seat_already_active(seat_account.as_ref().map(|a| a.data.as_slice()));
 
         // Epoch-remaining warning: if <10% of the epoch remains, the user is
         // paying full price for a partial epoch. Skip if: flag set, dry-run,
@@ -310,7 +313,7 @@ impl PayCommand {
             Ok(epoch_info) => {
                 // Use >= (not ==) to handle the unlikely case where active_epoch
                 // is ahead of the RPC's reported epoch due to timing.
-                let seat_active_this_epoch = if let Some(ref seat_account) = accounts[0] {
+                let seat_active_this_epoch = if let Some(seat_account) = seat_account.as_ref() {
                     if let Some((_, _, _, _, active_epoch)) =
                         state::parse_client_seat(&seat_account.data)
                     {
@@ -364,7 +367,7 @@ impl PayCommand {
         // Check the current price so the user gets a friendly error instead of
         // an opaque on-chain revert. If the seat has a per-seat price
         // override, use that instead of the metro base + device premium.
-        let seat_price_override = accounts[0]
+        let seat_price_override = seat_account
             .as_ref()
             .and_then(|a| state::parse_client_seat_price_override(&a.data));
 

--- a/crates/solana-cli/src/command/shreds/payments.rs
+++ b/crates/solana-cli/src/command/shreds/payments.rs
@@ -221,7 +221,7 @@ impl PaymentsCommand {
                         // reason — the wildcard arm below makes the match
                         // robust to future variants in either direction.
                         Ok(
-                            ShredSubscriptionInstructionData::InitializePaymentEscrow(..)
+                            ShredSubscriptionInstructionData::InitializePaymentEscrow
                             | ShredSubscriptionInstructionData::InitializeClientSeat { .. }
                             | ShredSubscriptionInstructionData::RequestInstantSeatAllocation
                             | ShredSubscriptionInstructionData::RequestInstantSeatWithdrawal

--- a/crates/solana-sdk/CHANGELOG.md
+++ b/crates/solana-sdk/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - migrate to Solana 3.0: workspace `solana-*` crates and `solana-sdk` move to the 3.0 line, `solana-program-test` to 3.0.12, and the doublezero SDK git-deps repin from `client/v0.27.1` to the malbeclabs/doublezero#3830 merge revision (malbeclabs/infra#1853)
-- `InitializePaymentEscrow` instruction mirror now carries the operator key (`InitializePaymentEscrow(Pubkey)`), matching the deployed program's discriminator + 32-byte `Pubkey` wire form. Deserialization defaults the key when the trailing `Pubkey` is absent, so historical (pre-field) transactions still decode.
 - remove `build_memo_instruction` (moved to `Wallet::build_memo_instruction` in `solana-client-tools`, alongside the memo compute-unit helpers)
 - add `find_claim_holding_address` PDA helper and `CLAIM_HOLDING_SEED_PREFIX` constant for `ValidatorClientRewards` claim holding accounts
 - add `ValidatorClientRewards` discriminator + offset constants and `parse_validator_client_rewards` parser

--- a/crates/solana-sdk/src/shred_subscription/instruction/mod.rs
+++ b/crates/solana-sdk/src/shred_subscription/instruction/mod.rs
@@ -30,9 +30,8 @@ pub struct ClaimHoldingId {
 pub enum ShredSubscriptionInstructionData {
     /// Initialize a client seat for a (device, client_ip) pair.
     InitializeClientSeat { client_ip: u32 },
-    /// Initialize a payment escrow for a (seat, withdraw_authority) pair. The
-    /// argument is the operator key (Pubkey::default() = no separate operator).
-    InitializePaymentEscrow(Pubkey),
+    /// Initialize a payment escrow for a (seat, withdraw_authority) pair.
+    InitializePaymentEscrow,
     /// Close a payment escrow and refund any remaining USDC.
     ClosePaymentEscrow,
     /// Fund a payment escrow with USDC.
@@ -120,10 +119,7 @@ impl BorshSerialize for ShredSubscriptionInstructionData {
                 Self::INITIALIZE_CLIENT_SEAT.serialize(writer)?;
                 client_ip.serialize(writer)
             }
-            Self::InitializePaymentEscrow(operator_key) => {
-                Self::INITIALIZE_PAYMENT_ESCROW.serialize(writer)?;
-                operator_key.serialize(writer)
-            }
+            Self::InitializePaymentEscrow => Self::INITIALIZE_PAYMENT_ESCROW.serialize(writer),
             Self::ClosePaymentEscrow => Self::CLOSE_PAYMENT_ESCROW.serialize(writer),
             Self::FundPaymentEscrowUsdc(amount) => {
                 Self::FUND_PAYMENT_ESCROW_USDC.serialize(writer)?;
@@ -191,31 +187,7 @@ impl BorshDeserialize for ShredSubscriptionInstructionData {
                 let client_ip = u32::deserialize_reader(reader)?;
                 Ok(Self::InitializeClientSeat { client_ip })
             }
-            Self::INITIALIZE_PAYMENT_ESCROW => {
-                // Optional trailing argument: absent (legacy tx) -> default key;
-                // exactly 32 bytes -> that key. Any other length is malformed.
-                // We read to end and check the length explicitly rather than
-                // relying on Pubkey::deserialize_reader + borsh's leftover-bytes
-                // guard: a slice reader's read_exact consumes the remaining
-                // bytes before erroring, so 1..=31 trailing bytes would
-                // otherwise decode to the default key — bytes the onchain
-                // program (strict on length) rejects.
-                let mut rest = Vec::new();
-                reader.read_to_end(&mut rest)?;
-                let operator_key = match rest.len() {
-                    0 => Pubkey::default(),
-                    32 => Pubkey::try_from(rest.as_slice()).map_err(|_| {
-                        io::Error::new(io::ErrorKind::InvalidData, "invalid operator key")
-                    })?,
-                    _ => {
-                        return Err(io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            "InitializePaymentEscrow operator key must be absent or 32 bytes",
-                        ));
-                    }
-                };
-                Ok(Self::InitializePaymentEscrow(operator_key))
-            }
+            Self::INITIALIZE_PAYMENT_ESCROW => Ok(Self::InitializePaymentEscrow),
             Self::CLOSE_PAYMENT_ESCROW => Ok(Self::ClosePaymentEscrow),
             Self::FUND_PAYMENT_ESCROW_USDC => {
                 let amount = u64::deserialize_reader(reader)?;
@@ -285,50 +257,6 @@ mod tests {
         let bytes = borsh::to_vec(ix).unwrap();
         let parsed = ShredSubscriptionInstructionData::try_from_slice(&bytes).unwrap();
         assert_eq!(*ix, parsed);
-    }
-
-    #[test]
-    fn test_round_trip_initialize_payment_escrow() {
-        round_trip(&ShredSubscriptionInstructionData::InitializePaymentEscrow(
-            Pubkey::new_unique(),
-        ));
-    }
-
-    #[test]
-    fn test_frozen_bytes_initialize_payment_escrow() {
-        let key = Pubkey::new_unique();
-        let ix = ShredSubscriptionInstructionData::InitializePaymentEscrow(key);
-        let mut expected =
-            borsh::to_vec(&ShredSubscriptionInstructionData::INITIALIZE_PAYMENT_ESCROW)
-                .expect("discriminator serialization");
-        expected.extend_from_slice(&key.to_bytes());
-        assert_eq!(borsh::to_vec(&ix).unwrap(), expected);
-    }
-
-    // An old client that sent only the discriminator (the pre-operator-key
-    // wire form) must still decode — payments.rs decodes historical
-    // transactions. The absent key decodes to the default.
-    #[test]
-    fn test_initialize_payment_escrow_decodes_legacy_wire_form() {
-        let bytes = borsh::to_vec(&ShredSubscriptionInstructionData::INITIALIZE_PAYMENT_ESCROW)
-            .expect("discriminator serialization");
-        let parsed = ShredSubscriptionInstructionData::try_from_slice(&bytes).unwrap();
-        assert_eq!(
-            parsed,
-            ShredSubscriptionInstructionData::InitializePaymentEscrow(Pubkey::default()),
-        );
-    }
-
-    // A truncated operator key (1..=31 trailing bytes) is malformed and must
-    // error, matching the strict onchain program. Without the explicit length
-    // check, a slice reader's read_exact consumes the partial bytes and the
-    // payload decodes to the default key instead of failing.
-    #[test]
-    fn test_initialize_payment_escrow_rejects_truncated_operator_key() {
-        let mut bytes = borsh::to_vec(&ShredSubscriptionInstructionData::INITIALIZE_PAYMENT_ESCROW)
-            .expect("discriminator serialization");
-        bytes.extend_from_slice(&[0xAB; 31]);
-        assert!(ShredSubscriptionInstructionData::try_from_slice(&bytes).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Refs: malbeclabs/infra#1807

Backs out the buyer-CLI half of the operator-key split, which is being replaced by a simpler allowlist-based approach (see the doublezero-shreds revert). Coordinated with that PR.

## Summary

- Reverts #398: the `--operator-key` flag on `shreds pay` and the operator-key argument in the `solana-sdk` `InitializePaymentEscrow` builder.

## Deploy / rollout

- Ship together with the doublezero-shreds revert: the reverted `shred-subscription` program rejects the trailing operator-key bytes this CLI appended, so a non-reverted CLI against the reverted program would fail escrow creation.
