### PR TITLE
solana-client-tools: add a payload budget and a checked encoder for Squads vaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,12 +5,26 @@
 ### Naming and prose
 
 - Always write "onchain", never "on-chain".
-- **No abbreviations for account or variable names — anywhere.** Spell out `validator_client_rewards`, not `vcr`. `validator_publisher_rewards`, not `vpr`. `shred_distribution`, not `sd`. This applies to source variable names, test bindings, code comments, program logs, PR titles, branch names, commit subjects, and any prose in this codebase. Acronyms that are universally known in the Solana/SPL ecosystem are fine — `PDA`, `ATA`, `CPI`, `SPL`, `SVM`, `IDL`. Project-specific shorthand is not — write out the full name even if it appears many times in a single function.
+- **No abbreviations for account or variable names — anywhere.** Spell out `validator_client_rewards`, not `vcr`. `validator_publisher_rewards`, not `vpr`. `shred_distribution`, not `sd`. This applies to source variable names, test bindings, code comments, program logs, PR titles, branch names, commit subjects, and any prose in this codebase. Acronyms that are universally known in the Solana/SPL ecosystem are fine — `tx`, `PDA`, `ATA`, `CPI`, `SPL`, `SVM`, `IDL`. Project-specific shorthand is not — write out the full name even if it appears many times in a single function.
+- **The `try_` prefix is reserved for functions returning `Result`.** A fallible-looking function returning `bool` or `Option` takes a plain name (`add_requested_feeds(...) -> bool`, not `try_add_requested_feeds`). Giving an existing function a `Result` return means renaming it to `try_`, and its callers with it. Where an existing `try_`-named function returns something else, treat it as a straggler rather than a pattern to copy.
+- **Prose in this repo uses no contractions, no emdashes, and no sentence-chaining semicolons, and American spelling throughout.** Write "do not" rather than "don't", a comma or a period or parentheses rather than an emdash, two sentences rather than one joined by a semicolon, and "behavior" rather than "behaviour". This covers code comments, docstrings, READMEs, CHANGELOG entries, commit subjects, and PR and issue bodies. Semicolons inside a list are fine. The rule is for text you write or substantively change. Existing text, including the older parts of this file, is not worth a cleanup pass.
 
 ### Type annotations
 
 - **Never** define types anywhere the Rust compiler can infer them. This is non-negotiable and applies everywhere — `let` bindings (source and tests), numeric literals, function-call turbofishes, test helpers, struct field initializers, function arguments. If `let x = ...;` compiles, do not write `let x: Foo = ...;`. If `5_000` compiles, do not write `5_000u16` or `5_000_u32`. If `.collect()` compiles, do not write `.collect::<Vec<_>>()`. **In particular, do not write `let mut x: u64 = 0;` — write `let mut x = 0;` and let the first usage drive inference.** Only add annotations when the compiler genuinely cannot infer. When in doubt, write without the annotation and add one only if the compiler asks.
 - When the compiler does need a type hint, prefer **turbofish on the call site** (`.collect::<Vec<_>>()`, `<u32>::try_from(x)`) over annotating the `let` binding (`let xs: Vec<_> = ...`). Turbofish documents the type at the point it is needed; a let-binding annotation hides that intent and decays as the surrounding code changes.
+
+### Numeric literals
+
+- **Derive a constant in code, not in a comment.** When a constant is a sum of parts (a byte layout, a size reserve), write the sum with one term per line and a comment naming each term, then pin the total with `const _: () = assert!(NAME == 384);`. A literal carrying its arithmetic in a comment cannot be checked: the terms can fail to add up to it, and a term that changes leaves the literal stale with nothing to catch it. Group a long derivation into named block consts, each with its own assertion, and reference one from another where the same cost appears in both.
+- **Annotate per literal, never above a run.** A comment above `3 + 1 + 96 + 32` leaves the reader mapping prose onto numbers by position, and gives no way to tell a wrong mapping from a right one. Break the expression across lines so each literal carries its own comment.
+- **Do not pre-multiply, and do not repeat a literal that has a meaning.** `96` for three account keys hides both the count and which three, so write `3 * 32` where the items are interchangeable or one `32` per item where each has a name worth checking. A literal appearing in more than one expression is a constant that has not been named yet.
+- Prefer a plain literal whose comment names the field over `size_of::<T>()`. Reach for `size_of::<T>()` where the width follows from a type that could plausibly change, or where the term is a composite no short comment makes obvious.
+- All of the above apply in tests exactly as in source.
+
+### Workspace dependencies
+
+- **Put required features on the `[workspace.dependencies]` entry, not in a per-crate `{ workspace = true, features = [...] }` override.** Cargo unifies features across a build, so a per-crate feature is not isolated to that crate: every user of that dependency in the same build graph gets it anyway. The override buys no isolation and splits the dependency's feature set across manifests. A feature enabled in one member but missing from the workspace entry is the smell.
 
 ### Comments and docstrings
 

--- a/crates/solana-client-tools/CHANGELOG.md
+++ b/crates/solana-client-tools/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- add `squads::vault_transaction_payload_budget` and `squads::try_encode_vault_transaction`, which size a payload against the transaction Squads wraps around it rather than the transaction limit alone. Replaces `encode_vault_transaction` and `print_vault_transaction` with checked `try_` forms ([malbeclabs/doublezero#4184](https://github.com/malbeclabs/doublezero/issues/4184))
 - add a `squads` module with Squads Protocol v4 vault support. Behind a new default-on `squads` feature, so consumers can opt out with `default-features = false`
 - add a crate `README.md` covering the `squads` module
 - add `Wallet::write_verbose_output` and `write_transaction_details` methods that write to an arbitrary `impl Write` instead of stdout, for testability (#383)

--- a/crates/solana-client-tools/README.md
+++ b/crates/solana-client-tools/README.md
@@ -89,7 +89,7 @@ multisig and its vault.
 ### Emitting a transaction for the UI
 
 ```rust
-print_vault_transaction(&connection, &vault_key, &[instruction]);
+try_print_vault_transaction(&connection, &vault_key, &[instruction])?;
 ```
 
 Alongside the base58 payload this prints an explorer transaction inspector link
@@ -113,7 +113,7 @@ that it is now part of the link, since an endpoint on another SVM network is
 unrecognizable from here and that says nothing either way about how sensitive it
 is. Whether it matters is the caller's call.
 
-`encode_vault_transaction` is the same thing without the surrounding output, for
+`try_encode_vault_transaction` is the same thing without the surrounding output, for
 callers that want the string.
 
 This is a wire contract with the Squads UI, so it is worth stating exactly: a
@@ -124,6 +124,47 @@ into a vault transaction. How members import it differs by UI.
 The format is pinned by a test that decodes the output back and asserts those
 properties, and it has been confirmed by executing emitted transactions against a
 devnet Squad.
+
+### Sizing a payload
+
+The transaction that has to carry a payload is the one Squads wraps around it, not
+the payload itself. That wrapper is a `vault_transaction_create` carrying the payload
+as its `transaction_message`, bundled with the compute budget pair, a
+`proposal_create`, and a `proposal_approve`, which is how one transaction takes a
+payload all the way to the approvers. A payload that overruns it is refused at import,
+before any approval exists.
+
+| Function                                              | Purpose                                  |
+|-------------------------------------------------------|------------------------------------------|
+| `vault_transaction_payload_budget(instruction_count)` | Bytes the payload's message may occupy.  |
+| `try_encode_vault_transaction(vault, instructions)`   | Encodes, or refuses an unusable payload. |
+
+The budget governs the serialized legacy message, meaning
+`Message::serialize().len()`, not the base58 string the encoder returns, which is
+around 1.37 times longer. A caller sizing its own instruction measures the former.
+
+It is `MAX_TRANSACTION_SIZE` less a 384-byte reserve, less one byte per payload
+instruction. The derivation, and the Squads app behavior it deliberately does not
+cover, sit beside the constant. A memo typed at import is unbounded, so no reserve can
+cover one, which is the reason a payload sized to the last byte is a payload a memo
+breaks. A test assembles the wrapper and asserts that a payload sized to the budget
+still fits, so the arithmetic beside the constant is executable rather than asserted.
+
+Size is not the only thing that makes a payload unusable, and the other two checks
+matter more, because a size failure surfaces at import while these surface at execute,
+after the approvals are spent. The encoder refuses a payload naming a signer other than
+the vault, since any such key has to sign the execute transaction itself and nothing
+here knows who will run it. It refuses more than 48 instructions, since each runs as
+its own invocation against an instruction trace the whole execute transaction shares.
+That 48 is an arbitrarily conservative lower bound, not the runtime's limit.
+
+An empty payload is refused too, which is a courtesy rather than a correctness matter:
+it imports and executes nothing, at the cost of the approvals.
+
+`vault_transaction_execute` is checked as well, though nothing the budget accepts can
+overrun it. By execute the payload's instruction data lives in the transaction account
+and no longer travels, which leaves execute looser than create at every size, so create
+binds. A test pins that pairing rather than leaving it a claim.
 
 ### Reading loader-v3 authorities
 

--- a/crates/solana-client-tools/src/squads.rs
+++ b/crates/solana-client-tools/src/squads.rs
@@ -5,13 +5,117 @@ use solana_loader_v3_interface::state::UpgradeableLoaderState;
 use solana_message::Message;
 use solana_sdk::{instruction::Instruction, pubkey, pubkey::Pubkey};
 
-use crate::rpc::{NetworkEnvironment, SolanaConnection};
+use crate::{
+    rpc::{NetworkEnvironment, SolanaConnection},
+    transaction::MAX_TRANSACTION_SIZE,
+};
 
 // Squads Protocol v4 multisig program.
 pub const SQUADS_V4_PROGRAM_ID: Pubkey = pubkey!("SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf");
 
 const VAULT_SEED_PREFIX: &[u8] = b"multisig";
 const VAULT_SEED: &[u8] = b"vault";
+
+// A payload travels as the `transaction_message` of `vault_transaction_create`, and the
+// app bundles the compute budget pair, a `proposal_create`, and a `proposal_approve` into
+// that same transaction, which is how one transaction takes a payload all the way to the
+// approvers. That transaction is what has to fit MAX_TRANSACTION_SIZE, so what it spends
+// is what a payload does not get to spend. Each block below adds up to the byte count its
+// assertion names, and the total is the reserve.
+
+// vault_transaction_create, as a legacy transaction.
+const VAULT_TRANSACTION_CREATE_BYTES: usize = 1 // signature count (shortvec)
+    + 64 // creator signature
+    + 3 // message header
+    + 1 // account key count (shortvec)
+    + 32 // multisig key
+    + 32 // transaction account key
+    + 32 // member key, both creator and rent payer
+    + 32 // system program key
+    + 32 // Squads program key
+    + 32 // recent blockhash
+    + 1 // instruction count (shortvec)
+    + 1 // program id index
+    + 1 // account index count (shortvec)
+    + 5 // account indexes
+    // Instruction data length (shortvec), 2 bytes once a payload pushes the data past 127.
+    + 2
+    + 8 // instruction discriminator
+    + 1 // vault_index
+    + 1 // ephemeral_signers
+    + 4 // transaction_message length (borsh Vec<u8> prefix)
+    + 1; // memo: None
+const _: () = assert!(VAULT_TRANSACTION_CREATE_BYTES == 286);
+
+// The compute budget pair the app bundles.
+const COMPUTE_BUDGET_PAIR_BYTES: usize = 32 // compute budget program key
+    + 1 // program id index (limit)
+    + 1 // account index count (shortvec)
+    + 1 // instruction data length (shortvec)
+    + 5 // SetComputeUnitLimit payload, a discriminator and a u32
+    + 1 // program id index (price)
+    + 1 // account index count (shortvec)
+    + 1 // instruction data length (shortvec)
+    + 9; // SetComputeUnitPrice payload, a discriminator and a u64
+const _: () = assert!(COMPUTE_BUDGET_PAIR_BYTES == 52);
+
+// The proposal_create the app bundles, whose other four accounts are already keys of the
+// create instruction.
+const PROPOSAL_CREATE_BYTES: usize = 32 // proposal account key
+    + 1 // program id index
+    + 1 // account index count (shortvec)
+    + 5 // account indexes
+    + 1 // instruction data length (shortvec)
+    + 8 // instruction discriminator
+    + 8 // transaction_index, a u64
+    + 1; // draft
+const _: () = assert!(PROPOSAL_CREATE_BYTES == 57);
+
+// The proposal_approve the app bundles, all of whose accounts are already keys.
+const PROPOSAL_APPROVE_BYTES: usize = 1 // program id index
+    + 1 // account index count (shortvec)
+    + 3 // account indexes
+    + 1 // instruction data length (shortvec)
+    + 8 // instruction discriminator
+    + 1; // memo: None
+const _: () = assert!(PROPOSAL_APPROVE_BYTES == 15);
+
+// What Squads spends around a payload, against the length that payload measures as a
+// legacy message.
+const VAULT_TRANSACTION_RESERVED_BYTES: usize = VAULT_TRANSACTION_CREATE_BYTES
+    + COMPUTE_BUDGET_PAIR_BYTES
+    + PROPOSAL_CREATE_BYTES
+    + PROPOSAL_APPROVE_BYTES
+    + 2 // in case the app compiles that transaction as v0 rather than legacy
+    - 32 // recent blockhash a Squads TransactionMessage does not carry
+    + 1 // address_table_lookups length a Squads TransactionMessage always writes
+    + 3; // rounding up the 381 of everything above
+const _: () = assert!(VAULT_TRANSACTION_RESERVED_BYTES == 384);
+
+// Three Squads app behaviors the terms above assume away are not program schema, and the
+// three bytes of rounding cover none of them:
+//      +4  and the text, per memo typed at import, on the create instruction and again on
+//          the approval, where text of 115 bytes or more costs one further byte for the
+//          approval's own data length prefix. Borsh writes Some(String) as a tag, a
+//          4-byte length and the text where None writes one byte, and nothing bounds the
+//          text, so no reserve can cover a memo. It spends from a payload's own headroom,
+//          which is why a payload sized to the last byte is a payload that a memo breaks.
+//     +96  for a rent payer separate from the creator, being 32 for the key and 64 for
+//          its signature. The app pays from the connected wallet, which is also the
+//          creator, so this is assumed away rather than reserved for.
+//     +33  per further account key the wrapper carries, being 32 for the key and 1 for
+//          the index of it, and more where that key arrives with an instruction of its
+//          own. A tip account paid by a System transfer costs 49.
+
+// Payload instructions run as separate invocations from vault_transaction_execute,
+// against a runtime instruction trace that holds 64 entries for the whole transaction.
+// Execute spends three of them on the compute budget pair and on itself, leaving around
+// 61, and fewer for every payload instruction that invokes further.
+//
+// 48 is an arbitrarily conservative lower bound, not that ceiling. Nothing here measures
+// how deep a payload's own invocations go, so the limit leaves room for them rather than
+// pricing them, and a real payload needing more is the reason to raise it.
+const MAX_PAYLOAD_INSTRUCTIONS: usize = 48;
 
 // Squads options for a command that always acts as a vault.
 #[derive(Debug, Args)]
@@ -190,12 +294,12 @@ pub fn try_upgrade_authority(state: &UpgradeableLoaderState) -> Result<Option<Pu
 }
 
 /// Print a base58 encoded transaction for import into the Squads UI.
-pub fn print_vault_transaction(
+pub fn try_print_vault_transaction(
     connection: &SolanaConnection,
     vault_key: &Pubkey,
     instructions: &[Instruction],
-) {
-    let encoded = encode_vault_transaction(vault_key, instructions);
+) -> Result<()> {
+    let encoded = try_encode_vault_transaction(vault_key, instructions)?;
     let rpc_url = connection.url();
 
     println!("Import this base58 encoded transaction into Squads:");
@@ -209,6 +313,8 @@ pub fn print_vault_transaction(
         println!("WARNING: that link carries the endpoint this command was given.");
         println!("Do not share it anywhere that endpoint should not go.");
     }
+
+    Ok(())
 }
 
 /// Explorer link that decodes the message, so it can be read before it is signed.
@@ -239,16 +345,122 @@ fn is_public_solana_endpoint(rpc_url: &str) -> bool {
     .contains(&rpc_url.trim_end_matches('/'))
 }
 
-/// Encode instructions as the base58 payload the Squads UI imports.
-pub fn encode_vault_transaction(vault_key: &Pubkey, instructions: &[Instruction]) -> String {
+/// Bytes `Message::serialize` may produce for a payload of `instruction_count`
+/// instructions, which is not the length of the base58 the encoder returns.
+pub fn vault_transaction_payload_budget(instruction_count: usize) -> usize {
+    // A Squads TransactionMessage writes each instruction's data length as a u16
+    // where a legacy message writes it in one byte, so every payload instruction
+    // costs one byte more once wrapped than the payload measures here. The term
+    // stops being spent at 128 data bytes, where the legacy prefix grows to two as
+    // well, which makes it conservative rather than exact.
+    //
+    // Const subtraction on purpose, so a reserve raised past the transaction limit is a
+    // build failure rather than a budget of zero that refuses every payload.
+    (MAX_TRANSACTION_SIZE - VAULT_TRANSACTION_RESERVED_BYTES).saturating_sub(instruction_count)
+}
+
+/// Encode instructions as the base58 payload the Squads UI imports, refusing one
+/// that will not fit the transaction Squads wraps around it.
+pub fn try_encode_vault_transaction(
+    vault_key: &Pubkey,
+    instructions: &[Instruction],
+) -> Result<String> {
+    // An empty payload encodes and imports perfectly well, and costs a human the
+    // approvals to execute nothing.
+    ensure!(
+        !instructions.is_empty(),
+        "no instructions to encode for the vault"
+    );
+    ensure!(
+        instructions.len() <= MAX_PAYLOAD_INSTRUCTIONS,
+        "payload has {} instructions, over the {MAX_PAYLOAD_INSTRUCTIONS} a Squads vault \
+         transaction is allowed here. Each one runs as its own invocation against an \
+         instruction trace the whole execute transaction shares",
+        instructions.len()
+    );
+
     // The wire contract with that UI: a legacy message, the vault as fee payer and
     // sole signer, and a placeholder blockhash Squads replaces when it wraps the
     // instructions into a vault transaction.
-    bs58::encode(Message::new(instructions, Some(vault_key)).serialize()).into_string()
+    let message = Message::new(instructions, Some(vault_key));
+
+    // Squads signs for the vault. Any other signer the payload names has to sign the
+    // execute transaction itself, which the UI can only arrange for the member running
+    // it, and nothing here knows who that will be. Such a payload imports and collects
+    // approvals before running out of signers, unlike an oversized one, which is refused
+    // at import.
+    ensure!(
+        message.header.num_required_signatures == 1,
+        "payload requires {} signatures. Squads signs for the vault, and any other signer the \
+         payload names has to sign the execute transaction itself, which cannot be arranged for a \
+         key chosen when the payload was written",
+        message.header.num_required_signatures
+    );
+
+    let account_key_count = message.account_keys.len();
+    let payload = message.serialize();
+
+    let budget = vault_transaction_payload_budget(instructions.len());
+    ensure!(
+        payload.len() <= budget,
+        "payload is {} bytes, {} over the {budget} a Squads vault transaction can \
+         carry. Squads spends {VAULT_TRANSACTION_RESERVED_BYTES} of the \
+         {MAX_TRANSACTION_SIZE}-byte transaction limit wrapping a payload into a \
+         create transaction alongside its proposal and approval, plus a byte per \
+         payload instruction. Emit fewer or smaller instructions",
+        payload.len(),
+        payload.len() - budget
+    );
+
+    // By execute the payload's instruction data lives in the transaction account and
+    // does not travel, which leaves execute looser than create at every size, so this
+    // cannot fire on a payload create accepted. Checked anyway, so nothing certifies a
+    // payload that imports and then cannot execute.
+    let execute_size = vault_transaction_execute_size(account_key_count);
+    ensure!(
+        execute_size <= MAX_TRANSACTION_SIZE,
+        "the payload's {account_key_count} account keys need a {execute_size}-byte transaction to \
+         execute, over the {MAX_TRANSACTION_SIZE}-byte limit. Emit instructions touching fewer \
+         accounts"
+    );
+
+    Ok(bs58::encode(payload).into_string())
+}
+
+// vault_transaction_execute, as a legacy transaction bundled with the same compute budget
+// pair the app puts alongside create.
+const VAULT_TRANSACTION_EXECUTE_BYTES: usize = 1 // signature count (shortvec)
+    + 64 // member signature
+    + 3 // message header
+    + 1 // account key count (shortvec)
+    + 32 // multisig key
+    + 32 // proposal key
+    + 32 // transaction account key
+    + 32 // member key
+    + 32 // Squads program key
+    + 32 // recent blockhash
+    + 1 // instruction count (shortvec)
+    + 1 // program id index
+    + 1 // account index count (shortvec)
+    + 4 // account indexes
+    + 1 // instruction data length (shortvec)
+    + 8 // instruction discriminator
+    + COMPUTE_BUDGET_PAIR_BYTES;
+const _: () = assert!(VAULT_TRANSACTION_EXECUTE_BYTES == 329);
+
+// What each payload account key costs the transaction carrying it, whether that is the
+// payload's own message or the execute that passes it as a remaining account.
+const PER_ACCOUNT_KEY_BYTES: usize = 32 // the key
+    + 1; // the index of it
+const _: () = assert!(PER_ACCOUNT_KEY_BYTES == 33);
+
+fn vault_transaction_execute_size(account_key_count: usize) -> usize {
+    VAULT_TRANSACTION_EXECUTE_BYTES + PER_ACCOUNT_KEY_BYTES * account_key_count
 }
 
 #[cfg(test)]
 mod tests {
+    use solana_compute_budget_interface::ComputeBudgetInstruction;
     use solana_sdk::instruction::AccountMeta;
 
     use super::*;
@@ -257,17 +469,68 @@ mod tests {
     const VAULT_KEY: Pubkey = pubkey!("2KAv4oDNwoB9oy6ja29jZ38KPqUqQiJpnaHr5QS4yTd3");
     const PROGRAM_KEY: Pubkey = pubkey!("a1oQyDEkMKk8PLcKTXgAVP8C9g4HUBAmB564Dvszh6F");
 
-    fn instruction() -> Instruction {
+    // What a single-instruction payload spends around that instruction's data and the
+    // data's own length prefix.
+    const AROUND_INSTRUCTION_DATA: usize = 3 // message header
+        + 1 // account key count (shortvec)
+        + 32 // vault key, the fee payer
+        + 32 // multisig key, the instruction's one account
+        + 32 // program key
+        + 32 // recent blockhash
+        + 1 // instruction count (shortvec)
+        + 1 // program id index
+        + 1 // account index count (shortvec)
+        + 1; // account index
+    const _: () = assert!(AROUND_INSTRUCTION_DATA == 136);
+
+    // The same framing for a payload of unique accounts and no instruction data, which
+    // spends an instruction data length where the one above spends an account index.
+    const AROUND_ACCOUNT_KEYS: usize = 3 // message header
+        + 1 // account key count (shortvec)
+        + 32 // vault key, the fee payer
+        + 32 // program key
+        + 32 // recent blockhash
+        + 1 // instruction count (shortvec)
+        + 1 // program id index
+        + 1 // account index count (shortvec)
+        + 1; // instruction data length (shortvec)
+    const _: () = assert!(AROUND_ACCOUNT_KEYS == 104);
+
+    // A second instruction over the same account and program, before its own data and
+    // that data's length prefix.
+    const AROUND_SECOND_INSTRUCTION: usize = 1 // program id index
+        + 1 // account index count (shortvec)
+        + 1; // account index
+    const _: () = assert!(AROUND_SECOND_INSTRUCTION == 3);
+
+    fn instruction_with_data_len(data_len: usize) -> Instruction {
+        let data = vec![0; data_len];
+
         Instruction::new_with_bytes(
             PROGRAM_KEY,
-            &[1, 2, 3],
+            &data,
             vec![AccountMeta::new_readonly(MULTISIG_KEY, false)],
         )
     }
 
+    fn instruction_with_account_count(account_count: usize) -> Instruction {
+        let accounts = (0..account_count)
+            .map(|_| AccountMeta::new_readonly(Pubkey::new_unique(), false))
+            .collect();
+
+        Instruction::new_with_bytes(PROGRAM_KEY, &[], accounts)
+    }
+
+    fn payload_len(instructions: &[Instruction]) -> usize {
+        let encoded = try_encode_vault_transaction(&VAULT_KEY, instructions).unwrap();
+
+        bs58::decode(encoded).into_vec().unwrap().len()
+    }
+
     #[test]
     fn test_inspector_url_carries_the_message_squads_takes() {
-        let encoded = encode_vault_transaction(&VAULT_KEY, &[instruction()]);
+        let encoded =
+            try_encode_vault_transaction(&VAULT_KEY, &[instruction_with_data_len(3)]).unwrap();
         let url = inspector_url(&encoded, "https://api.devnet.solana.com");
 
         // Unescaped on purpose: the base58 alphabet is URL safe.
@@ -381,8 +644,9 @@ mod tests {
     }
 
     #[test]
-    fn test_encode_vault_transaction_makes_the_vault_the_sole_signer() {
-        let encoded = encode_vault_transaction(&VAULT_KEY, &[instruction()]);
+    fn test_encoded_payload_makes_the_vault_the_sole_signer() {
+        let encoded =
+            try_encode_vault_transaction(&VAULT_KEY, &[instruction_with_data_len(3)]).unwrap();
         let message: Message =
             bincode::deserialize(&bs58::decode(&encoded).into_vec().unwrap()).unwrap();
 
@@ -392,5 +656,236 @@ mod tests {
         assert_eq!(message.header.num_required_signatures, 1);
         assert_eq!(message.recent_blockhash, Default::default());
         assert_eq!(message.instructions.len(), 1);
+    }
+
+    #[test]
+    fn test_budget_spends_one_byte_per_payload_instruction() {
+        // 1_232 - 384, then one byte per instruction for the u16 data length a Squads
+        // TransactionMessage writes where a legacy message writes one byte.
+        assert_eq!(vault_transaction_payload_budget(0), 848);
+        assert_eq!(vault_transaction_payload_budget(1), 847);
+        assert_eq!(vault_transaction_payload_budget(4), 844);
+    }
+
+    #[test]
+    fn test_payload_length_prefix_grows_where_the_per_instruction_term_stops() {
+        assert_eq!(
+            payload_len(&[instruction_with_data_len(3)]),
+            AROUND_INSTRUCTION_DATA + 1 + 3
+        );
+
+        // The legacy prefix grows to two bytes here, which is where the budget's
+        // per-instruction term stops buying anything.
+        assert_eq!(
+            payload_len(&[instruction_with_data_len(127)]),
+            AROUND_INSTRUCTION_DATA + 1 + 127
+        );
+        assert_eq!(
+            payload_len(&[instruction_with_data_len(128)]),
+            AROUND_INSTRUCTION_DATA + 2 + 128
+        );
+    }
+
+    #[test]
+    fn test_encoder_takes_the_budget_the_accessor_reports_and_refuses_one_byte_more() {
+        let budget = vault_transaction_payload_budget(1);
+
+        // The framing above, plus the 2-byte legacy length prefix that much data needs.
+        let data_len = budget - (AROUND_INSTRUCTION_DATA + 2);
+
+        assert_eq!(payload_len(&[instruction_with_data_len(data_len)]), budget);
+
+        let error =
+            try_encode_vault_transaction(&VAULT_KEY, &[instruction_with_data_len(data_len + 1)])
+                .unwrap_err()
+                .to_string();
+
+        // The numbers rather than the explanation around them, so rewording the message
+        // is not a test change.
+        assert!(
+            error.starts_with(&format!(
+                "payload is {} bytes, 1 over the {budget} ",
+                budget + 1
+            )),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn test_encoder_spends_the_per_instruction_byte_on_a_second_instruction() {
+        let budget = vault_transaction_payload_budget(2);
+
+        let data_len = budget
+            - (AROUND_INSTRUCTION_DATA
+                + 1 // the first instruction's data length prefix
+                + 3 // the first instruction's data
+                + AROUND_SECOND_INSTRUCTION
+                + 2); // the second instruction's data length prefix
+        let instructions = [
+            instruction_with_data_len(3),
+            instruction_with_data_len(data_len),
+        ];
+
+        assert_eq!(payload_len(&instructions), budget);
+
+        let over = [
+            instruction_with_data_len(3),
+            instruction_with_data_len(data_len + 1),
+        ];
+        assert!(try_encode_vault_transaction(&VAULT_KEY, &over).is_err());
+    }
+
+    #[test]
+    fn test_create_binds_before_execute_at_the_widest_payload_the_budget_takes() {
+        // Account keys are all execute charges for, so the payload that gets closest to
+        // its limit is unique accounts and no instruction data.
+        let account_count =
+            (vault_transaction_payload_budget(1) - AROUND_ACCOUNT_KEYS) / PER_ACCOUNT_KEY_BYTES;
+
+        assert_eq!(
+            payload_len(&[instruction_with_account_count(account_count)]),
+            AROUND_ACCOUNT_KEYS + PER_ACCOUNT_KEY_BYTES * account_count
+        );
+        assert!(
+            try_encode_vault_transaction(
+                &VAULT_KEY,
+                &[instruction_with_account_count(account_count + 1)]
+            )
+            .is_err()
+        );
+
+        // The vault and the program are account keys of that payload too, and execute
+        // passes every one of them as a remaining account. Failing here means execute
+        // has become the binding constraint and the check in the encoder can now fire.
+        assert!(vault_transaction_execute_size(account_count + 2) <= MAX_TRANSACTION_SIZE);
+    }
+
+    #[test]
+    fn test_cannot_encode_when_there_are_no_instructions() {
+        let error = try_encode_vault_transaction(&VAULT_KEY, &[]).unwrap_err();
+
+        // Named rather than any error, since an empty payload is inside every size
+        // check and would otherwise pass this test for the wrong reason.
+        assert_eq!(error.to_string(), "no instructions to encode for the vault");
+    }
+
+    #[test]
+    fn test_cannot_encode_more_instructions_than_execute_runs() {
+        let within = vec![instruction_with_data_len(0); MAX_PAYLOAD_INSTRUCTIONS];
+        let over = vec![instruction_with_data_len(0); MAX_PAYLOAD_INSTRUCTIONS + 1];
+
+        // Both are far inside the byte budget, so the count is the only thing refusing
+        // the second.
+        assert!(payload_len(&within) < vault_transaction_payload_budget(within.len()));
+
+        let error = try_encode_vault_transaction(&VAULT_KEY, &over).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .starts_with(&format!("payload has {} instructions", over.len())),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn test_cannot_encode_when_an_instruction_names_another_signer() {
+        let instruction = Instruction::new_with_bytes(
+            PROGRAM_KEY,
+            &[],
+            vec![AccountMeta::new(Pubkey::new_unique(), true)],
+        );
+        let error = try_encode_vault_transaction(&VAULT_KEY, &[instruction]).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .starts_with("payload requires 2 signatures"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn test_the_wrapper_around_a_budget_sized_payload_still_fits() {
+        let budget = vault_transaction_payload_budget(1);
+        let payload_size = payload_len(&[instruction_with_data_len(
+            budget - (AROUND_INSTRUCTION_DATA + 2),
+        )]);
+        assert_eq!(payload_size, budget);
+
+        // What Squads stores in place of the payload's own message. The last term is what
+        // the budget charges rather than what this payload spends, whose data is past 127
+        // and so already carries a two-byte legacy prefix.
+        let transaction_message_len = payload_size
+            - 32 // recent blockhash a TransactionMessage does not carry
+            + 1 // address_table_lookups length it always writes
+            + 1; // the u16 data length, per payload instruction
+
+        // The transaction the app submits at import. Only keys and data lengths decide
+        // its size, so the discriminators and arguments are stand-ins of the right size.
+        let member_key = Pubkey::new_unique();
+        let transaction_key = Pubkey::new_unique();
+        let proposal_key = Pubkey::new_unique();
+        let system_program_key = Pubkey::new_unique();
+
+        let create_data_len = 8 // instruction discriminator
+            + 1 // vault_index
+            + 1 // ephemeral_signers
+            + 4 // transaction_message length (borsh Vec<u8> prefix)
+            + transaction_message_len
+            + 1; // memo: None
+        let proposal_create_data_len = 8 // instruction discriminator
+            + 8 // transaction_index, a u64
+            + 1; // draft
+        let proposal_approve_data_len = 8 // instruction discriminator
+            + 1; // memo: None
+
+        let wrapper = Message::new(
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(0),
+                ComputeBudgetInstruction::set_compute_unit_price(0),
+                Instruction::new_with_bytes(
+                    SQUADS_V4_PROGRAM_ID,
+                    &vec![0; create_data_len],
+                    vec![
+                        AccountMeta::new(MULTISIG_KEY, false),
+                        AccountMeta::new(transaction_key, false),
+                        AccountMeta::new_readonly(member_key, true),
+                        AccountMeta::new(member_key, true),
+                        AccountMeta::new_readonly(system_program_key, false),
+                    ],
+                ),
+                Instruction::new_with_bytes(
+                    SQUADS_V4_PROGRAM_ID,
+                    &vec![0; proposal_create_data_len],
+                    vec![
+                        AccountMeta::new_readonly(MULTISIG_KEY, false),
+                        AccountMeta::new(proposal_key, false),
+                        AccountMeta::new_readonly(member_key, true),
+                        AccountMeta::new(member_key, true),
+                        AccountMeta::new_readonly(system_program_key, false),
+                    ],
+                ),
+                Instruction::new_with_bytes(
+                    SQUADS_V4_PROGRAM_ID,
+                    &vec![0; proposal_approve_data_len],
+                    vec![
+                        AccountMeta::new_readonly(MULTISIG_KEY, false),
+                        AccountMeta::new(member_key, true),
+                        AccountMeta::new(proposal_key, false),
+                    ],
+                ),
+            ],
+            Some(&member_key),
+        );
+
+        let wrapper_size = 1 // signature count (shortvec)
+            + 64 // member signature
+            + wrapper.serialize().len()
+            + 2; // what a v0 compile would add over legacy
+
+        // The reserve rounds 381 up to 384, so a payload sized to the budget leaves
+        // exactly three bytes unspent. Failing here means the derivation beside the
+        // constant no longer describes the transaction Squads builds.
+        assert_eq!(wrapper_size, MAX_TRANSACTION_SIZE - 3);
     }
 }

--- a/crates/solana-client-tools/src/squads.rs
+++ b/crates/solana-client-tools/src/squads.rs
@@ -346,7 +346,8 @@ fn is_public_solana_endpoint(rpc_url: &str) -> bool {
 }
 
 /// Bytes `Message::serialize` may produce for a payload of `instruction_count`
-/// instructions, which is not the length of the base58 the encoder returns.
+/// instructions, and not the length of the base58 the encoder returns. Sizing to the last
+/// byte leaves no room for a memo typed at import.
 pub fn vault_transaction_payload_budget(instruction_count: usize) -> usize {
     // A Squads TransactionMessage writes each instruction's data length as a u16
     // where a legacy message writes it in one byte, so every payload instruction

--- a/crates/solana-client-tools/src/squads.rs
+++ b/crates/solana-client-tools/src/squads.rs
@@ -115,7 +115,7 @@ const _: () = assert!(VAULT_TRANSACTION_RESERVED_BYTES == 384);
 // 48 is an arbitrarily conservative lower bound, not that ceiling. Nothing here measures
 // how deep a payload's own invocations go, so the limit leaves room for them rather than
 // pricing them, and a real payload needing more is the reason to raise it.
-const MAX_PAYLOAD_INSTRUCTIONS: usize = 48;
+pub const MAX_PAYLOAD_INSTRUCTIONS: usize = 48;
 
 // Squads options for a command that always acts as a vault.
 #[derive(Debug, Args)]


### PR DESCRIPTION
Closes https://github.com/malbeclabs/doublezero/issues/4184

## Summary
- Add `vault_transaction_payload_budget`, reporting the bytes a payload of a given instruction count may serialize to, for a caller that grows a single instruction until it stops fitting
- Add `try_encode_vault_transaction`, which measures the payload and refuses one that cannot work. `print_vault_transaction` becomes `try_print_vault_transaction` and routes through it
- Derive the reserve as const arithmetic rather than in a comment, one term per line, from the `vault_transaction_create` envelope plus the compute budget pair, `proposal_create`, and `proposal_approve` the Squads app bundles into that same transaction. Compile-time assertions pin each block's subtotal and the 384 total, so a changed term fails the build instead of leaving a stale literal. A comment records the three app behaviors the derivation assumes away and what each costs
- Refuse a payload naming a signer other than the vault, and one carrying more than 48 instructions. Both import and collect approvals before failing at execute, unlike an oversized payload, which fails at import
- Check the `vault_transaction_execute` transaction as well, at 329 bytes plus 33 per payload account key. The issue specifies 277, which omits the compute budget pair the app bundles there too
- Record the conventions this change was written under in `CLAUDE.md`, covering numeric literals, prose in comments and documentation, the `try_` prefix, and where workspace dependency features belong

## Testing
- Hand-computed payload lengths at 3, 127 and 128 instruction-data bytes, spanning the legacy length prefix boundary
- A payload landing exactly on the budget and one byte over it, at one instruction and at two
- The wrapper Squads builds around a budget-sized payload, assembled and measured at 1,229 bytes of the 1,232 available
- The widest payload the budget accepts, at 24 account keys and 1,121 bytes to execute
- Refusals for an empty payload, a foreign signer, and 49 instructions
- A downstream caller's vault print path against devnet, run before and after the change, byte-identical
