### PR TITLE
deps: bump malbeclabs/doublezero pins to client/v0.31.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2655,8 +2655,8 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "doublezero-cli-core"
-version = "0.29.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=8b795a3c876c96d6427d4e0e47dc81ec05199f4a#8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
+version = "0.30.0"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.31.0#25ae6ee721991ba8d660279bcc6eec8a72e6c690"
 dependencies = [
  "bitflags 2.13.0",
  "clap",
@@ -2674,8 +2674,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-config"
-version = "0.29.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=8b795a3c876c96d6427d4e0e47dc81ec05199f4a#8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
+version = "0.30.0"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.31.0#25ae6ee721991ba8d660279bcc6eec8a72e6c690"
 dependencies = [
  "eyre",
  "serde",
@@ -2740,8 +2740,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-geolocation"
-version = "0.29.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=8b795a3c876c96d6427d4e0e47dc81ec05199f4a#8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
+version = "0.30.0"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.31.0#25ae6ee721991ba8d660279bcc6eec8a72e6c690"
 dependencies = [
  "borsh",
  "borsh-incremental",
@@ -2752,7 +2752,7 @@ dependencies = [
  "solana-loader-v3-interface",
  "solana-program",
  "solana-sdk-ids",
- "solana-system-interface 2.0.0",
+ "solana-system-interface 3.2.0",
  "thiserror 2.0.18",
 ]
 
@@ -2857,15 +2857,15 @@ dependencies = [
 
 [[package]]
 name = "doublezero-program-common"
-version = "0.29.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=8b795a3c876c96d6427d4e0e47dc81ec05199f4a#8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
+version = "0.30.0"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.31.0#25ae6ee721991ba8d660279bcc6eec8a72e6c690"
 dependencies = [
  "borsh",
  "byteorder",
  "ipnetwork",
  "serde",
  "solana-program",
- "solana-system-interface 2.0.0",
+ "solana-system-interface 3.2.0",
 ]
 
 [[package]]
@@ -2893,12 +2893,12 @@ dependencies = [
 
 [[package]]
 name = "doublezero-record"
-version = "0.29.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=8b795a3c876c96d6427d4e0e47dc81ec05199f4a#8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
+version = "0.30.0"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.31.0#25ae6ee721991ba8d660279bcc6eec8a72e6c690"
 dependencies = [
  "bytemuck",
  "solana-program",
- "solana-system-interface 2.0.0",
+ "solana-system-interface 3.2.0",
  "thiserror 2.0.18",
 ]
 
@@ -2954,8 +2954,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-serviceability"
-version = "0.29.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=8b795a3c876c96d6427d4e0e47dc81ec05199f4a#8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
+version = "0.30.0"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.31.0#25ae6ee721991ba8d660279bcc6eec8a72e6c690"
 dependencies = [
  "bitflags 2.13.0",
  "borsh",
@@ -2966,7 +2966,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "solana-program",
- "solana-system-interface 2.0.0",
+ "solana-system-interface 3.2.0",
  "thiserror 2.0.18",
 ]
 
@@ -3182,8 +3182,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero-telemetry"
-version = "0.29.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=8b795a3c876c96d6427d4e0e47dc81ec05199f4a#8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
+version = "0.30.0"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.31.0#25ae6ee721991ba8d660279bcc6eec8a72e6c690"
 dependencies = [
  "borsh",
  "borsh-incremental",
@@ -3197,8 +3197,8 @@ dependencies = [
 
 [[package]]
 name = "doublezero_sdk"
-version = "0.29.0"
-source = "git+https://github.com/malbeclabs/doublezero?rev=8b795a3c876c96d6427d4e0e47dc81ec05199f4a#8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
+version = "0.30.0"
+source = "git+https://github.com/malbeclabs/doublezero?tag=client%2Fv0.31.0#25ae6ee721991ba8d660279bcc6eec8a72e6c690"
 dependencies = [
  "async-trait",
  "backon",
@@ -3232,7 +3232,7 @@ dependencies = [
  "solana-pubsub-client",
  "solana-rpc-client-api",
  "solana-sdk",
- "solana-system-interface 2.0.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction-status",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,43 +125,42 @@ tag = "revenue-distribution/v0.3.7"
 # RFC-20 CLI core: provides CliContext, OutputFormat, RequirementCheck, the
 # render_* output helpers, and the eyre-based error type. The whole SDK family
 # is pinned to a single monorepo revision so shared types unify across the
-# boundary. The pin is the malbeclabs/doublezero#4030 merge commit (per-feed
-# EdgeSeat FeedSeat billing state + SetAccessPassFeeds), 42 commits past the
-# #3830 Solana 3.0 boundary on the same v3 line; swap for the next
-# v3-containing client/* tag once one is cut.
+# boundary. client/v0.31.0 is the first released client tag on the Solana 3.0
+# line (past #3830) and carries the EdgeSeat FeedSeat schema (#3954/#4030)
+# deployed on testnet, replacing the interim #4030 merge-commit pin.
 [workspace.dependencies.doublezero-cli-core]
 git = "https://github.com/malbeclabs/doublezero"
-rev = "8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
+tag = "client/v0.31.0"
 
 # Source of the RFC-20 `Environment` enum consumed by `CliContext`. MUST be
 # pinned to the same revision as doublezero-cli-core so the `Environment` type
 # unifies across the boundary.
 [workspace.dependencies.doublezero-config]
 git = "https://github.com/malbeclabs/doublezero"
-rev = "8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
+tag = "client/v0.31.0"
 
 [workspace.dependencies.doublezero-program-common]
 git = "https://github.com/malbeclabs/doublezero"
-rev = "8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
+tag = "client/v0.31.0"
 
 [workspace.dependencies.doublezero-record]
 features = ["no-entrypoint"]
 git = "https://github.com/malbeclabs/doublezero"
-rev = "8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
+tag = "client/v0.31.0"
 
 [workspace.dependencies.doublezero_sdk]
 git = "https://github.com/malbeclabs/doublezero"
-rev = "8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
+tag = "client/v0.31.0"
 
 [workspace.dependencies.doublezero-serviceability]
 features = ["no-entrypoint", "serde"]
 git = "https://github.com/malbeclabs/doublezero"
-rev = "8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
+tag = "client/v0.31.0"
 
 [workspace.dependencies.doublezero-telemetry]
 features = ["no-entrypoint", "serde"]
 git = "https://github.com/malbeclabs/doublezero"
-rev = "8b795a3c876c96d6427d4e0e47dc81ec05199f4a"
+tag = "client/v0.31.0"
 
 ### Other git dependencies
 


### PR DESCRIPTION
## Summary

- Bump the malbeclabs/doublezero SDK-family pins (`doublezero-cli-core`, `doublezero-config`, `doublezero-program-common`, `doublezero-record`, `doublezero_sdk`, `doublezero-serviceability`, `doublezero-telemetry`) from the interim #4030 merge-commit rev (`8b795a3c`) to the released tag `client/v0.31.0` (`25ae6ee7`) — the swap the pin comment planned for "the next v3-containing client/* tag once one is cut".
- This unblocks the do-tn-rewards1 incident: contributor-rewards v0.6.1 crash-loops with `memory allocation of 52264173600 bytes failed` because its `client/v0.27.1`-pinned SDK cannot decode the EdgeSeat access pass created on testnet 2026-07-22T14:46:30Z (`5x9DTsWCrAQtYKH4W7trEjoaCRHnzywsZp2oFX3sg5Zg`, `EdgeSeat(Vec<FeedSeat>)` schema from malbeclabs/doublezero#3954). The pre-FeedSeat decoder misreads an allowlist length from mid-FeedSeat bytes and `deserialize_vec_with_capacity` preallocates (1,633,255,424 + 1) × 32 bytes. A contributor-rewards release cut from this pin decodes the account correctly.
- No code changes needed — the workspace compiles unchanged against v0.31.0. Diff is `Cargo.toml` + `Cargo.lock` only, same shape as #399.

Follow-ups tracked separately (not in this PR): cap the unbounded `Vec::with_capacity` in the serviceability SDK helper, and make `serviceability::fetch` warn+skip undecodable accounts like `telemetry::fetch` does.

## Testing Verification

- `cargo test -p doublezero-contributor-rewards`: 145 tests pass (100 unit + 45 integration), 0 failures.
- Live decode replay against the testnet DZ ledger, replicating `serviceability::fetch` exactly (per-discriminator `getProgramAccounts`, Base64Zstd, finalized): all 1,956 serviceability accounts decode with 0 errors under an 8 GiB memory cap — including the EdgeSeat access pass above, which reproduces the byte-identical 52 GB allocation abort when fetched with the previous SDK pin.
